### PR TITLE
configure GCS not to cache image summary badges+JSON

### DIFF
--- a/.github/actions/image-summary/action.yml
+++ b/.github/actions/image-summary/action.yml
@@ -159,12 +159,14 @@ runs:
         project_id: ${{ inputs.gcsAuthProjectId }}
         install_components: beta
 
-    # Upload to GCS
+    # Upload to GCS (and don't cache the badges)
     - id: gcsupload1
       if: inputs.gcsBucketName != ''
       shell: bash
       run: |
-        gsutil rsync image-summary-output/ gs://${{ inputs.gcsBucketName }}/summary
+        gcloud --quiet storage cp \
+            --cache-control=no-store \
+            image-summary-output/* gs://${{ inputs.gcsBucketName }}/summary
 
     - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
       if: always()


### PR DESCRIPTION
Currently when you see a red badge because a build fails, it will get cached and show up for an hour even if it passed on retry.

Badges are small and presumably don't contribute a lot to egress or page load time. If we decide we want to cache these we could at least make them cached for a shorter time like 5-10 minutes.