### PR TITLE
update presubmt job to aggregate the result and be able to have one required check

### DIFF
--- a/.github/workflows/presubmit-build-melange.yaml
+++ b/.github/workflows/presubmit-build-melange.yaml
@@ -3,7 +3,8 @@ on:
   pull_request:
     branches:
       - main
-    types: [labeled]
+    types:
+      - labeled
 jobs:
   presubmit-matrix-melange:
     if: contains(github.event.pull_request.labels.*.name, 'melange')
@@ -11,16 +12,17 @@ jobs:
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - id: files
-      uses: tj-actions/changed-files@b2d17f51244a144849c6b37a3a6791b98a51d86f # v35.9.2
-      with:
-        separator: ','
-    - id: generate-matrix
-      uses: ./.github/actions/generate-matrix
-      with:
-        modified-files: ${{ steps.files.outputs.all_changed_files }}
-        melange-mode: only
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - id: files
+        uses: tj-actions/changed-files@b2d17f51244a144849c6b37a3a6791b98a51d86f # v35.9.2
+        with:
+          separator: ','
+      - id: generate-matrix
+        uses: ./.github/actions/generate-matrix
+        with:
+          modified-files: ${{ steps.files.outputs.all_changed_files }}
+          melange-mode: only
+
   presubmit-build-melange:
     if: contains(github.event.pull_request.labels.*.name, 'melange')
     runs-on: ubuntu-latest
@@ -32,9 +34,19 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: ./.github/actions/build-image
         with: ${{ matrix }}
+
   presubmit-roundup-melange:
+    needs:
+      - presubmit-build-melange
     runs-on: ubuntu-latest
-    needs: presubmit-build-melange
+    if: always()
     steps:
-      - run: |
-          echo "all matrix jobs completed"
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 0
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 1

--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -6,16 +6,17 @@ jobs:
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - id: files
-      uses: tj-actions/changed-files@b2d17f51244a144849c6b37a3a6791b98a51d86f # v35.9.2
-      with:
-        separator: ','
-    - id: generate-matrix
-      uses: ./.github/actions/generate-matrix
-      with:
-        modified-files: ${{ steps.files.outputs.all_changed_files }}
-        melange-mode: none
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - id: files
+        uses: tj-actions/changed-files@b2d17f51244a144849c6b37a3a6791b98a51d86f # v35.9.2
+        with:
+          separator: ','
+      - id: generate-matrix
+        uses: ./.github/actions/generate-matrix
+        with:
+          modified-files: ${{ steps.files.outputs.all_changed_files }}
+          melange-mode: none
+
   presubmit-build:
     runs-on: ubuntu-latest
     needs: presubmit-matrix
@@ -31,9 +32,19 @@ jobs:
           exit 1
       - uses: ./.github/actions/build-image
         with: ${{ matrix }}
+
   presubmit-roundup:
+    needs:
+      - presubmit-build
     runs-on: ubuntu-latest
-    needs: presubmit-build
+    if: always()
     steps:
-      - run: |
-          echo "all matrix jobs completed"
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 0
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 1

--- a/.github/workflows/presubmit-k8s-tests.yaml
+++ b/.github/workflows/presubmit-k8s-tests.yaml
@@ -2,7 +2,8 @@ on:
   pull_request:
     branches:
       - main
-    types: [labeled]
+    types:
+      - labeled
 jobs:
   presubmit-matrix-k8s:
     if: contains(github.event.pull_request.labels.*.name, 'k8s')
@@ -10,21 +11,23 @@ jobs:
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - id: files
-      uses: tj-actions/changed-files@b2d17f51244a144849c6b37a3a6791b98a51d86f # v35.9.2
-      with:
-        separator: ','
-    - id: generate-matrix
-      uses: ./.github/actions/generate-matrix
-      with:
-        modified-files: ${{ steps.files.outputs.all_changed_files }}
-        melange-mode: none
-        test-tags: k8s
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - id: files
+        uses: tj-actions/changed-files@b2d17f51244a144849c6b37a3a6791b98a51d86f # v35.9.2
+        with:
+          separator: ','
+      - id: generate-matrix
+        uses: ./.github/actions/generate-matrix
+        with:
+          modified-files: ${{ steps.files.outputs.all_changed_files }}
+          melange-mode: none
+          test-tags: k8s
+
   presubmit-build-k8s:
     if: contains(github.event.pull_request.labels.*.name, 'k8s')
     runs-on: ubuntu-latest
-    needs: presubmit-matrix-k8s
+    needs:
+      - presubmit-matrix-k8s
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.presubmit-matrix-k8s.outputs.matrix) }}
@@ -54,9 +57,19 @@ jobs:
           export IMAGE_TAG_SUFFIX="${{ matrix.apkoTargetTagSuffix }}"
           cd "${{ matrix.testCommandDir }}"
           ${{ matrix.testCommandExe }}
-  presubmit-roundup-k8s:
+
+  presubmit-roundup:
+    needs:
+      - presubmit-build-k8s
     runs-on: ubuntu-latest
-    needs: presubmit-build-k8s
+    if: always()
     steps:
-      - run: |
-          echo "all matrix jobs completed"
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 0
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 1

--- a/.github/workflows/presubmit-readme.yaml
+++ b/.github/workflows/presubmit-readme.yaml
@@ -4,7 +4,7 @@ jobs:
   presubmit-readme:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-    - uses: ./.github/actions/verify-readme
-      with:
-        gcsBucketName: chainguard-images-build-outputs
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: ./.github/actions/verify-readme
+        with:
+          gcsBucketName: chainguard-images-build-outputs


### PR DESCRIPTION
- update presubmt job to aggregate the result and be able to have one required check

same changes applied in the other repository and did a small format to match

Fixes: n/a

Related: 

### Pre-review Checklist

<!--
PLEASE REMOVE THE CHECKLIST ITEMS OR THE ENTIRE CHECKLIST IF THEY DON'T APPLY.

This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**

#### For new image PRs only

If you have an apko.yaml file in this PR you need to follow this checklist, otherwise feel free to remove.
- [ ] Image is marked experimental or stable as appropriate
- [ ] The version included is the latest GA version of the software
- [ ] The latest tag points to the newest stable version
- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] The image runs as `nonroot` and GID/UID are set to 65532
  - [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
  - [ ] See above for exceptions to nonroot rule
- [ ] ENTRYPOINT
  - [ ] For applications/servers/utilities call main program with no arguments e.g. [redis-server]
  - [ ] For base images leave empty
  - [ ] For dev variants set to entrypoint script that falls back to system
- [ ] CMD:
  - [ ] For server applications give arguments to start in daemon mode (may be empty)
  - [ ] For utilities/tooling bring up help e.g. `–help`
  - [ ] For base images with a shell, call it e.g. [/bin/sh]
- [ ] Consider where and how the image deviates from popular alternatives. Is there a good reason and is it documented?
- [ ] Add annotations e.g:
```
annotations:
  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/ # use the academy site here
  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bazel # use github here
```
- [ ] Check if environment variables are needed e.g. to set data locations
- [ ] Ensure the image responds to SIGTERM
  - [ ] `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`
- [ ] Documentation. Let's make this excellent. Include usage example.
- [ ] Error logs write to stderr and normal logs to stdout. DO NOT write to file.
- [ ] Include tests, at the very least a basic smoke test.
