### PR TITLE
Fix: add openjdk 17 to the gradle image

### DIFF
--- a/images/gradle/configs/latest.apko.yaml
+++ b/images/gradle/configs/latest.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - busybox
     - gradle-8
     - wolfi-baselayout
+    - openjdk-17
 
 accounts:
   groups:
@@ -27,6 +28,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
+  JAVA_HOME: /usr/lib/jvm/openjdk-17
 
 paths:
   - path: /home/build


### PR DESCRIPTION
Blocked on https://github.com/wolfi-dev/os/pull/1671