### PR TITLE
use new JAVA_HOME path and *-default-jvm for jdk/jre-11

### DIFF
--- a/images/jdk/configs/openjdk-11.apko.yaml
+++ b/images/jdk/configs/openjdk-11.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - glibc-locale-en
     - busybox
     - openjdk-11
+    - openjdk-11-default-jvm
     - libstdc++
 
 accounts:
@@ -25,7 +26,7 @@ work-dir: /home/build
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-11-openjdk
 
 paths:
   - path: /home/build

--- a/images/jre/configs/openjdk-11.apko.yaml
+++ b/images/jre/configs/openjdk-11.apko.yaml
@@ -8,6 +8,7 @@ contents:
     - wolfi-baselayout
     - glibc-locale-en
     - openjdk-11-jre
+    - openjdk-11-default-jvm
     - libstdc++
 
 accounts:
@@ -26,7 +27,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-11-openjdk
 
 archs:
   - x86_64


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Brings 11 up to the new standard installation path for java, and uses the `-default-jvm` package.

Related: https://github.com/wolfi-dev/os/pull/2075