### PR TITLE
Warning for upcoming breaking changes to NGINX image

### DIFF
--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -13,6 +13,23 @@
 
 A minimal nginx base image rebuilt every night from source.
 
+## Upcoming Breaking Changes
+
+On May 3 2023 there will be potentially breaking changes made to the Chainguard nginx image. You may
+need to take action to update your application to prevent disruption. 
+
+Specifically, the config file is being changed to bring the default configuration closer to that of
+other images. If you override the config with a custom configuration, you should not be affected.
+
+The changes include:
+
+ - Moving the default port from 80 to 8080. This is required to run on Kubernetes as a non-privileged user.
+ - Allowing nginx to automatically determine the number of worker processes
+ - Moving the HTML directory to /usr/share/nginx/html
+
+You can test the new image out now by pulling the `cgr.dev/chainguard/nginx:next` image. This is a
+temporary variant that will be removed shortly after we make the change.
+
 ## Get It!
 
 The image is available on `cgr.dev`:

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -15,11 +15,11 @@ A minimal nginx base image rebuilt every night from source.
 
 ## Upcoming Breaking Changes
 
-On May 3 2023 the Chainguard nginx image will be rebuilt with several improvements including
+On May 3 2023 the Chainguard nginx image will be rebuilt with several improvements, including
 breaking changes. You may need to take action to update your application to prevent disruption. 
 
 Specifically, the config file is being changed to bring the default configuration closer to that of
-other images. If you override the config with a custom configuration, you should not be affected.
+official nginx image. If you override the config with a custom configuration, you should not be affected.
 
 The changes include:
 

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -15,8 +15,8 @@ A minimal nginx base image rebuilt every night from source.
 
 ## Upcoming Breaking Changes
 
-On May 3 2023 there will be potentially breaking changes made to the Chainguard nginx image. You may
-need to take action to update your application to prevent disruption. 
+On May 3 2023 the Chainguard nginx image will be rebuilt with several improvements including
+breaking changes. You may need to take action to update your application to prevent disruption. 
 
 Specifically, the config file is being changed to bring the default configuration closer to that of
 other images. If you override the config with a custom configuration, you should not be affected.
@@ -24,11 +24,12 @@ other images. If you override the config with a custom configuration, you should
 The changes include:
 
  - Moving the default port from 80 to 8080. This is required to run on Kubernetes as a non-privileged user.
- - Allowing nginx to automatically determine the number of worker processes
+ - Setting nginx to automatically determine the number of worker processes
  - Moving the HTML directory to /usr/share/nginx/html
 
 You can test the new image out now by pulling the `cgr.dev/chainguard/nginx:next` image. This is a
-temporary variant that will be removed shortly after we make the change.
+temporary tag that will be removed shortly after May 3, 2023, when the changes will merged into the
+`latest` image.
 
 ## Get It!
 

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -25,7 +25,7 @@ The changes include:
 
  - Moving the default port from 80 to 8080. This is required to run on Kubernetes as a non-privileged user.
  - Setting nginx to automatically determine the number of worker processes
- - Moving the HTML directory to /usr/share/nginx/html
+ - Moving the HTML directory to `/usr/share/nginx/html`
 
 You can test the new image out now by pulling the `cgr.dev/chainguard/nginx:next` image. This is a
 temporary tag that will be removed shortly after May 3, 2023, when the changes will merged into the

--- a/images/nginx/configs/next.apko.yaml
+++ b/images/nginx/configs/next.apko.yaml
@@ -1,0 +1,51 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - ca-certificates-bundle
+    - wolfi-baselayout
+    - nginx
+    - nginx-package-config
+
+accounts:
+  groups:
+    - groupname: nginx
+      gid: 65532
+  users:
+    - username: nginx
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+paths:
+  - path: /var/lib/nginx
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /var/lib/nginx/tmp
+    uid: 65532
+    gid: 65532
+    type: directory
+    permissions: 0o755
+    recursive: true
+  - path: /var/run
+    uid: 65532
+    gid: 65532
+    type: directory
+    permissions: 0o755
+    recursive: false
+
+entrypoint:
+    command: /usr/sbin/nginx 
+
+cmd: -c /etc/nginx/nginx.conf -g "daemon off;"
+
+stop-signal: SIGQUIT
+
+archs:
+  - x86_64
+  - aarch64


### PR DESCRIPTION
This PR updates the nginx README to warn of the [upcoming change](https://github.com/chainguard-images/images/pull/478).

It also includes the new version as a variant so that people can test.