### PR TITLE
Add gha-creds to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 monopod/monopod
 .idea
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json
+


### PR DESCRIPTION
The [google-github-actions/auth](https://github.com/google-github-actions/auth) action used by this repository dumps GCP credentials into the git directory it checks out. 

To prevent future credential leakage if the release process changes, it's recommended to have this .gitignore entry in place. From the documentation at https://github.com/google-github-actions/auth : 


> If you plan to create binaries, containers, pull requests, or other releases, add the > following to your .gitignore to prevent accidentially committing credentials to your > release artifact:

```
# Ignore generated credentials from google-github-actions/auth
gha-creds-*.json
```