### PR TITLE
dont use bucket name as secret

### DIFF
--- a/.github/workflows/presubmit-readme.yaml
+++ b/.github/workflows/presubmit-readme.yaml
@@ -7,4 +7,4 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/verify-readme
       with:
-        gcsBucketName: ${{ secrets.GCS_BUCKET_NAME }}
+        gcsBucketName: chainguard-images-build-outputs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           EXTRA_INPUT_GCS_AUTH_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCS_AUTH_WORKLOAD_IDENTITY_PROVIDER }}
           EXTRA_INPUT_GCS_AUTH_SERVICE_ACCOUNT: ${{ secrets.GCS_AUTH_SERVICE_ACCOUNT }}
           EXTRA_INPUT_GCS_AUTH_PROJECT_ID: ${{ secrets.GCS_AUTH_PROJECT_ID }}
-          EXTRA_INPUT_GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
+          EXTRA_INPUT_GCS_BUCKET_NAME: chainguard-images-build-outputs
         run: |
           # convert env vars beginning with "EXTRA_INPUT_"
           # to camelcased input variables passed to next step


### PR DESCRIPTION
there is the job `https://github.com/chainguard-images/images/blob/main/.github/workflows/presubmit-readme.yaml` that runs on PRs and inject the secret, but that will not run on Forked PRs caused the job to fail because the secret will not be injected.

we have the bucket name public and there is not needed to have that in a secret.
We can delete the secret after this PR is merged

Slack 🧵 : https://chainguard-dev.slack.com/archives/C0322APD4LU/p1670235759571799