### PR TITLE
Feature: Add a digestabot workflow and pin digests

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -80,6 +80,7 @@ runs:
     - id: apko
       uses: chainguard-images/actions/apko-build@main
       with:
+        apko-image: ghcr.io/wolfi-dev/apko:latest@sha256:d0d35729ac785d5bc15d50a1d99ea9a2aef565779fadf37235edfc9b30a10e75
         config: ${{ inputs.apkoConfig }}
         tag: ${{ inputs.imageName }}:${{ github.sha }}-${{ inputs.apkoTargetTag }}
         keyring-append: ${{ inputs.apkoKeyringAppend }}

--- a/.github/actions/policy-check-image/action.yml
+++ b/.github/actions/policy-check-image/action.yml
@@ -19,7 +19,7 @@ runs:
         EOL
 
         docker run --rm -v "${PWD}:/work" \
-          ghcr.io/wolfi-dev/apko:latest \
+          ghcr.io/wolfi-dev/apko:latest@sha256:d0d35729ac785d5bc15d50a1d99ea9a2aef565779fadf37235edfc9b30a10e75 \
           build --debug \
           --arch=amd64 --sbom=false \
           --repository-append=https://packages.wolfi.dev/os \

--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -139,6 +139,7 @@ runs:
     - id: apko
       uses: chainguard-images/actions/apko-snapshot@main
       with:
+        apko-image: ghcr.io/wolfi-dev/apko:latest@sha256:3f7077f5a9d74747c03c03e18d202e81343e654f1b33220220af76db914dc1d1
         config: ${{ inputs.apkoConfig }}
         base-tag: ${{ inputs.apkoBaseTag }}
         target-tag: ${{ inputs.apkoTargetTag }}

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,22 @@
+name: Image digest update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  image-update:
+    name: Image digest update
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: chainguard-dev/actions/digesta-bot@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/k8s-tests.yaml
+++ b/.github/workflows/k8s-tests.yaml
@@ -57,6 +57,7 @@ jobs:
           echo "ip=$(docker inspect registry.local | jq -r '.[0].NetworkSettings.Networks["bridge"].IPAddress')" >> $GITHUB_OUTPUT
       - uses: chainguard-images/actions/apko-publish@main
         with:
+          apko-image: ghcr.io/wolfi-dev/apko:latest@sha256:d0d35729ac785d5bc15d50a1d99ea9a2aef565779fadf37235edfc9b30a10e75
           config: ${{ matrix.apkoConfig }}
           tag: ${{ steps.registry-ip.outputs.ip }}:5000/${{ matrix.imageName }}:${{ matrix.apkoTargetTag }}
       - name: Run k8s tests

--- a/.github/workflows/presubmit-k8s-tests.yaml
+++ b/.github/workflows/presubmit-k8s-tests.yaml
@@ -42,6 +42,7 @@ jobs:
           echo "ip=$(docker inspect registry.local | jq -r '.[0].NetworkSettings.Networks["bridge"].IPAddress')" >> $GITHUB_OUTPUT
       - uses: chainguard-images/actions/apko-publish@main
         with:
+          apko-image: ghcr.io/wolfi-dev/apko:latest@sha256:d0d35729ac785d5bc15d50a1d99ea9a2aef565779fadf37235edfc9b30a10e75
           config: ${{ matrix.apkoConfig }}
           tag: ${{ steps.registry-ip.outputs.ip }}:5000/${{ matrix.imageName }}:${{ matrix.apkoTargetTag }}
       - name: Run k8s tests


### PR DESCRIPTION
:gift: This change adds a digestabot workflow to update digests daily, and pins several image names to digests in support of this.

This is WIP until https://github.com/chainguard-images/actions/pull/102 merges and I update the workflows to point to their source of truth

/kind feature
