### PR TITLE
Cleanup: Have `wait-for-it` run as non-root

### DIFF
--- a/images/wait-for-it/configs/latest.apko.yaml
+++ b/images/wait-for-it/configs/latest.apko.yaml
@@ -6,8 +6,20 @@ contents:
   packages:
     - wait-for-it
     - wolfi-baselayout
+
 entrypoint:
   command: /usr/bin/wait-for-it
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
 archs:
-- x86_64
-- aarch64
+  - x86_64
+  - aarch64


### PR DESCRIPTION
:broom: This changes the `wait-for-it` image to run as non-root by default for a better security posture.

There isn't a strong reason that this should need `root`.

/kind broom
