### PR TITLE
fix permissions on postgres image

### DIFF
--- a/images/postgres/configs/latest.apko.yaml
+++ b/images/postgres/configs/latest.apko.yaml
@@ -36,7 +36,7 @@ paths:
     type: directory
     uid: 70
     gid: 70
-    permissions: 777
+    permissions: 0o777
 
 archs:
   - x86_64


### PR DESCRIPTION
The permissions are read as uint32, so it needs to be an octal. Every other file has `0o777` or similar, but Postgres has just 777, which breaks things. This fixes it.