### PR TITLE
explicitly re-add default envs for images that overrode them

### DIFF
--- a/images/apko/examples/wolfi-base.yaml
+++ b/images/apko/examples/wolfi-base.yaml
@@ -6,7 +6,3 @@ contents:
     - wolfi-baselayout
 
 cmd: /bin/sh -l
-  
-# optional environment configuration
-environment:
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/images/bazel/configs/latest.apko.yaml
+++ b/images/bazel/configs/latest.apko.yaml
@@ -27,6 +27,8 @@ entrypoint:
 
 environment:
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 work-dir: /home/bazel
 

--- a/images/deno/configs/latest.apko.yaml
+++ b/images/deno/configs/latest.apko.yaml
@@ -18,9 +18,6 @@ paths:
 
 work-dir: /app
 
-environment:
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin
-
 entrypoint:
   command: /usr/bin/deno
 cmd: --help

--- a/images/etcd/configs/latest.apko.yaml
+++ b/images/etcd/configs/latest.apko.yaml
@@ -26,6 +26,8 @@ paths:
 
 environment:
   ETCD_DATA_DIR: /var/lib/etcd
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/bin/etcd

--- a/images/fluentd/configs/edge.apko.yaml
+++ b/images/fluentd/configs/edge.apko.yaml
@@ -17,6 +17,8 @@ entrypoint:
 environment:
   FLUENTD_CONF: "fluent.conf"
   LD_PRELOAD: ""
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 accounts:
   groups:

--- a/images/fluentd/configs/latest.apko.yaml
+++ b/images/fluentd/configs/latest.apko.yaml
@@ -16,6 +16,8 @@ entrypoint:
 environment:
   FLUENTD_CONF: "fluent.conf"
   LD_PRELOAD: ""
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 accounts:
   groups:

--- a/images/go/configs/latest.apko.yaml
+++ b/images/go/configs/latest.apko.yaml
@@ -24,6 +24,8 @@ accounts:
 
 environment:
   GODEBUG: tarinsecurepath=0,zipinsecurepath=0
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/bin/go

--- a/images/gradle/configs/latest.apko.yaml
+++ b/images/gradle/configs/latest.apko.yaml
@@ -29,6 +29,8 @@ entrypoint:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 paths:
   - path: /home/build

--- a/images/helm-chartmuseum/configs/latest.apko.yaml
+++ b/images/helm-chartmuseum/configs/latest.apko.yaml
@@ -32,6 +32,8 @@ environment:
   DISABLE_STATEFILES: true
   STORAGE: local
   STORAGE_LOCAL_ROOTDIR: /charts
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/bin/chartmuseum

--- a/images/influxdb/configs/latest.apko.yaml
+++ b/images/influxdb/configs/latest.apko.yaml
@@ -27,6 +27,8 @@ environment:
   INFLUXD_INIT_PORT: 9999
   INFLUXD_INIT_PING_ATTEMPTS: 600
   DOCKER_INFLUXDB_INIT_CLI_CONFIG_NAME: default
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 paths:
   - path: /var/lib/influxdb2

--- a/images/jdk/configs/latest.apko.yaml
+++ b/images/jdk/configs/latest.apko.yaml
@@ -26,6 +26,8 @@ work-dir: /home/build
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 paths:
   - path: /home/build

--- a/images/jdk/configs/openjdk-11.apko.yaml
+++ b/images/jdk/configs/openjdk-11.apko.yaml
@@ -26,6 +26,8 @@ work-dir: /home/build
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 paths:
   - path: /home/build

--- a/images/jenkins/configs/latest.apko.yaml
+++ b/images/jenkins/configs/latest.apko.yaml
@@ -33,6 +33,8 @@ environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
   JENKINS_HOME: /var/jenkins_home
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 paths:
   - path: /var/jenkins_home

--- a/images/jre/configs/latest.apko.yaml
+++ b/images/jre/configs/latest.apko.yaml
@@ -27,6 +27,8 @@ entrypoint:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 archs:
   - x86_64

--- a/images/jre/configs/openjdk-11.apko.yaml
+++ b/images/jre/configs/openjdk-11.apko.yaml
@@ -27,6 +27,8 @@ entrypoint:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 archs:
   - x86_64

--- a/images/k8s-sidecar/configs/latest.apko.yaml
+++ b/images/k8s-sidecar/configs/latest.apko.yaml
@@ -11,6 +11,8 @@ contents:
 
 environment:
   PYTHONUNBUFFERED: 1
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/share/app/.venv/bin/python -u /usr/share/app/sidecar.py

--- a/images/maven/configs/latest.apko.yaml
+++ b/images/maven/configs/latest.apko.yaml
@@ -29,6 +29,8 @@ entrypoint:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 paths:
   - path: /home/build

--- a/images/maven/configs/openjdk-11.apko.yaml
+++ b/images/maven/configs/openjdk-11.apko.yaml
@@ -29,6 +29,8 @@ entrypoint:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 paths:
   - path: /home/build

--- a/images/node/configs/19.apko.yaml
+++ b/images/node/configs/19.apko.yaml
@@ -25,8 +25,9 @@ environment:
   # By convention, Node apps look to the NODE_PORT env var to determine what
   # port to listen on. Default to a high port since the user runs as non-root.
   NODE_PORT: 3000
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin
   NPM_CONFIG_UPDATE_NOTIFIER: false # Disables npm update notifications
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/bin/node

--- a/images/node/configs/20.apko.yaml
+++ b/images/node/configs/20.apko.yaml
@@ -25,8 +25,9 @@ environment:
   # By convention, Node apps look to the NODE_PORT env var to determine what
   # port to listen on. Default to a high port since the user runs as non-root.
   NODE_PORT: 3000
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin
   NPM_CONFIG_UPDATE_NOTIFIER: false # Disables npm update notifications
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/bin/node

--- a/images/node/configs/latest.apko.yaml
+++ b/images/node/configs/latest.apko.yaml
@@ -25,8 +25,9 @@ environment:
   # By convention, Node apps look to the NODE_PORT env var to determine what
   # port to listen on. Default to a high port since the user runs as non-root.
   NODE_PORT: 3000
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin
   NPM_CONFIG_UPDATE_NOTIFIER: false # Disables npm update notifications
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/bin/node

--- a/images/opensearch/configs/latest.apko.yaml
+++ b/images/opensearch/configs/latest.apko.yaml
@@ -21,6 +21,8 @@ accounts:
 
 environment:
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 entrypoint:
   command: /usr/bin/docker-entrypoint.sh

--- a/images/php/configs/latest.apko.yaml
+++ b/images/php/configs/latest.apko.yaml
@@ -12,9 +12,6 @@ contents:
 entrypoint:
   command: /bin/php
 
-environment:
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin
-
 paths:
   - path: /app
     type: directory

--- a/images/postgres/configs/latest.apko.yaml
+++ b/images/postgres/configs/latest.apko.yaml
@@ -31,6 +31,8 @@ environment:
   PGDATA: /var/lib/postgresql/data
   # Postgres defers to locale and docker-library/postgres sets UTF-8 as default.
   LANG: en_US.UTF-8
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 work-dir: /home/postgres
 

--- a/images/pulumi/configs/latest.apko.yaml
+++ b/images/pulumi/configs/latest.apko.yaml
@@ -53,9 +53,6 @@ accounts:
       uid: 65532
   run-as: 65532
 
-environment:
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin
-
 entrypoint:
   command: /usr/bin/pulumi
 cmd: -h

--- a/images/rabbitmq/configs/latest.apko.yaml
+++ b/images/rabbitmq/configs/latest.apko.yaml
@@ -57,6 +57,7 @@ environment:
   HOME: /var/lib/rabbitmq
   LANG: en_US.UTF-8
   PATH: /usr/sbin:/sbin:/usr/bin:/bin:/usr/lib/rabbitmq/bin/
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 # By convention, the official Docker node image defines a `node` user, but
 # doesn't run as it unless the image based on it specifies that user.

--- a/images/skaffold/configs/latest.apko.yaml
+++ b/images/skaffold/configs/latest.apko.yaml
@@ -20,9 +20,6 @@ paths:
 
 work-dir: /app
 
-environment:
-  PATH: /usr/sbin:/sbin:/usr/bin:/bin
-
 entrypoint:
   command: /usr/bin/skaffold
 cmd: --help

--- a/images/zookeeper/configs/latest.apko.yaml
+++ b/images/zookeeper/configs/latest.apko.yaml
@@ -36,6 +36,8 @@ paths:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/openjdk
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
 
 archs:
   - x86_64


### PR DESCRIPTION
⚠️ Please review this carefully ⚠️ 

This was an action item from the `PATH` change post-mortem from a couple weeks ago.

`apko` sets default environment variables when the config doesn't specify any. Specifically, it sets:

- `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`
- `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`

([here](https://github.com/chainguard-dev/apko/blob/87f7f0ff54fab41ca6dd580343487310e8e25d94/pkg/build/oci/oci.go#L204-L209))

Crucially, it only sets these when the apko config YAML doesn't specify any envs -- if it specifies any envs, those default envs are not added.

This means that, for example, `go`'s apko.yaml setting `GODEBUG` by default, also _unsets_ `PATH` and `SSL_CERT_FILE`. Presumably this behavior is not catastrophic, since we haven't heard any complaints about this difference between the 1.19 and 1.20 images. But, it's still surprising, and _could_ break someone coming from an image that has no env var set, where they get the implicit default, to an image that has another unrelated env var set, where the implicit defaults are missing.

Note also that rabbitmq has a different `PATH` than this default, so its value should be retained, and not reverted to apko's implicit default.

Some configs specified `PATH` that was just a subset of the implicit path, and I believe these should be avoided -- the default `PATH` is more consistent and less surprising. _Please speak up if you believe some images should have different `PATH`s that are a subset of the default._

In general we might want to be totally explicit about the envs in all configs, enforced by linting. We may also want to stage this change out, though none of the images affected by this change are in the "high profile" category (static, busybox, git, wolfi-base). We may even want to warn about `apko`'s implicit env behavior, and eventually remove it -- this may be a surprising breaking change for `apko` users.

I'm going to mark this PR as draft until I've gotten approvals from all of @amdawson @amouat @patflynn @kaniini 