### PR TITLE
secrets-store-csi-driver: add util-linux-misc to make mount available

### DIFF
--- a/images/secrets-store-csi-driver/configs/latest.apko.yaml
+++ b/images/secrets-store-csi-driver/configs/latest.apko.yaml
@@ -7,6 +7,7 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - secrets-store-csi-driver
+    - util-linux-misc
 
 accounts:
   groups:

--- a/images/secrets-store-csi-driver/tests/01-runs.sh
+++ b/images/secrets-store-csi-driver/tests/01-runs.sh
@@ -10,3 +10,6 @@ fi
 # Help exits with 1 for some reason, so disable pipefail
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep secrets-store-csi
+
+# The image must have mount installed.
+docker run --rm --entrypoint mount "${IMAGE_NAME}" --help


### PR DESCRIPTION
As discovered in https://github.com/wolfi-dev/wolfictl/pull/203 this image needs `mount` to be usable.

`mount` is provided by `util-linux-misc`. This PR also adds a test that the image contains `mount` and that it can be called.

`mount` is installed in the upstream image here: https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/45588e2b83698962037c47458922f4451cfcbfe7/docker/Dockerfile#L33