### PR TITLE
Rust-ify the curl image!

### DIFF
--- a/images/curl/configs/latest.apko.yaml
+++ b/images/curl/configs/latest.apko.yaml
@@ -6,6 +6,7 @@ contents:
   packages:
     - curl
     - wolfi-baselayout
+    - libcurl-rustls4
 
 entrypoint:
   command: /usr/bin/curl


### PR DESCRIPTION
I think this is the right way to force curl to select the rustls backend.

Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>