### PR TITLE
run secrets-store CSI driver images as root

### DIFF
--- a/images/secrets-store-csi-driver-provider-gcp/configs/latest.apko.yaml
+++ b/images/secrets-store-csi-driver-provider-gcp/configs/latest.apko.yaml
@@ -15,7 +15,7 @@ accounts:
   users:
     - username: secrets-store-csi-driver-provider-gcp
       uid: 65532
-  run-as: secrets-store-csi-driver-provider-gcp
+  run-as: 0 # run as root
   recursive: true
 
 entrypoint:

--- a/images/secrets-store-csi-driver/configs/latest.apko.yaml
+++ b/images/secrets-store-csi-driver/configs/latest.apko.yaml
@@ -15,7 +15,7 @@ accounts:
   users:
     - username: secrets-store-csi-driver
       uid: 65532
-  run-as: secrets-store-csi-driver
+  run-as: 0 # run as root
   recursive: true
 
 entrypoint:


### PR DESCRIPTION
These images require root to be able to connect to CSI infrastructure over sockets.

Without it, `CrashLoopBackoff`:

```
"failed to listen" err="listen unix //csi/csi.sock: bind: permission denied" proto="unix" address="//csi/csi.sock"
```

and 

```
err: "listen unix /etc/kubernetes/secrets-store-csi-providers/gcp.sock: bind: permission denied"
```

The upstream images run as root:

```
$ docker run --entrypoint sh k8s.gcr.io/csi-secrets-store/driver:v1.3.2 -c whoami
root
```

```
$ crane config us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin:v1.2.0 | jq .config.User
"0"
```

Configuring these images to run as root and using them in the build cluster caused the daemonsets to come up again.

This was discovered while trying to dogfood the images in our own arm64 build cluster (https://github.com/wolfi-dev/wolfictl/pull/194)