### PR TITLE
Update nginx README.md with -p 8080:8080 published port mappings

### DIFF
--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -49,7 +49,7 @@ docker pull cgr.dev/chainguard/nginx:latest
 To try out the image, run:
 
 ```
-docker run -p 8080:80 cgr.dev/chainguard/nginx
+docker run -p 8080:8080 cgr.dev/chainguard/nginx
 ```
 
 If you navigate to `localhost:8080`, you should see the nginx welcome page.
@@ -57,15 +57,15 @@ If you navigate to `localhost:8080`, you should see the nginx welcome page.
 To run an example Hello World app, navigate to the root of this repo and run:
 
 ```
-docker run -v $(pwd)/examples/hello-world/site-content:/var/lib/nginx/html -p 8080:80 cgr.dev/chainguard/nginx
+docker run -v $(pwd)/examples/hello-world/site-content:/var/lib/nginx/html -p 8080:8080 cgr.dev/chainguard/nginx
 ```
 
 If you navigate to `localhost:8080`, you should see `Hello World from Nginx!`.
 
-To use a custom `nginx.conf` you can mount the file into the container
+To use a custom `nginx.conf` you can mount the file into the container, being sure to edit the `-p 8080:8080` published port(s) to match your configuration's `listen` directive:
 
 ```
-docker run -v $(pwd)/$CUSTOM_NGINX_CONF_DIRECTORY/nginx.conf:/etc/nginx/nginx.conf -p 8080:80 cgr.dev/chainguard/nginx
+docker run -v $(pwd)/$CUSTOM_NGINX_CONF_DIRECTORY/nginx.conf:/etc/nginx/nginx.conf -p 8080:8080 cgr.dev/chainguard/nginx
 ```
 
 ## Run in a read-only File System


### PR DESCRIPTION
Related: #452 

This updates the nginx README.md to use `-p 8080:8080` published ports. Running the examples as they are results in errors like this:

```
docker run --rm -d -p 8080:80 cgr.dev/chainguard/nginx:latest && curl -I localhost:8080
a9567dde7c0296bcf5e6581784aeceef1d3d7599c1c482dbb35a5af238adc793
curl: (52) Empty reply from server
```

Whereas with these changes the following works:

```
docker run --rm -d -p 8080:8080 cgr.dev/chainguard/nginx:latest && curl -I localhost:8080
3cd44f2f42948ad0299fd333c29c6fd84877b594f829588d84c1ac838a35472f
HTTP/1.1 200 OK
. . .
```

### Pre-review Checklist

- [X] Documentation. Let's make this excellent. Include usage example.
