### PR TITLE
Fix to use correct changed files output name

### DIFF
--- a/.github/workflows/presubmit-build-melange.yaml
+++ b/.github/workflows/presubmit-build-melange.yaml
@@ -19,7 +19,7 @@ jobs:
     - id: generate-matrix
       uses: ./.github/actions/generate-matrix
       with:
-        modified-files: ${{ steps.files.outputs.all }}
+        modified-files: ${{ steps.files.outputs.all_changed_files }}
         melange-mode: only
   presubmit-build-melange:
     if: contains(github.event.pull_request.labels.*.name, 'melange')

--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -14,7 +14,7 @@ jobs:
     - id: generate-matrix
       uses: ./.github/actions/generate-matrix
       with:
-        modified-files: ${{ steps.files.outputs.all }}
+        modified-files: ${{ steps.files.outputs.all_changed_files }}
         melange-mode: none
   presubmit-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
       if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
       uses: ./.github/actions/generate-matrix
       with:
-        modified-files: ${{ steps.files.outputs.all }}
+        modified-files: ${{ steps.files.outputs.all_changed_files }}
     - id: generate-matrix
       run: |
         set -x


### PR DESCRIPTION
This was causing builds to build everything vs. just what changed. Issue introduced in https://github.com/chainguard-images/images/pull/425