### PR TITLE
Revert "rabbitmq: switch uid and guid to be consistent with other cha…

### DIFF
--- a/images/rabbitmq/configs/latest.apko.yaml
+++ b/images/rabbitmq/configs/latest.apko.yaml
@@ -16,34 +16,34 @@ paths:
   - path: /var/lib/rabbitmq
     type: directory
     permissions: 0o777
-    uid: 65532
-    gid: 65532
+    uid: 999
+    gid: 999
     resursive: true
   - path: /app
     type: directory
     permissions: 0o777
-    uid: 65532
-    gid: 65532
+    uid: 999
+    gid: 999
   - path: /var/lib/rabbitmq/mnesia
     type: directory
     permissions: 0o777
-    uid: 65532
-    gid: 65532
+    uid: 999
+    gid: 999
   - path: /var/log/rabbitmq
     type: directory
     permissions: 0o777
-    uid: 65532
-    gid: 65532
+    uid: 999
+    gid: 999
   - path: /home/rabbitmq
     type: directory
     permissions: 0o777
-    uid: 65532
-    gid: 65532
+    uid: 999
+    gid: 999
   - path: /var/log/rabbitmq/rabbit
     type: directory
     permissions: 0o777
-    uid: 65532
-    gid: 65532
+    uid: 999
+    gid: 999
 
 work-dir: /var/lib/rabbitmq
 
@@ -63,11 +63,11 @@ environment:
 accounts:
   groups:
     - groupname: rabbitmq
-      gid: 65532
+      gid: 999
   users:
     - username: rabbitmq
-      uid: 65532
-  run-as: 65532
+      uid: 999
+  run-as: 999
 
 archs:
 - x86_64


### PR DESCRIPTION
…inguard images"

This reverts commit 4588f0119aabefdbc88cd1a7191aee301abc0ece.

It seems these GID and UID do need to be 999 https://sourcegraph.com/github.com/rabbitmq/cluster-operator/-/blob/internal/resource/statefulset.go?L541