### PR TITLE
weaviate: tests: fix invocation of helm chart

### DIFF
--- a/images/weaviate/tests/01-help.sh
+++ b/images/weaviate/tests/01-help.sh
@@ -7,4 +7,4 @@ if [[ "${IMAGE_NAME}" == "" ]]; then
     exit 1
 fi
 
-docker run --rm "${IMAGE_NAME}" --help | grep "Cloud-native, modular vector search engine"
+docker run --rm "${IMAGE_NAME}" --help | grep "Cloud-native, modular vector database"

--- a/images/weaviate/tests/02-install.sh
+++ b/images/weaviate/tests/02-install.sh
@@ -24,9 +24,12 @@ function preflight() {
 preflight
 
 helm repo add weaviate https://weaviate.github.io/weaviate-helm
+wget https://raw.githubusercontent.com/weaviate/weaviate-helm/v16.2.0/weaviate/values.yaml
 
 # The helm chart doesn't allow overriding the full image registry or imagePullPolicy, so we need to do some surgery.
 helm install  my-weaviate weaviate/weaviate \
+    --version 16.2.0 \
+    --values ./values.yaml \
     --set image.repo="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}" --set image.tag="${IMAGE_TAG}" \
     --dry-run | \
     sed  's/imagePullPolicy: Always/imagePullPolicy: Never/g' | \


### PR DESCRIPTION
It was missing a values.yaml file, which among other things, specified the auth module that should be used.