### PR TITLE
Set the default config location in fluent-bit.

### DIFF
--- a/images/fluent-bit/configs/latest.apko.yaml
+++ b/images/fluent-bit/configs/latest.apko.yaml
@@ -25,6 +25,7 @@ paths:
 
 entrypoint:
   command: /usr/bin/fluent-bit
+cmd: -c /fluent-bit/etc/fluent-bit.conf
 
 archs:
   - x86_64


### PR DESCRIPTION
Fixes: https://github.com/chainguard-images/images/issues/431

Related: 

### Pre-review Checklist
