### PR TITLE
opensearch: fix JAVA_HOME location

### DIFF
--- a/images/opensearch/configs/latest.apko.yaml
+++ b/images/opensearch/configs/latest.apko.yaml
@@ -20,7 +20,7 @@ accounts:
   recursive: true
 
 environment:
-  JAVA_HOME: /usr/lib/jvm/openjdk-jre/
+  JAVA_HOME: /usr/lib/jvm/openjdk
 
 entrypoint:
   command: /usr/bin/docker-entrypoint.sh


### PR DESCRIPTION
the JAVA_HOME location for Java 11 JRE has moved to /usr/lib/jvm/openjdk.