### PR TITLE
Switch from jitterbit/get-changed-files to tj-actions/changed-files

### DIFF
--- a/.github/workflows/presubmit-build-melange.yaml
+++ b/.github/workflows/presubmit-build-melange.yaml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - id: files
-      uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
+      uses: tj-actions/changed-files@79adacd43ea069e57037edc891ea8d33013bc3da # v35.7.11
       with:
-        format: csv
+        separator: ','
     - id: generate-matrix
       uses: ./.github/actions/generate-matrix
       with:

--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -8,9 +8,9 @@ jobs:
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - id: files
-      uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
+      uses: tj-actions/changed-files@79adacd43ea069e57037edc891ea8d33013bc3da # v35.7.11
       with:
-        format: csv
+        separator: ','
     - id: generate-matrix
       uses: ./.github/actions/generate-matrix
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,9 @@ jobs:
     # On push to main branch, only build images necessary
     - id: files
       if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
-      uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
+      uses: tj-actions/changed-files@79adacd43ea069e57037edc891ea8d33013bc3da # v35.7.11
       with:
-        format: csv
+        separator: ','
     - id: generate-matrix-main
       if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       uses: ./.github/actions/generate-matrix


### PR DESCRIPTION
Resolves #204 (hopefully)

Should also help to prevent the following actions warnings:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```