### PR TITLE
Use absolute links in README.md files to fix 404s outside GitHub

### DIFF
--- a/images/deno/README.md
+++ b/images/deno/README.md
@@ -25,7 +25,7 @@ docker pull cgr.dev/chainguard/deno:latest
 
 ## Usage Example
 
-Navigate to the [`example/`](./example/) directory:
+Navigate to the [`example/`](https://github.com/chainguard-images/images/tree/main/images/deno/example) directory:
 
 ```
 cd example/

--- a/images/fluentd/README.md
+++ b/images/fluentd/README.md
@@ -25,7 +25,7 @@ docker pull cgr.dev/chainguard/fluentd
 
 Run a Fluentd instance that will receive messages over TCP port 24224 through the Forward protocol, and send the messages to the STDOUT interface in JSON format
 
-Run the fluentd container and mount the fluent.conf in [examples/](./examples/)
+Run the fluentd container and mount the fluent.conf in [examples/](https://github.com/chainguard-images/images/tree/main/images/fluentd/examples)
 
 ```sh
 docker run --rm -p 127.0.0.1:24224:24224 -v ${PWD}/examples/basic_docker.conf:/etc/fluent/fluent.conf cgr.dev/chainguard/fluentd

--- a/images/gcc-glibc/README.md
+++ b/images/gcc-glibc/README.md
@@ -23,7 +23,7 @@ docker pull cgr.dev/chainguard/gcc-glibc:latest
 
 ## Usage
 
-To build the C application in [examples/hello/main.c](examples/hello/main.c):
+To build the C application in [examples/hello/main.c](https://github.com/chainguard-images/images/blob/main/images/gcc-glibc/examples/hello/main.c):
 
 ```
 $ docker run --rm -v "${PWD}:/work" cgr.dev/chainguard/gcc-glibc examples/hello/main.c -o hello

--- a/images/go/README.md
+++ b/images/go/README.md
@@ -30,7 +30,7 @@ still available at `cgr.dev/chainguard/go:latest-musl`.
 
 ## Host architecture example
 
-To build the Go application in [examples/hello/main.go](examples/hello/main.go)
+To build the Go application in [examples/hello/main.go](https://github.com/chainguard-images/images/blob/main/images/go/examples/hello/main.go)
 using the host architecture:
 
 ```sh


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/edu/issues/651

Related: https://github.com/chainguard-dev/edu/issues/674 - this is the output from the link scanner on academy that found these relative URLs. They work fine on GitHub, but since we embed the README files on Academy, they result in 404s.

### Pre-review Checklist

- [X] Documentation. Let's make this excellent. Include usage example.

