### PR TITLE
sdk: install gsutil and gcloud

### DIFF
--- a/images/sdk/configs/latest.melange.yaml
+++ b/images/sdk/configs/latest.melange.yaml
@@ -23,6 +23,7 @@ package:
       - bash
       - bubblewrap
       - tree
+      - python3
 
 environment:
   contents:
@@ -37,8 +38,31 @@ environment:
       - go
       - make
       - git
+      - python3
 
 pipeline:
+  # Install gcloud and gsutil for either x86_64 or aarch64, but no other architectures.
+  - if: ${{build.arch}} == "x86_64"
+    uses: fetch
+    with:
+      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-410.0.0-linux-x86_64.tar.gz
+      expected-sha256: de3525b315d7ea3c3696eba466ddd97313ccad45f6f684bcdd9224374baa6c08
+  - if: ${{build.arch}} == "x86_64"
+    runs: |
+      install.sh
+      install -m755 bin/gcloud "${{targets.destdir}}"/bin/gcloud
+      install -m755 bin/gsutil "${{targets.destdir}}"/bin/gsutil
+  - if: ${{build.arch}} == "aarch64"
+    uses: fetch
+    with:
+      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-410.0.0-linux-arm.tar.gz
+      expected-sha256: ce382528da5f5d5daf84f63ec4289ed60069e78f0cd8d9fa11c46ae5993854ea
+  - if: ${{build.arch}} == "aarch64"
+    runs: |
+      install.sh
+      install -m755 bin/gcloud "${{targets.destdir}}"/bin/gcloud
+      install -m755 bin/gsutil "${{targets.destdir}}"/bin/gsutil
+
   - runs: |
       set -x
 


### PR DESCRIPTION
Fixes https://github.com/chainguard-images/meta/issues/22

Open to other ideas about how to do this. I wasn't sure if we wanted a Wolfi package for gsutil/gcloud since they're not OSS, or if we wanted a separate apk for them that the sdk image uses, vs putting them directly into the sdk package like I'm doing here. Feedback very welcome.

Keeping these up to date may also become a pain since they do ~weekly-ish releases, but at least since they're only used by the sdk image I think the downside of an out-of-date package is less bad than if it were in a shared place like the Wolfi repo. And anyway we only really need basic `gsutil` functionality, which doesn't change very often.

Signed-off-by: Jason Hall <jason@chainguard.dev>