### PR TITLE
randomly sleep up to 10 mins to avoid ghcr rate limits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,11 +91,14 @@ jobs:
             mv inputs.json.tmp inputs.json
           done
           echo "release-image-inputs=$(cat inputs.json | tr -d '\n')" >> $GITHUB_OUTPUT
-      # Sleep a random amount of time up to 2 minutes.
+      # Sleep a random amount of time up to 10 minutes.
       # This staggers our pushes, to hopefully avoid hitting rate limits.
       # See https://github.com/chainguard-images/images/issues/173
       - name: Random Sleep
-        run: sleep $(( ( RANDOM % 120 )  + 1 ))
+        run: |
+          rand=$(( ( RANDOM % 600 )  + 1 ))
+          echo "sleeping $rand seconds..."
+          sleep $rand
       - uses: ./.github/actions/release-image
         with: ${{ fromJSON(steps.release-image-inputs.outputs.release-image-inputs) }}
       - uses: ./.github/actions/policy-check-image


### PR DESCRIPTION
As we have more and more images with multiple architectures and with more and more attachments (SBOM attestations, etc.), we're seeing https://github.com/chainguard-images/images/issues/173 more and more. Basically regularly daily, requiring manual retries.

Bumping the 2-minute random sleep to 10-minutes should fix it. 🤞 

We can remove these sleeps when we only push to cgr.dev.