### PR TITLE
Add real test for traefik image

### DIFF
--- a/images/traefik/tests/01-version.sh
+++ b/images/traefik/tests/01-version.sh
@@ -5,5 +5,4 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 IMAGE_DIR="$(basename "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd )")"
 IMAGE_NAME=${IMAGE_NAME:-"cgr.dev/chainguard/${IMAGE_DIR}:latest"}
 
-# See https://github.com/chainguard-images/images/issues/265
-echo "TODO: add real tests for traefik image here"
+docker run --rm "${IMAGE_NAME}" version


### PR DESCRIPTION
Resolves #265

Actually the traefik image is now working after https://github.com/chainguard-dev/melange/issues/281 was fixed, the issue above should be closed too. This just adds a test to prevent further regression.