### PR TITLE
Improvements to PHP image

### DIFF
--- a/images/php/README.md
+++ b/images/php/README.md
@@ -27,7 +27,7 @@ Zend Engine v4.1.10, Copyright (c) Zend Technologies
 
 ### Application Setup for End Users
 
-When creating a Dockerfile to extend from these images, the recommended approach is to set up a multi-stage build so that you're able to install your Composer dependencies on a separate environment and then copy the files over to a distroless image.
+When creating a Dockerfile to extend from these images, the recommended approach is to set up a multi-stage build so that you're able to install your Composer dependencies on a separate environment and then copy the files over to a smaller production image.
 
 The following example demonstrates how to do that:
 

--- a/images/php/README.md
+++ b/images/php/README.md
@@ -1,16 +1,13 @@
 # php
 
-This is a minimal PHP image based on Alpine, using PHP apks available on the Alpine Community repositories (not built from source as of now).
+Minimalist PHP images for building and running PHP applications (CLI).
 
-W hile this image is being developed, we will stick to the latest stable PHP version which at this moment is `8.1`. Supported versions in the long term are TBD.
+## Available Tags
 
-## Get It!
-
-The image is available on `cgr.dev`:
-
-```
-docker pull cgr.dev/chainguard/php:latest
-```
+- `latest`: Alpine-based image for production runtimes (distroless)
+- `latest-glibc`: Wolfi-based image for production runtimes (distroless)
+- `latest-dev`: Alpine-based image for development and build runtimes (includes Composer and busybox)
+- `latest-glibc-dev`: Wolfi-based image for development and production runtimes (includes Composer and busybox)
 
 ## Usage 
 
@@ -20,8 +17,39 @@ To try out the image, run:
 docker run --rm cgr.dev/chainguard/php --version
 ```
 
+This will automatically pull the image to your local system and execute the command `php --version`. You should see output similar to this:
+
 ```
 PHP 8.1.10 (cli) (built: Sep  1 2022 16:13:09) (NTS)
 Copyright (c) The PHP Group
 Zend Engine v4.1.10, Copyright (c) Zend Technologies
+```
+
+### Application Setup for End Users
+
+When creating a Dockerfile to extend from these images, the recommended approach is to set up a multi-stage build so that you're able to install your Composer dependencies on a separate environment and then copy the files over to a distroless image.
+
+The following example demonstrates how to do that:
+
+```Dockerfile
+FROM cgr.dev/chainguard/php:latest-glibc-dev AS builder
+COPY . /app
+RUN cd /app && \
+    composer install --no-progress --no-dev --prefer-dist
+
+FROM cgr.dev/chainguard/php:latest-glibc
+COPY --from=builder /app /app
+
+ENTRYPOINT [ "php", "/app/minicli fact" ]
+
+```
+
+## Detailed Environment Information
+
+To obtain detailed information about the environment, you can run a `php --info` command on any of the image tags and use `grep` to look for a specific module or extension.
+
+For instance, to check for `curl` settings, you can run:
+
+```shell
+docker run --rm cgr.dev/chainguard/php:latest-glibc --info | grep curl
 ```

--- a/images/php/configs/latest-dev.apko.yaml
+++ b/images/php/configs/latest-dev.apko.yaml
@@ -29,4 +29,3 @@ accounts:
     - username: php
       uid: 65532
       gid: 65532
-  run-as: 65532

--- a/images/php/configs/latest-dev.apko.yaml
+++ b/images/php/configs/latest-dev.apko.yaml
@@ -18,6 +18,15 @@ contents:
 entrypoint:
   command: /usr/bin/php81
 
+paths:
+  - path: /app
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+
+work-dir: /app
+
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
 

--- a/images/php/configs/latest-dev.apko.yaml
+++ b/images/php/configs/latest-dev.apko.yaml
@@ -4,6 +4,7 @@ contents:
     - https://dl-cdn.alpinelinux.org/alpine/edge/community
   packages:
     - alpine-baselayout
+    - ca-certificates-bundle
     - alpine-release
     - php81
     - php81-common

--- a/images/php/configs/latest-glibc-dev.apko.yaml
+++ b/images/php/configs/latest-glibc-dev.apko.yaml
@@ -15,6 +15,15 @@ entrypoint:
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
 
+paths:
+  - path: /app
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+
+work-dir: /app
+
 accounts:
   groups:
     - groupname: php
@@ -26,4 +35,3 @@ accounts:
 
 archs:
   - x86_64
-

--- a/images/php/configs/latest-glibc-dev.apko.yaml
+++ b/images/php/configs/latest-glibc-dev.apko.yaml
@@ -23,7 +23,7 @@ accounts:
     - username: php
       uid: 65532
       gid: 65532
-  run-as: 65532
 
 archs:
   - x86_64
+

--- a/images/php/configs/latest-glibc-dev.apko.yaml
+++ b/images/php/configs/latest-glibc-dev.apko.yaml
@@ -5,6 +5,7 @@ contents:
     - https://packages.wolfi.dev/os
   packages:
     - wolfi-baselayout
+    - ca-certificates-bundle
     - busybox
     - php
     - composer

--- a/images/php/configs/latest-glibc.apko.yaml
+++ b/images/php/configs/latest-glibc.apko.yaml
@@ -5,7 +5,9 @@ contents:
     - https://packages.wolfi.dev/os
   packages:
     - wolfi-baselayout
+    - ca-certificates-bundle
     - php
+
 
 entrypoint:
   command: /bin/php

--- a/images/php/configs/latest-glibc.apko.yaml
+++ b/images/php/configs/latest-glibc.apko.yaml
@@ -13,6 +13,15 @@ entrypoint:
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
 
+paths:
+  - path: /app
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+
+work-dir: /app
+
 accounts:
   groups:
     - groupname: php
@@ -21,7 +30,7 @@ accounts:
     - username: php
       uid: 65532
       gid: 65532
+  run-as: 65532
 
 archs:
   - x86_64
-

--- a/images/php/configs/latest-glibc.apko.yaml
+++ b/images/php/configs/latest-glibc.apko.yaml
@@ -21,7 +21,7 @@ accounts:
     - username: php
       uid: 65532
       gid: 65532
-  run-as: 65532
 
 archs:
   - x86_64
+

--- a/images/php/configs/latest.apko.yaml
+++ b/images/php/configs/latest.apko.yaml
@@ -27,4 +27,3 @@ accounts:
     - username: php
       uid: 65532
       gid: 65532
-  run-as: 65532

--- a/images/php/configs/latest.apko.yaml
+++ b/images/php/configs/latest.apko.yaml
@@ -16,6 +16,15 @@ contents:
 entrypoint:
   command: /usr/bin/php81
 
+paths:
+  - path: /app
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+
+work-dir: /app
+
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
 
@@ -27,3 +36,4 @@ accounts:
     - username: php
       uid: 65532
       gid: 65532
+  run-as: 65532

--- a/images/php/configs/latest.apko.yaml
+++ b/images/php/configs/latest.apko.yaml
@@ -4,6 +4,7 @@ contents:
     - https://dl-cdn.alpinelinux.org/alpine/edge/community
   packages:
     - alpine-baselayout
+    - ca-certificates-bundle
     - alpine-release
     - php81
     - php81-common


### PR DESCRIPTION
This PR brings a few changes to make the PHP images more flexible for end users, facilitating the installation of userland dependencies via Composer both for development as well as for production runtimes.

**WIP**
- [X] Remove `run-as` from -dev variants
- [X] Create  `/app` directory for non-root user, where users can install their apps
- [X] Update README
