### PR TITLE
Remove references to ghcr

### DIFF
--- a/images/netcat/README.md
+++ b/images/netcat/README.md
@@ -24,7 +24,7 @@ docker pull cgr.dev/chainguard/netcat:latest
 ## Usage
 
 ```
-docker run --rm -ti ghcr.io/chainguard/netcat -zv google.com 443
+docker run --rm -ti cgr.dev/chainguard/netcat -zv google.com 443
 ```
 
 See [here](https://manpages.debian.org/unstable/netcat-openbsd/nc.1.en.html) for more invocation details.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes:

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**

#### For new image PRs only

If you have an apko.yaml file in this PR you need to follow this checklist, otherwise feel free to remove.
- [x] Image is marked experimental or stable as appropriate
- [x] The last two minor versions are available
- [x] The latest tag points to the newest stable version
- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [x] The image runs as `nonroot` and GID/UID are set to 65532
  - [x] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
  - [x] See above for exceptions to nonroot rule
- [x] ENTRYPOINT
  - [x] For applications/servers/utilities call main program with no arguments e.g. [redis-server]
  - [x] For base images leave empty
  - [x] For dev variants set to entrypoint script that falls back to system
- [x] CMD:
  - [x] For server applications give arguments to start in daemon mode (may be empty)
  - [x] For utilities/tooling bring up help e.g. `–help`
  - [x] For base images with a shell, call it e.g. [/bin/sh]
- [x] Consider where and how the image deviates from popular alternatives. Is there a good reason and is it documented?
- [x] Add annotations e.g:
```
annotations:
  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/ # use the academy site here
  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bazel # use github here
```
- [x] Check if environment variables are needed e.g. to set data locations
- [x] Ensure the image responds to SIGTERM
  - [x] `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`
- [x] Documentation. Let's make this excellent. Include usage example.
- [x] Error logs write to stderr and normal logs to stdout. DO NOT write to file.
- [x] Include tests, at the very least a basic smoke test.
