### PR TITLE
Add a bash image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 | Name | OCI Reference | Status | Variants/Tags |
 | ----- | ----- | ----- |  -------- |
 | [apko](./images/apko) | `cgr.dev/chainguard/apko` | stable | [![](https://storage.googleapis.com/chainguard-images-build-outputs/badges/apko.build.status.latest.svg)](https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/apko:latest) |
+| [bash](./images/bash) | `cgr.dev/chainguard/bash` | stable | [![](https://storage.googleapis.com/chainguard-images-build-outputs/badges/bash.build.status.latest.svg)](https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/bash:latest) |
 | [bazel](./images/bazel) | `cgr.dev/chainguard/bazel` | experimental | [![](https://storage.googleapis.com/chainguard-images-build-outputs/badges/bazel.build.status.latest.svg)](https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/bazel:latest) |
 | [busybox](./images/busybox) | `cgr.dev/chainguard/busybox` | stable | [![](https://storage.googleapis.com/chainguard-images-build-outputs/badges/busybox.build.status.latest-glibc.svg)](https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/busybox:latest-glibc)<br/>[![](https://storage.googleapis.com/chainguard-images-build-outputs/badges/busybox.build.status.latest.svg)](https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/busybox:latest) |
 | [cc-dynamic](./images/cc-dynamic) | `cgr.dev/chainguard/cc-dynamic` | stable | [![](https://storage.googleapis.com/chainguard-images-build-outputs/badges/cc-dynamic.build.status.latest.svg)](https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/cc-dynamic:latest) |

--- a/images/bash/README.md
+++ b/images/bash/README.md
@@ -1,0 +1,22 @@
+<!--monopod:start-->
+# bash
+| | |
+| - | - |
+| **Status** | stable |
+| **OCI Reference** | `cgr.dev/chainguard/bash` |
+| **Variants/Tags** | ![](https://storage.googleapis.com/chainguard-images-build-outputs/summary/bash.svg) |
+
+*[Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Container image with only bash and libc. Suitable for running any small scripts or binaries that need bash instead of just the busybox shell.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/bash:latest
+```

--- a/images/bash/configs/latest.apko.yaml
+++ b/images/bash/configs/latest.apko.yaml
@@ -1,0 +1,18 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - curl
+    - wolfi-baselayout
+    - bash
+    - busybox
+    - ca-certificates-bundle
+
+entrypoint:
+  command: /bin/bash -c
+
+archs:
+- x86_64
+- aarch64

--- a/images/bash/image.yaml
+++ b/images/bash/image.yaml
@@ -1,0 +1,5 @@
+versions:
+  - apko:
+      config: configs/latest.apko.yaml
+      extractTagsFrom:
+        package: bash

--- a/images/bash/tests/01-runs.sh
+++ b/images/bash/tests/01-runs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+IMAGE_DIR="$(basename "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd )")"
+IMAGE_NAME=${IMAGE_NAME:-"cgr.dev/chainguard/${IMAGE_DIR}:latest"}
+
+docker run --rm $IMAGE_NAME ls > /dev/null


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: 
Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**

#### For new image PRs only

If you have an apko.yaml file in this PR you need to follow this checklist, otherwise feel free to remove.

- [ ]  Image is marked experimental or stable as appropriate
- [ ]  The last two minor versions are available
- [ ]  The latest tag points to the newest stable version
- [ ]  There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ]  The image runs as `nonroot` and GID/UID are set to 65532
  - [ ]  Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
  - [ ]  See above for exceptions to nonroot rule
- [ ]  ENTRYPOINT
  - [ ]  For applications/servers/utilities call main program with no arguments e.g. [redis-server]
  - [ ]  For base images leave empty
  - [ ]  For dev variants set to entrypoint script that falls back to system
- [ ]  CMD:
  - [ ]  For server applications give arguments to start in daemon mode (may be empty)
  - [ ]  For utilities/tooling bring up help e.g. `–help`
  - [ ]  For base images with a shell, call it e.g. [/bin/sh]
- [ ]  Consider where and how the image deviates from popular alternatives. Is there a good reason and is it documented?
- [ ]  Add annotations e.g:

        annotations:
          "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
          "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/ #use the academy site here
          "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bazel #use github here

- [ ]  Check if environment variables are needed e.g. to set data locations
- [ ]  Ensure the image responds to SIGTERM
  - [ ]   `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`
- [ ]  Documentation. Let's make this excellent. Include usage example.
- [ ]  Error logs write to stderr and normal logs to stdout. DO NOT write to file.
- [ ]  Include tests, at the very least a basic smoke test.