### PR TITLE
Updated ruby entrypoint and command

### DIFF
--- a/images/ruby/configs/3.0.apko.yaml
+++ b/images/ruby/configs/3.0.apko.yaml
@@ -25,7 +25,9 @@ paths:
 
 work-dir: /work
 
-cmd: /usr/bin/irb
+entrypoint:
+  command: /usr/bin/ruby
+cmd: --version
 
 archs:
 - x86_64

--- a/images/ruby/configs/3.1.apko.yaml
+++ b/images/ruby/configs/3.1.apko.yaml
@@ -25,7 +25,9 @@ paths:
 
 work-dir: /work
 
-cmd: /usr/bin/irb
+entrypoint:
+  command: /usr/bin/ruby
+cmd: --version
 
 archs:
 - x86_64

--- a/images/ruby/configs/latest.apko.yaml
+++ b/images/ruby/configs/latest.apko.yaml
@@ -25,7 +25,9 @@ paths:
 
 work-dir: /work
 
-cmd: /usr/bin/irb
+entrypoint:
+  command: /usr/bin/ruby
+cmd: --version
 
 archs:
 - x86_64

--- a/images/ruby/tests/01-version.sh
+++ b/images/ruby/tests/01-version.sh
@@ -7,5 +7,5 @@ if [[ "${IMAGE_NAME}" == "" ]]; then
     exit 1
 fi
 
-docker run --rm "${IMAGE_NAME}" ruby -v
-docker run --rm "${IMAGE_NAME}" irb -v
+docker run --rm "${IMAGE_NAME}"
+docker run --rm --entrypoint irb "${IMAGE_NAME}" -v


### PR DESCRIPTION
This PR updates the entrypoint for Ruby images to use `/usr/bin/ruby` with the default command set to `--version`.

The current entry point is set to the interactive ruby tool `irb`, resulting in odd behavior when you try to run Ruby scripts directly via `docker run`. This change was discussed in an [internal Slack thread](https://chainguard-dev.slack.com/archives/C0322APD4LU/p1681480063454969).

With the update, it is possible to execute a Ruby script with:

```shell
docker run --rm -v ${PWD}:/work cgr.dev/chainguard/ruby:latest script.rb
```
