### PR TITLE
Fixed typo in python image docs

### DIFF
--- a/images/python/README.md
+++ b/images/python/README.md
@@ -14,14 +14,14 @@ While this image is being developed, we will stick to the latest stable Python v
 
 ## Get It!
 
-We have two images available: a `python:dev-latest` variant that contains `pip` and a shell, and a minimal runtime image that just contains
+We have two images available: a `python:latest-dev` variant that contains `pip` and a shell, and a minimal runtime image that just contains
 python itself.
 
 These images are available on `cgr.dev`:
 
 ```
 docker pull cgr.dev/chainguard/python:latest
-docker pull cgr.dev/chainguard/python:dev-latest
+docker pull cgr.dev/chainguard/python:latest-dev
 ```
 
 ## Usage
@@ -29,7 +29,7 @@ docker pull cgr.dev/chainguard/python:dev-latest
 The python image can be used directly for simple cases, or with a multi-stage build using python-dev as the build container.
 
 ```Dockerfile
-FROM cgr.dev/chainguard/python:dev-latest AS builder
+FROM cgr.dev/chainguard/python:latest-dev AS builder
 COPY . /app
 RUN cd /app && pip install -r requirements.txt
 


### PR DESCRIPTION
## Type of change
Fixed documentation to include the correct name of the image tag for python dev. Tried to fix it in the edu repo in https://github.com/chainguard-dev/edu/pull/317. But it is generated from this README

### What should this PR do?
The tag for the dev version of the python image is called `latest-dev` not `dev-latest`

### Why are we making this change?
If a user tries to pull `cgr.dev/chainguard/python:dev-latest` it will not work.

### What are the acceptance criteria? 
-

### How should this PR be tested?
-