### PR TITLE
Feature: Start to authenticate with Chainguard registry.

### DIFF
--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -15,6 +15,14 @@ runs:
   steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
+    - name: Setup chainctl
+      uses: chainguard-dev/actions/setup-chainctl@main
+      with:
+        # This allows chainguard-images/images to publish images to cgr.dev/chainguard
+        # We maintain this identity here:
+        # https://github.com/chainguard-dev/mono/blob/main/env/chainguard-images/iac/images-pusher.tf
+        identity: "720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f"
+
     # optionally fetch a gcs bucket to be used by melange and apko builds
     - id: gcsfetchauth1
       if: inputs.gcsFetchBucketName != ''


### PR DESCRIPTION
:gift: This change adds setup-chainctl to start authenticating with our registry.

A subsequent change will start to take advantage of this, but we want to try authenticating as the first baby step.

/kind feature

