### PR TITLE
Fix: add jdk and JAVA_HOME to gradle image

### DIFF
--- a/images/gradle/configs/latest.apko.yaml
+++ b/images/gradle/configs/latest.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - busybox
     - gradle-8
     - wolfi-baselayout
+    - openjdk-17
 
 accounts:
   groups:
@@ -27,6 +28,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
+  JAVA_HOME: /usr/lib/jvm/open-jdk
 
 paths:
   - path: /home/build

--- a/images/gradle/configs/latest.apko.yaml
+++ b/images/gradle/configs/latest.apko.yaml
@@ -28,7 +28,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/open-jdk
+  JAVA_HOME: /usr/lib/jvm/openjdk
 
 paths:
   - path: /home/build


### PR DESCRIPTION
Fixes: https://github.com/chainguard-images/images/actions/runs/4835767823/jobs/8618374679