### PR TITLE
Add a step to make the test scripts executable.

### DIFF
--- a/.github/workflows/presubmit-k8s-tests.yaml
+++ b/.github/workflows/presubmit-k8s-tests.yaml
@@ -63,7 +63,7 @@ jobs:
           export NEW_RELIC_LICENSE_KEY="${{ secrets.NEW_RELIC_LICENSE_KEY }}"
 
           cd "${{ matrix.testCommandDir }}"
-          ${{ matrix.testCommandExe }}
+          chmod +x ${{ matrix.testCommandExe }} && ${{ matrix.testCommandExe }}
 
   presubmit-roundup:
     needs:


### PR DESCRIPTION
We forget this a lot and it leads to test failures.
