### PR TITLE
Add libstdc++ to jvm based images (jre, jdk)

### DIFF
--- a/images/jdk/configs/latest.apko.yaml
+++ b/images/jdk/configs/latest.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - glibc-locale-en
     - busybox
     - openjdk-17
+    - libstdc++
 
 accounts:
   groups:

--- a/images/jdk/configs/openjdk-11.apko.yaml
+++ b/images/jdk/configs/openjdk-11.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - glibc-locale-en
     - busybox
     - openjdk-11
+    - libstdc++
 
 accounts:
   groups:

--- a/images/jre/configs/latest.apko.yaml
+++ b/images/jre/configs/latest.apko.yaml
@@ -8,6 +8,7 @@ contents:
     - wolfi-baselayout
     - glibc-locale-en
     - openjdk-17-jre
+    - libstdc++
 
 accounts:
   groups:

--- a/images/jre/configs/openjdk-11.apko.yaml
+++ b/images/jre/configs/openjdk-11.apko.yaml
@@ -8,6 +8,7 @@ contents:
     - wolfi-baselayout
     - glibc-locale-en
     - openjdk-11-jre
+    - libstdc++
 
 accounts:
   groups:


### PR DESCRIPTION
Adds `libstdc++` to jvm based images to allow usage of libraries and profilers
which require it.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: #422

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**
