### PR TITLE
Create alternate actions path for tf-apko, opt-in ko

### DIFF
--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -1,4 +1,4 @@
-name: release-image
+name: release-image-terraform
 inputs:
   slackWebhookUrl:
     default: ''
@@ -135,26 +135,111 @@ runs:
         yq -M '{"options": .}' tmp.yaml >> "${{ inputs.apkoConfig }}"
         rm -f tmp.yaml
 
-    # Build and push
-    - id: apko
-      uses: chainguard-images/actions/apko-snapshot@main
+    # Needed in step below to login to registry (if cgr.dev), and also for SLSA attestation
+    - name: Setup cosign
+      uses: sigstore/cosign-installer@v3
+
+    # Create docker config for use by rumble
+    - id: rumble-docker-config
+      shell: bash
+      run: |
+        REGISTRY_HOSTNAME="$(echo ${{ inputs.apkoBaseTag }} | cut -d / -f 1)"
+        export DOCKER_CONFIG="${PWD}/.docker-rumble"
+        mkdir -p "${DOCKER_CONFIG}"
+        echo '{}' > "${DOCKER_CONFIG}/config.json"
+        if [[ "${REGISTRY_HOSTNAME}" == "cgr.dev" ]]; then
+          CRED_HELPER_GET_RESPONSE="$(echo "cgr.dev" | docker-credential-cgr get)"
+          echo "$(echo "${CRED_HELPER_GET_RESPONSE}" | jq -r .Secret)" | \
+            cosign login -u "$(echo "${CRED_HELPER_GET_RESPONSE}" | jq -r .Username)" --password-stdin "cgr.dev"
+        elif [[ "${REGISTRY_HOSTNAME}" == *"gcr.io" || "${REGISTRY_HOSTNAME}" == *"pkg.dev" ]]; then
+          gcloud auth print-access-token | \
+            docker login -u oauth2accesstoken --password-stdin "https://${REGISTRY_HOSTNAME}"
+        else
+          echo "${{ github.token }}" | \
+            docker login -u "${{ github.repository_owner }}" --password-stdin "https://ghcr.io"
+        fi
+
+    - name: Setup Terrafrom
+      id: setup-terraform
+      uses: hashicorp/setup-terraform@v2
       with:
-        apko-image: ${{ inputs.apkoImage }}
-        config: ${{ inputs.apkoConfig }}
-        base-tag: ${{ inputs.apkoBaseTag }}
-        target-tag: ${{ inputs.apkoTargetTag }}
-        keyring-append: ${{ inputs.apkoKeyringAppend }}
-        repository-append: ${{ inputs.apkoRepositoryAppend }}
-        additional-tags: ${{ inputs.apkoAdditionalTags }}
-        package-version-tag: ${{ inputs.apkoPackageVersionTag }}
-        package-version-tag-stem: true
-        package-version-tag-prefix: ${{ inputs.apkoPackageVersionTagPrefix }}
-        stage_tags: apko.tags
-        build-options: ${{ inputs.apkoBuildOptions }}
-        sbom-attest: true
-        slsa-attest: ${{ inputs.slsaProvenanceCacheKey != '' }}
-        generic-user: ${{ steps.cgrauth2.outputs.username }}
-        generic-pass: ${{ steps.cgrauth2.outputs.password }}
+        terraform_version: '1.3.*'
+        terraform_wrapper: false
+
+    - name: Terraform apply (apko publish)
+      id: terraform-apply
+      shell: bash
+      env:
+        TF_VAR_apko_config_path: ${{ inputs.apkoConfig }}
+        TF_VAR_target_repository: ${{ inputs.apkoBaseTag }}
+        TF_VAR_extract_package: ${{ inputs.apkoPackageVersionTag }}
+        TF_VAR_build_options: ${{ inputs.apkoBuildOptions }}
+        DOCKER_CONFIG: .docker-rumble
+      run: |
+        set -x
+        env | grep '^TF_VAR_'
+        terraform init
+        terraform apply -auto-approve
+
+    # Needed in step below to process arch-specific manifest digests etc.
+    - name: Setup crane
+      id: setup-crane
+      uses: imjasonh/setup-crane@v0.3
+
+    - name: Process Terraform outputs
+      id: apko
+      shell: bash
+      env:
+        DOCKER_CONFIG: .docker-rumble
+      run: |
+        set -x
+
+        # Extra stuff related to output etc. used in remainder of pipeline
+        digest="$(terraform output --raw image_ref)"
+        output="digest-index=${digest}"
+        echo "Adding GitHub step output: ${output}"
+        echo "${output}" >> $GITHUB_OUTPUT
+        output="shortdigest-index=$(echo "${digest}" | cut -d@ -f 2)"
+        echo "Adding GitHub step output: ${output}"
+        echo "${output}" >> $GITHUB_OUTPUT
+
+        # If its an index, extract the platform digests too
+        CRANE_MANIFEST_OUTPUT="$(crane manifest ${digest})"
+        if [[ "$(echo $CRANE_MANIFEST_OUTPUT | jq -r .mediaType)" == "application/vnd.oci.image.index.v1+json" ]]; then
+          for combo in `echo $CRANE_MANIFEST_OUTPUT | jq -r '.manifests[] | .platform.architecture + .platform.variant + "_" + .digest'`; do
+            arch="$(echo "${combo}" | cut -d "_" -f1)"
+            digest="$(echo "${combo}" | cut -d "_" -f2)"
+            output="digest-${arch}=${{ inputs.apkoBaseTag }}@${digest}"
+            echo "Adding GitHub step output: ${output}"
+            echo "${output}" >> $GITHUB_OUTPUT
+            output="shortdigest-${arch}=${digest}"
+            echo "Adding GitHub step output: ${output}"
+            echo "${output}" >> $GITHUB_OUTPUT
+          done
+        fi
+
+    # The apko.tags file is needed in tagging below after all attestations and tests pass etc.
+    - name: Create apko.tags file
+      id: create-apko-tags
+      shell: bash
+      env:
+        DOCKER_CONFIG: .docker-rumble
+      run: |
+        set -x
+
+        # Add the primary tag (e.g. "latest") and the timestamped tag (e.g. "latest-20230512")
+        echo "${{ inputs.apkoBaseTag }}:${{ inputs.apkoTargetTag }}" > apko.tags
+        echo "${{ inputs.apkoBaseTag }}:${{ inputs.apkoTargetTag }}-$(date -u +%Y%m%d)" >> apko.tags
+
+        package_version_json="$(terraform output --json package_version)"
+        echo "Package version JSON: ${package_version_json}"
+        for v in $(echo "${package_version_json}" | jq -r '.[]'); do
+          tag="${v}${{ inputs.apkoTargetTagSuffix }}"
+          echo "${{ inputs.apkoBaseTag }}:${tag}" >> apko.tags
+        done
+
+        echo "Contents of apko.tags:"
+        cat apko.tags
 
     # SLSA attestation
     # Originally found in apko-snapshot action
@@ -166,8 +251,7 @@ runs:
       with:
         path: ./provenance.json
         key: ${{ inputs.slsaProvenanceCacheKey }}
-
-    - name: Attest SLSA provenance
+    - name: 'SLSA: Generate provenance and attest'
       if: inputs.slsaProvenanceCacheKey != ''
       shell: bash
       env:
@@ -214,26 +298,6 @@ runs:
         export IMAGE_TAG_SUFFIX="${{ inputs.apkoTargetTagSuffix }}"
         cd "${{ inputs.testCommandDir }}"
         ${{ inputs.testCommandExe }}
-
-    # Create docker config for use by rumble
-    - id: rumble-docker-config
-      shell: bash
-      run: |
-        REGISTRY_HOSTNAME="$(echo ${{ inputs.apkoBaseTag }} | cut -d / -f 1)"
-        export DOCKER_CONFIG="${PWD}/.docker-rumble"
-        mkdir -p "${DOCKER_CONFIG}"
-        echo '{}' > "${DOCKER_CONFIG}/config.json"
-        if [[ "${REGISTRY_HOSTNAME}" == "cgr.dev" ]]; then
-          CRED_HELPER_GET_RESPONSE="$(echo "cgr.dev" | docker-credential-cgr get)"
-          echo "$(echo "${CRED_HELPER_GET_RESPONSE}" | jq -r .Secret)" | \
-            cosign login -u "$(echo "${CRED_HELPER_GET_RESPONSE}" | jq -r .Username)" --password-stdin "cgr.dev"
-        elif [[ "${REGISTRY_HOSTNAME}" == *"gcr.io" || "${REGISTRY_HOSTNAME}" == *"pkg.dev" ]]; then
-          gcloud auth print-access-token | \
-            docker login -u oauth2accesstoken --password-stdin "https://${REGISTRY_HOSTNAME}"
-        else
-          echo "${{ github.token }}" | \
-            docker login -u "${{ github.repository_owner }}" --password-stdin "https://ghcr.io"
-        fi
 
     # Scan - first index, then amd64, then arm64, then others
     # TODO: improve this - make a single action that runs multiple, or run in matrix at top level
@@ -380,11 +444,6 @@ runs:
             fi
           done
           if [[ "${skip}" == "0" ]]; then
-            # Do not add suffix to target tag or target tag + date
-            # (these aleady have suffix, e.g. "1.19-dev" or "1.19-dev-20230315")
-            if ! [[ "${tag}" == "${{ inputs.apkoBaseTag }}:${{ inputs.apkoTargetTag }}" || "${tag}" =~ ^"${{ inputs.apkoBaseTag }}:${{ inputs.apkoTargetTag }}"-[0-9]{8}$ ]]; then
-              tag="${tag}${{ inputs.apkoTargetTagSuffix }}"
-            fi
             crane cp "${REF}" "${tag}"
             # Mirror image to alternate destination
             if [[ "${{ inputs.mirror }}" != "" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,9 +53,55 @@ jobs:
         [[ "$(cat matrix-unique-images.json)" != "" ]] || echo '${{ steps.generate-matrix-schedule.outputs.matrix-unique-images }}' > matrix-unique-images.json
         [[ "$(cat matrix-unique-images.json)" != "" ]] || echo '${{ steps.generate-matrix-main.outputs.matrix-unique-images }}' > matrix-unique-images.json
         echo "matrix-unique-images=$(cat matrix-unique-images.json)" >> $GITHUB_OUTPUT
+
+  # Originally found in apko-snapshot action
+  generate-slsa-provenance:
+    runs-on: ubuntu-latest
+    outputs:
+      slsa-provenance-cache-key: ${{ steps.generate-slsa-provenance.outputs.slsa-provenance-cache-key }}
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+      actions: read
+    steps:
+      - name: Generate SLSA provenance
+        id: generate-slsa-provenance
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+          GENERATOR_REPOSITORY: slsa-framework/slsa-github-generator
+          GENERATOR_RELEASE_TAG: v1.5.0
+          GENERATOR_RELEASE_BINARY: slsa-generator-container-linux-amd64
+          GENERATOR_RELEASE_BINARY_SHA256: 6d8b83327ac2134aa8760e1e4f9cd5d3fdbcb56599e39be2cd965f1e04aa8ede
+          GH_TOKEN: "${{ github.token }}"
+          GITHUB_CONTEXT: "${{ toJSON(github) }}" # Needed by slsa-generator-container
+        run: |
+          set -x
+          # Fetch the generator
+          gh release -R "${GENERATOR_REPOSITORY}" download "${GENERATOR_RELEASE_TAG}" -p "${GENERATOR_RELEASE_BINARY}"
+          COMPUTED_HASH="$(sha256sum "${GENERATOR_RELEASE_BINARY}" | awk '{print $1}')"
+          if [[ "${COMPUTED_HASH}" != "${GENERATOR_RELEASE_BINARY_SHA256}" ]]; then
+            echo "Mismatched checksums (wanted ${GENERATOR_RELEASE_BINARY_SHA256} got ${COMPUTED_HASH}). Exiting."
+            exit 1
+          fi
+          chmod +x "${GENERATOR_RELEASE_BINARY}"
+
+          # Create the provenance document
+          echo "Generating SLSA build provenance ..."
+          "./${GENERATOR_RELEASE_BINARY}" generate --predicate="provenance.json"
+          echo "Provenance doc:"
+          cat provenance.json | jq
+          echo "slsa-provenance-cache-key=slsa-${{ github.run_id }}-$(date +%s)" >> $GITHUB_OUTPUT
+      - id: cache-slsa-provenance-doc
+        name: Cache the SLSA Provenance doc to be used in matrix legs
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ./provenance.json
+          key: "${{ steps.generate-slsa-provenance.outputs.slsa-provenance-cache-key }}"
+
   build:
     runs-on: ubuntu-latest
-    needs: generate-matrix
+    needs: [generate-matrix, generate-slsa-provenance]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
@@ -79,6 +125,7 @@ jobs:
           # https://github.com/chainguard-dev/mono/blob/main/env/chainguard-images/iac/images-pusher.tf
           EXTRA_INPUT_CHAINGUARD_IDENTITY: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
           EXTRA_INPUT_APKO_IMAGE: ghcr.io/wolfi-dev/apko:latest@sha256:d0d35729ac785d5bc15d50a1d99ea9a2aef565779fadf37235edfc9b30a10e75
+          EXTRA_INPUT_SLSA_PROVENANCE_CACHE_KEY: ${{ needs.generate-slsa-provenance.outputs.slsa-provenance-cache-key }}
         run: |
           # convert env vars beginning with "EXTRA_INPUT_"
           # to camelcased input variables passed to next step
@@ -91,7 +138,11 @@ jobs:
             mv inputs.json.tmp inputs.json
           done
           echo "release-image-inputs=$(cat inputs.json | tr -d '\n')" >> $GITHUB_OUTPUT
+      - uses: ./.github/actions/release-image-terraform
+        if: ${{ matrix.useTerraform }}
+        with: ${{ fromJSON(steps.release-image-inputs.outputs.release-image-inputs) }}
       - uses: ./.github/actions/release-image
+        if: ${{ ! matrix.useTerraform }}
         with: ${{ fromJSON(steps.release-image-inputs.outputs.release-image-inputs) }}
       - uses: ./.github/actions/policy-check-image
         with: ${{ fromJSON(steps.release-image-inputs.outputs.release-image-inputs) }}
@@ -99,7 +150,7 @@ jobs:
   image-summary:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [generate-matrix, build]
+    needs: [generate-matrix, generate-slsa-provenance, build]
     if: always()
     strategy:
       fail-fast: false

--- a/images/ko/image.yaml
+++ b/images/ko/image.yaml
@@ -1,3 +1,6 @@
+# Opt-in to the new terraform-based release
+terraform: true
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+terraform {
+  required_providers {
+    apko = {
+      source = "chainguard-dev/apko"
+    }
+    cosign = {
+      source = "chainguard-dev/cosign"
+    }
+    oci = {
+      source = "chainguard-dev/oci"
+    }
+  }
+}
+
+variable "apko_config_path" {
+  description = "The path to the apko image config file."
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "extract_package" {
+  description = "TODO."
+}
+
+provider "apko" {
+  extra_repositories = []
+  extra_keyring      = []
+  default_archs      = []
+  extra_packages     = []
+}
+
+module "image" {
+  source  = "chainguard-dev/apko/publisher"
+
+  target_repository = var.target_repository
+  config = file(var.apko_config_path)
+}
+
+output "image_ref" {
+  value = module.image.image_ref
+}
+
+output "package_version" {
+  value = [
+    for x in module.image.config.contents.packages : regexall("(((([a-z0-9]+)(?:[.][a-z0-9]+)?)(?:[.][a-z0-9]+)?)(?:[-][a-z0-9]+)?)", trimprefix(x, "${var.extract_package}=")) if startswith(x, "${var.extract_package}=")
+  ][0][0]
+}

--- a/monopod/pkg/images/images.go
+++ b/monopod/pkg/images/images.go
@@ -36,6 +36,7 @@ type Image struct {
 	TestCommandExe              string `json:"testCommandExe"`
 	TestCommandDir              string `json:"testCommandDir"`
 	ExcludeTags                 string `json:"excludeTags"`
+	UseTerraform                bool   `json:"useTerraform"`
 	ExcludeContact              bool   `json:"-"`
 }
 
@@ -43,6 +44,7 @@ type ImageManifest struct {
 	Ref            string                 `yaml:"ref"`
 	Status         string                 `yaml:"status"`
 	ExcludeContact bool                   `yaml:"excludeContact"`
+	Terraform      bool                   `yaml:"terraform"`
 	Variants       []ImageManifestVariant `yaml:"versions"`
 }
 
@@ -264,6 +266,8 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 				melangeConfig = strings.Join(tmp, ",")
 			}
 
+			useTerraform := m.Terraform
+
 			i := Image{
 				ImageName:                   imageName,
 				ImageStatus:                 imageStatus,
@@ -286,6 +290,7 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 				TestCommandExe:              testCommandExe,
 				TestCommandDir:              testCommandDir,
 				ExcludeTags:                 strings.Join(variant.Apko.ExtractTagsFrom.Exclude, ","),
+				UseTerraform:                useTerraform,
 				ExcludeContact:              imageExcludeContact,
 			}
 			allImages = append(allImages, i)


### PR DESCRIPTION
Also: generate the SLSA provenance ahead of time and cache it to prevent rate limiting

Plz wait to merge - waiting on tf-apko release to fix issue related to x86_64 vs. amd64