### PR TITLE
Modified permissions on directories to support tmpfs.

### DIFF
--- a/images/nginx/configs/next.apko.yaml
+++ b/images/nginx/configs/next.apko.yaml
@@ -30,13 +30,15 @@ paths:
     uid: 65532
     gid: 65532
     type: directory
-    permissions: 0o755
+    # Wide permissions required for running with tmpfs. Seems to be related to Docker bug https://github.com/moby/moby/issues/40881
+    permissions: 0o777
     recursive: true
   - path: /var/run
     uid: 65532
     gid: 65532
     type: directory
-    permissions: 0o755
+    # Wide permissions required for running with tmpfs. Seems to be related to Docker bug https://github.com/moby/moby/issues/40881
+    permissions: 0o777
     recursive: false
 
 entrypoint:


### PR DESCRIPTION
We want to be able to run nginx with:

```
docker run --read-only --tmpfs /var/lib/nginx/tmp/ --tmpfs /var/run -p 8080:8080 cgr.dev/chainguard/nginx:next
```

But it currently fails with permission errors.

The problem seems to be that `--tmpfs` does not set permissions correctly even when run with the `tmpfs-mode` option e.g: `--mount type=tmpfs,destination=/var/lib/nginx/tmp/,tmpfs-mode=777`. Probably related to https://github.com/moby/moby/issues/40881.

Related: https://github.com/chainguard-images/images/issues/288

This is *not* a breaking change (permissions are being relaxed).

