### PR TITLE
Adding env var to suppress npm update notification

### DIFF
--- a/images/node/configs/latest.apko.yaml
+++ b/images/node/configs/latest.apko.yaml
@@ -26,6 +26,7 @@ environment:
   # port to listen on. Default to a high port since the user runs as non-root.
   NODE_PORT: 3000
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
+  NPM_CONFIG_UPDATE_NOTIFIER: false # Disables npm update notifications
 
 entrypoint:
   command: /usr/bin/node


### PR DESCRIPTION
This PR adds an ENV variable setting `NPM_CONFIG_UPDATE_NOTIFIER` to `false` to stop the update notifications that show up when running `npm install`.

Tested with a local apko build.