### PR TITLE
Bring nginx closer to Docker official image.

### DIFF
--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -33,7 +33,7 @@ If you are unable to update currently, you can use the last build of the previou
 docker pull cgr.dev/chainguard/nginx@sha256:bcc6b0d052298112e4644b258de0fa4dc1509e3df8f7c0fba09e8c92987825e7
 ```
 
-This digest corresponds to nginx:1.24.0. This image is not updated and you should migrate to the
+This digest corresponds to nginx version 1.24.0. This image is not updated and you should migrate to the
 new configuration as soon as possible.
 
 ## Get It!

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -98,7 +98,7 @@ or an equivalent.
 ## Differences to [Docker Official Image](https://hub.docker.com/_/nginx)
 
 Where possible, the image tries to stay close to Docker official image configuration. However our
-image strives for minimalism and the default image does not include a shell or pacakge manager,
+image strives for minimalism and the default image does not include a shell or package manager,
 meaning it isn't possible to achieve an identical configuration. In this section we outline the
 major differences.
 

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -13,12 +13,12 @@
 
 A minimal nginx base image rebuilt every night from source.
 
-## Upcoming Breaking Changes
+## Breaking Changes
 
-On May 3 2023 the Chainguard nginx image will be rebuilt with several improvements, including
-breaking changes. You may need to take action to update your application to prevent disruption. 
+On May 3 2023 the Chainguard nginx image was rebuilt with several improvements, including
+breaking changes. You may need to take action to update your application. 
 
-Specifically, the config file is being changed to bring the default configuration closer to that of
+Specifically, the config file was changed to bring the default configuration closer to that of
 official nginx image. If you override the config with a custom configuration, you should not be affected.
 
 The changes include:
@@ -27,9 +27,14 @@ The changes include:
  - Setting nginx to automatically determine the number of worker processes
  - Moving the HTML directory to `/usr/share/nginx/html`
 
-You can test the new image out now by pulling the `cgr.dev/chainguard/nginx:next` image. This is a
-temporary tag that will be removed shortly after May 3, 2023, when the changes will merged into the
-`latest` image.
+If you are unable to update currently, you can use the last build of the previous image e.g: 
+
+```
+docker pull cgr.dev/chainguard/nginx@sha256:bcc6b0d052298112e4644b258de0fa4dc1509e3df8f7c0fba09e8c92987825e7
+```
+
+This digest corresponds to nginx:1.24.0. This image is not updated and you should migrate to the
+new configuration as soon as possible.
 
 ## Get It!
 
@@ -62,3 +67,70 @@ To use a custom `nginx.conf` you can mount the file into the container
 ```
 docker run -v $(pwd)/$CUSTOM_NGINX_CONF_DIRECTORY/nginx.conf:/etc/nginx/nginx.conf -p 8080:80 cgr.dev/chainguard/nginx
 ```
+
+## Run in a read-only File System
+
+If you want to run with read-only filesystem, you will need to mount the `/var/run` and
+`/var/lib/nginx/tmp` directories. The easiest way to do this is with `--tmpfs` e.g:
+
+```
+docker run \
+  --read-only \
+  --tmpfs /var/lib/nginx/tmp/ --tmpfs /var/run/ \
+  --cap-drop=ALL \
+  -p 8080:8080
+  cgr.dev/chainguard/nginx
+```
+
+### User Directive Warning
+
+Starting the container gives the following warning:
+
+```
+nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
+```
+
+The warning is telling us container is already running as the named user, so it doesn't have
+anything to do. If the container is run as root, it would switch to the named user. We decided to
+leave this configuration in despite the warning for anyone that runs with `--user` switch in Docker
+or an equivalent.
+
+## Differences to Docker Official Image
+
+Where possible, the image tries to stay close to Docker official image configuration. However our
+image strives for minimalism and the default image does not include a shell or pacakge manager,
+meaning it isn't possible to achieve an identical configuration. In this section we outline the
+major differences.
+
+### Default port
+
+To support the change to an unprivileged user, the default port was moved to 8080, contrasting with
+port 80 used by the official image.
+
+### IPv6 Support
+
+The official Docker image checks for the existence of `/proc/net/if_inet6` and automatically listens
+on `[::]:80` if it exists. For simplicity, we only listen on IPv4, but IPv6 support can be easily
+added by mounting a config file with a section such as:
+
+```
+server {
+    listen       8080;
+    listen  [::]:8080;
+    ...
+
+```
+
+Note that the default config has the relevant section at `/etc/nginx/conf.d/default.conf`
+
+### Users
+
+The official Docker image starts as the root user and forks to a less privileged user. By contrast,
+our image starts up as a less priviliged user and no forking is required. For most users this
+shouldn't make a difference, but note the "User Directive Warning" above.
+
+### Environment Variable Substitution
+
+The Docker official image has support for setting environment variables that get substitued into the
+config file. Currently we do not have support for this, but are [looking into options](https://github.com/chainguard-images/images/issues/435). 
+

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -95,7 +95,7 @@ anything to do. If the container is run as root, it would switch to the named us
 leave this configuration in despite the warning for anyone that runs with `--user` switch in Docker
 or an equivalent.
 
-## Differences to Docker Official Image
+## Differences to [Docker Official Image](https://hub.docker.com/_/nginx)
 
 Where possible, the image tries to stay close to Docker official image configuration. However our
 image strives for minimalism and the default image does not include a shell or pacakge manager,

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -21,7 +21,7 @@ breaking changes. You may need to take action to update your application.
 Specifically, the config file was changed to bring the default configuration closer to that of
 official nginx image. If you override the config with a custom configuration, you should not be affected.
 
-The changes include:
+The changes included:
 
  - Moving the default port from 80 to 8080. This is required to run on Kubernetes as a non-privileged user.
  - Setting nginx to automatically determine the number of worker processes

--- a/images/nginx/configs/latest.apko.yaml
+++ b/images/nginx/configs/latest.apko.yaml
@@ -7,6 +7,7 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - nginx
+    - nginx-package-config
 
 accounts:
   groups:
@@ -19,35 +20,26 @@ accounts:
   run-as: 65532
 
 paths:
-  - path: /s6
-    type: directory
-    uid: 65532
-    gid: 65532
-    permissions: 0o755
   - path: /var/lib/nginx
     type: directory
     uid: 65532
     gid: 65532
     permissions: 0o755
     recursive: true
-  - path: /run/nginx
-    uid: 65532
-    gid: 65532
-    type: directory
-    permissions: 0o755
-    recursive: true
-  - path: /var/log/nginx
-    uid: 65532
-    gid: 65532
-    type: directory
-    permissions: 0o755
-    recursive: true
   - path: /var/lib/nginx/tmp
     uid: 65532
     gid: 65532
     type: directory
-    permissions: 0o755
+    # Wide permissions required for running with tmpfs. Seems to be related to Docker bug https://github.com/moby/moby/issues/40881
+    permissions: 0o777
     recursive: true
+  - path: /var/run
+    uid: 65532
+    gid: 65532
+    type: directory
+    # Wide permissions required for running with tmpfs. Seems to be related to Docker bug https://github.com/moby/moby/issues/40881
+    permissions: 0o777
+    recursive: false
 
 entrypoint:
     command: /usr/sbin/nginx 

--- a/images/nginx/configs/latest.apko.yaml
+++ b/images/nginx/configs/latest.apko.yaml
@@ -52,7 +52,7 @@ paths:
 entrypoint:
     command: /usr/sbin/nginx 
 
-cmd: -c /etc/nginx/nginx.conf -g "daemon off;"
+cmd: -c /etc/nginx/nginx.conf -e /dev/stderr -g "daemon off;"
 
 stop-signal: SIGQUIT
 

--- a/images/nginx/configs/next.apko.yaml
+++ b/images/nginx/configs/next.apko.yaml
@@ -44,7 +44,7 @@ paths:
 entrypoint:
     command: /usr/sbin/nginx 
 
-cmd: -c /etc/nginx/nginx.conf -g "daemon off;"
+cmd: -c /etc/nginx/nginx.conf -e /dev/stderr -g "daemon off;"
 
 stop-signal: SIGQUIT
 

--- a/images/nginx/tests/02-welcome-page.sh
+++ b/images/nginx/tests/02-welcome-page.sh
@@ -9,9 +9,7 @@ fi
 
 CONTAINER_NAME=${CONTAINER_NAME:-"nginx-smoketest-$(date +%s)"}
 
-# The "-p 8080:8080 -p 8081:80" is a temporary hack to support both images
-# Port will 8080 after May 3, and we can drop anything port 8081 or port 80 from this file
-docker run -p 8080:8080 -p 8081:80 -d --name $CONTAINER_NAME $IMAGE_NAME
+docker run -p 8080:8080 -d --name $CONTAINER_NAME $IMAGE_NAME
 trap "docker logs $CONTAINER_NAME && docker rm -f $CONTAINER_NAME" EXIT
 sleep 5
 


### PR DESCRIPTION
*THIS INCLUDES BREAKING CHANGES*

Most notably default port is now 8080 rather than 80, but also other config changes including default html directory and auto determining how many worker processes to instantiate.

This is all referenced in the README, which also includes information on how to get the old version. Is this enough or do we need to handle this differently?

Fixes: #452 #382