### PR TITLE
Configure graceful shutdown of NGINX image

### DIFF
--- a/images/nginx/configs/latest.apko.yaml
+++ b/images/nginx/configs/latest.apko.yaml
@@ -50,7 +50,9 @@ paths:
     recursive: true
 
 entrypoint:
-    command: /usr/sbin/nginx -c /etc/nginx/nginx.conf -g "daemon off;"
+    command: /usr/sbin/nginx 
+
+cmd: -c /etc/nginx/nginx.conf -g "daemon off;"
 
 stop-signal: SIGQUIT
 

--- a/images/nginx/configs/latest.apko.yaml
+++ b/images/nginx/configs/latest.apko.yaml
@@ -48,10 +48,11 @@ paths:
     type: directory
     permissions: 0o755
     recursive: true
+
 entrypoint:
-  type: service-bundle
-  services:
-    nginx: /usr/sbin/nginx -c /etc/nginx/nginx.conf -g "daemon off;"
+    command: /usr/sbin/nginx -c /etc/nginx/nginx.conf -g "daemon off;"
+
+stop-signal: SIGQUIT
 
 archs:
   - x86_64

--- a/images/nginx/tests/03-shutdown.sh
+++ b/images/nginx/tests/03-shutdown.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+IMAGE_DIR="$(basename "$(cd "$(dirname ${BASH_SOURCE[0]})/.." && pwd )")"
+IMAGE_NAME=${IMAGE_NAME:-"cgr.dev/chainguard/${IMAGE_DIR}:latest"}
+
+# We want nginx to shutdown gracefully. It should get the SIGQUIT signal.
+LOGFILE=$(mktemp)
+ID=$(docker run --rm -d $IMAGE_NAME)
+docker attach $ID 2> $LOGFILE &
+sleep 5
+docker stop $ID 
+grep "SIGQUIT" $LOGFILE
+grep "gracefully shutting down" $LOGFILE 


### PR DESCRIPTION
Our nginx image was doing a "fast" shutdown. By sending it the SIGQUIT signal instead of SIGTERM, it will do a graceful shutdown.

To achieve this:
- removed s6 entrypoint
- added stop-signal support to give nginx SIGQUIT signal
- added tests to ensure graceful exit

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: #403 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**

#### For new image PRs only

If you have an apko.yaml file in this PR you need to follow this checklist, otherwise feel free to remove.
- [ ] Image is marked experimental or stable as appropriate
- [ ] The last two minor versions are available
- [ ] The latest tag points to the newest stable version
- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] The image runs as `nonroot` and GID/UID are set to 65532
  - [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
  - [ ] See above for exceptions to nonroot rule
- [ ] ENTRYPOINT
  - [ ] For applications/servers/utilities call main program with no arguments e.g. [redis-server]
  - [ ] For base images leave empty
  - [ ] For dev variants set to entrypoint script that falls back to system
- [ ] CMD:
  - [ ] For server applications give arguments to start in daemon mode (may be empty)
  - [ ] For utilities/tooling bring up help e.g. `–help`
  - [ ] For base images with a shell, call it e.g. [/bin/sh]
- [ ] Consider where and how the image deviates from popular alternatives. Is there a good reason and is it documented?
- [ ] Add annotations e.g:
```
annotations:
  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/ # use the academy site here
  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bazel # use github here
```
- [ ] Check if environment variables are needed e.g. to set data locations
- [ ] Ensure the image responds to SIGTERM
  - [ ] `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`
- [ ] Documentation. Let's make this excellent. Include usage example.
- [ ] Error logs write to stderr and normal logs to stdout. DO NOT write to file.
- [ ] Include tests, at the very least a basic smoke test.
