### PR TITLE
fix: set shell:bash for cgr login step

### DIFF
--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -297,6 +297,7 @@ runs:
       with:
         identity: ${{ inputs.chainguardIdentity }}
     - if: inputs.chainguardIdentity != ''
+      shell: bash
       run: |
         chainctl config set platform.registry https://cgr.dev
         chainctl auth configure-docker --identity ${{ inputs.chainguardIdentity }}


### PR DESCRIPTION
Fixes errors like https://github.com/chainguard-images/images/actions/runs/4491737796/jobs/7900630278