### PR TITLE
Update static/README.md

### DIFF
--- a/images/static/README.md
+++ b/images/static/README.md
@@ -6,8 +6,6 @@
 | **OCI Reference** | `cgr.dev/chainguard/static` |
 | **Variants/Tags** | ![](https://storage.googleapis.com/chainguard-images-build-outputs/summary/static.svg) |
 
-*[Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
-
 ---
 <!--monopod:end-->
 


### PR DESCRIPTION
Remove the note about enterprise support, SLAs and older versions for `static`, which does not have older versions.