### PR TITLE
Move the nats and nsc binaries to the nats-dev image using build-opti…

### DIFF
--- a/images/nats/README.md
+++ b/images/nats/README.md
@@ -23,7 +23,8 @@ docker pull cgr.dev/chainguard/nats:latest
 
 ## Using NATS
 
-Chainguard NATS images include the `nats-server` binary, the `nats` cli, and the `nsc` tool.
+The default Chainguard NATS images includes only the `nats-server` binary.
+The `dev` variant also includes the `nats` cli, and the `nsc` tool.
 The default entrypoint is set to run the `nats-server` binary with a sample configuration at `/etc/nats/nats-server.conf`.
 This can be overridden with the `--config-file` flag.
 

--- a/images/nats/configs/latest.apko.yaml
+++ b/images/nats/configs/latest.apko.yaml
@@ -6,8 +6,6 @@ contents:
   packages:
     - ca-certificates-bundle
     - wolfi-baselayout
-    - nats
-    - nsc
     - nats-server
 
 accounts:

--- a/images/nats/image.yaml
+++ b/images/nats/image.yaml
@@ -8,3 +8,11 @@ versions:
         - suffix: -dev
           options:
             - dev
+            - nats-dev
+options:
+  nats-dev:
+    contents:
+      packages:
+        add:
+          - nats
+          - nsc


### PR DESCRIPTION
…ons.

The nats image in the nats repo contains these by default, but the official Docker image does not.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes:

Related: 

### Pre-review Checklist

