### PR TITLE
ruby: use irb as entrypoint

### DIFF
--- a/images/ruby/configs/latest-3.0.apko.yaml
+++ b/images/ruby/configs/latest-3.0.apko.yaml
@@ -26,8 +26,7 @@ paths:
 work-dir: /work
 
 entrypoint:
-  command: /usr/bin/ruby
-cmd: --help
+  command: /usr/bin/irb
 
 archs:
 - x86_64

--- a/images/ruby/configs/latest-3.1.apko.yaml
+++ b/images/ruby/configs/latest-3.1.apko.yaml
@@ -26,8 +26,7 @@ paths:
 work-dir: /work
 
 entrypoint:
-  command: /usr/bin/ruby
-cmd: --help
+  command: /usr/bin/irb
 
 archs:
 - x86_64

--- a/images/ruby/configs/latest-3.2.apko.yaml
+++ b/images/ruby/configs/latest-3.2.apko.yaml
@@ -26,8 +26,7 @@ paths:
 work-dir: /work
 
 entrypoint:
-  command: /usr/bin/ruby
-cmd: --help
+  command: /usr/bin/irb
 
 archs:
 - x86_64


### PR DESCRIPTION
This matches the `ruby` image on Dockerhub:

```
$ docker run --rm -it ruby
irb(main):001:0>
```

and now, with this change:

```
$ docker run --rm -it image.tar
irb(main):001:0>
```

Signed-off-by: Jason Hall <jason@chainguard.dev>