### PR TITLE
Cleanup: Move the policy checks to use terraform.

### DIFF
--- a/.github/actions/policy-check-image/action.yml
+++ b/.github/actions/policy-check-image/action.yml
@@ -5,72 +5,26 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Build and image with policy-tester and crane
-      shell: bash
-      run: |
-        trap "rm -rf custom-image.tar custom-image.apko.yaml" EXIT
-
-        cat >./custom-image.apko.yaml <<EOL
-        contents:
-          packages:
-            - ca-certificates-bundle
-            - crane
-            - policy-controller-tester
-        EOL
-
-        docker run --rm -v "${PWD}:/work" \
-          "${{ inputs.apkoImage }}" \
-          build --debug \
-          --arch=amd64 --sbom=false \
-          --repository-append=https://packages.wolfi.dev/os \
-          --keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
-          /work/custom-image.apko.yaml \
-          custom-image:latest \
-          custom-image.tar
-
-        IMAGE_NAME=$(docker load < custom-image.tar | grep "Loaded image" | sed 's/^Loaded image: //')
-
-        cat >/tmp/custom-image <<EOL
-        #!/usr/bin/env bash
-        set -e
-        docker run --rm \
-          -v "${PWD}:/work" -w /work --entrypoint "\$(basename "\$0")" \
-          "${IMAGE_NAME}" \$@
-        EOL
-
-        chmod +x /tmp/custom-image
-        cp /tmp/custom-image /tmp/policy-tester
-        cp /tmp/custom-image /tmp/crane
-
+    - uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: '1.3.*'
+        terraform_wrapper: false
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-    - name: Determine image ref
-      shell: bash
+    - shell: bash
+      working-directory: ./policies
       run: |
         set -x
 
         BASE_TAG="${{ inputs.apkoBaseTag }}"
         REF="${BASE_TAG}:${{ inputs.apkoTargetTag }}"
 
-        # First check the policy against the image index
-        for policy in `find policies -name '*.yaml' | sort`; do
-          echo "Checking image index against ${policy} ..."
-          /tmp/policy-tester \
-            --policy "${policy}" \
-            --image "${REF}"
-        done
-
-        # Next check the policy against each architecture image manifest
-        for combo in `/tmp/crane manifest ${REF} | jq -r '.manifests[] | .platform.architecture + .platform.variant + "_" + .digest'`; do
-          arch="$(echo "${combo}" | cut -d "_" -f1)"
-          digest="$(echo "${combo}" | cut -d "_" -f2)"
-          arch_ref="${BASE_TAG}@${digest}"
-          for policy in `find policies -name '*.yaml' | sort`; do
-            echo "Checking image manifest (${arch}) against ${policy} ..."
-            /tmp/policy-tester \
-              --policy "${policy}" \
-              --image "${arch_ref}"
-          done
-        done
+        export TF_VAR_image_refs=$(cat <<EOF | jq -c -s .
+        "${REF}"
+        $(crane manifest ${REF} | jq '"'${REF}'@" + .manifests[].digest')
+        EOF
+        )
+        terraform init
+        terraform apply -auto-approve
 
     # There is currently no way to obtain the job ID for a single matrix leg, so we have to
     # try to hit the GitHub API and match the job based on the name, then extract the html_url

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ monopod/monopod
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
 
+.terraform*
+terraform.tfstate*
+plan.out*

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,3 +1,12 @@
 This folder contains
 [`ClusterImagePolicy`](https://docs.sigstore.dev/policy-controller/overview/)
 resources which should apply to all Chainguard Images.
+
+You can run these policies over a list of image references with:
+
+```shell
+export TF_VAR_image_refs='["foo", "bar", "baz"]'
+
+terraform init
+terraform apply
+```

--- a/policies/main.tf
+++ b/policies/main.tf
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+terraform {
+  required_providers {
+    cosign = {
+      source = "chainguard-dev/cosign"
+    }
+  }
+}
+
+variable "image_refs" {
+  type = list(string)
+  description = "The image references to verify against our policies."
+}
+
+data "cosign_verify" "is-signed" {
+  for_each = toset(var.image_refs)
+  image    = each.key
+  policy   = file("${path.module}/01-is-signed.yaml")
+}
+
+data "cosign_verify" "has-vuln-att" {
+  for_each = toset(var.image_refs)
+  image    = each.key
+  policy   = file("${path.module}/02-has-vuln-attestation.yaml")
+}
+
+data "cosign_verify" "has-sbom-att" {
+  for_each = toset(var.image_refs)
+  image    = each.key
+  policy   = file("${path.module}/03-has-sbom-attestation.yaml")
+}
+
+data "cosign_verify" "has-slsa-att" {
+  for_each = toset(var.image_refs)
+  image    = each.key
+  policy   = file("${path.module}/04-has-slsa-attestation.yaml")
+}


### PR DESCRIPTION
:broom: This change moves the way we invoke our policy checks to use terraform instead of the policy tester.

For now this simply applies the terraform directly over the manually supplied refs, but the way this is structured the same terraform may be invokes as a module from other terraform in the future.

/kind cleanup

Here is an example where I invoke this manually on the list of digests for `cgr.dev/chainguard/git:latest-glibc`:
```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - chainguard-dev/apko in /Users/mattmoor/go/src/github.com/chainguard-dev/terraform-provider-apko
│  - chainguard/chainguard in /Users/mattmoor/go/src/github.com/chainguard-dev/mono/terraform-provider-chainguard
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.cosign_verify.has-slsa-att["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Reading...
data.cosign_verify.has-slsa-att["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Reading...
data.cosign_verify.has-vuln-att["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Reading...
data.cosign_verify.is-signed["cgr.dev/chainguard/git:latest-glibc"]: Reading...
data.cosign_verify.has-slsa-att["cgr.dev/chainguard/git:latest-glibc"]: Reading...
data.cosign_verify.is-signed["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Reading...
data.cosign_verify.has-sbom-att["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Reading...
data.cosign_verify.is-signed["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Reading...
data.cosign_verify.has-vuln-att["cgr.dev/chainguard/git:latest-glibc"]: Reading...
data.cosign_verify.has-vuln-att["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Reading...
data.cosign_verify.is-signed["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Read complete after 3s [id=cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc]
data.cosign_verify.has-sbom-att["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Reading...
data.cosign_verify.is-signed["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Read complete after 4s [id=cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75]
data.cosign_verify.has-sbom-att["cgr.dev/chainguard/git:latest-glibc"]: Reading...
data.cosign_verify.has-slsa-att["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Read complete after 4s [id=cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc]
data.cosign_verify.has-vuln-att["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Read complete after 5s [id=cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc]
data.cosign_verify.has-sbom-att["cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc"]: Read complete after 5s [id=cgr.dev/chainguard/git:latest-glibc@sha256:74063725f24cbd7617d7b9fa54273f4e6fe2aad49d1bee7b29613647e12338bc]
data.cosign_verify.is-signed["cgr.dev/chainguard/git:latest-glibc"]: Read complete after 5s [id=cgr.dev/chainguard/git@sha256:0bba3b16167ee412d8a62b844d26f65c5d3ea4b1dfc4c675cc6a1af573e792f3]
data.cosign_verify.has-slsa-att["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Read complete after 5s [id=cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75]
data.cosign_verify.has-vuln-att["cgr.dev/chainguard/git:latest-glibc"]: Read complete after 5s [id=cgr.dev/chainguard/git@sha256:0bba3b16167ee412d8a62b844d26f65c5d3ea4b1dfc4c675cc6a1af573e792f3]
data.cosign_verify.has-vuln-att["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Read complete after 5s [id=cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75]
data.cosign_verify.has-slsa-att["cgr.dev/chainguard/git:latest-glibc"]: Read complete after 5s [id=cgr.dev/chainguard/git@sha256:0bba3b16167ee412d8a62b844d26f65c5d3ea4b1dfc4c675cc6a1af573e792f3]
data.cosign_verify.has-sbom-att["cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75"]: Read complete after 3s [id=cgr.dev/chainguard/git:latest-glibc@sha256:4e82796b8147a41f6a13963661a7841923fd4ae2ffa2b1f8506eb445ebf3fd75]
data.cosign_verify.has-sbom-att["cgr.dev/chainguard/git:latest-glibc"]: Read complete after 3s [id=cgr.dev/chainguard/git@sha256:0bba3b16167ee412d8a62b844d26f65c5d3ea4b1dfc4c675cc6a1af573e792f3]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```