### PR TITLE
fix: busybox Alpine image missing os-release

### DIFF
--- a/images/busybox/configs/latest.apko.yaml
+++ b/images/busybox/configs/latest.apko.yaml
@@ -5,6 +5,7 @@ contents:
     # These packages match chainguard-images/static
     - alpine-baselayout-data
     - ca-certificates-bundle
+    - alpine-release
 
     # busybox gives us a shell we can use, when we need one.
     - busybox


### PR DESCRIPTION
Missing a package that adds the `/etc/os-release` file means vuln scanners can't properly detect the distro or apply secdb data to the scan.

I believe this was the only Alpine image missing the `alpine-release` package.