### PR TITLE
Add netcat openbsd image

### DIFF
--- a/images/netcat-openbsd/README.md
+++ b/images/netcat-openbsd/README.md
@@ -1,0 +1,11 @@
+# netcat-openbsd
+
+Minimal image with netcat-openbsd binary. **EXPERIMENTAL**
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/netcat-openbsd:latest
+```

--- a/images/netcat-openbsd/configs/latest.apko.yaml
+++ b/images/netcat-openbsd/configs/latest.apko.yaml
@@ -1,0 +1,21 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+  packages:
+    - ca-certificates-bundle
+    - busybox
+    - netcat-openbsd
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+archs:
+- x86_64
+- aarch64

--- a/images/netcat-openbsd/configs/latest.apko.yaml
+++ b/images/netcat-openbsd/configs/latest.apko.yaml
@@ -16,6 +16,11 @@ accounts:
       gid: 65532
   run-as: 65532
 
+entrypoint:
+  command: /usr/bin/nc
+cmd: -h
+work-dir: /home/nc
+
 archs:
 - x86_64
 - aarch64

--- a/images/netcat-openbsd/image.yaml
+++ b/images/netcat-openbsd/image.yaml
@@ -1,0 +1,5 @@
+versions:
+  - apko:
+      config: configs/latest.apko.yaml
+      extractTagsFrom:
+        package: netcat-openbsd

--- a/images/netcat-openbsd/test.sh
+++ b/images/netcat-openbsd/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail
+
+IMAGE_NAME=${IMAGE_NAME:-"cgr.dev/chainguard/netcat-openbsd"}
+
+docker run $IMAGE_NAME -h


### PR DESCRIPTION
currently, the scaffolding chart uses trillian which rely on toolbelt/nc image. that image is amd64 only which then make the scaffolding chart requires amd64 node.

https://github.com/sigstore/helm-charts/blob/a80c33c8ca6f3c37d9b1dcb4dab14ca625f77831/charts/trillian/values.yaml#L160

