### PR TITLE
add alpine-keys to sdk+apko images

### DIFF
--- a/images/apko/configs/latest.apko.yaml
+++ b/images/apko/configs/latest.apko.yaml
@@ -5,6 +5,7 @@ contents:
     - https://packages.wolfi.dev/os
     - '@local /github/workspace/packages'
   packages:
+    - alpine-keys
     - ca-certificates-bundle
     - wolfi-base
     - apko@local

--- a/images/sdk/configs/latest.apko.yaml
+++ b/images/sdk/configs/latest.apko.yaml
@@ -7,6 +7,7 @@ contents:
   packages:
     - sdk@local
     - wolfi-baselayout
+    - alpine-keys
 entrypoint:
   command: /usr/bin/sdk
 


### PR DESCRIPTION
These are needed in order to be able to pull alpine packages, like we do when bootstrapping wolfi.