### PR TITLE
add e2e test for external-dns

### DIFF
--- a/images/external-dns/tests/02-e2e.sh
+++ b/images/external-dns/tests/02-e2e.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+# monopod:tag:k8s
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+set +t
+
+function preflight() {
+	if [[ "${IMAGE_REGISTRY}" == "" ]]; then
+		echo "Must set IMAGE_REGISTRY environment variable. Exiting."
+		exit 1
+	fi
+
+	if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
+		echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
+		exit 1
+	fi
+
+	if [[ "${IMAGE_TAG}" == "" ]]; then
+		echo "Must set IMAGE_TAG environment variable. Exiting."
+		exit 1
+	fi
+}
+
+preflight
+
+# Install a dev etcd
+set +u
+cat >etcd.yaml <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-client
+spec:
+  type: ClusterIP
+  ports:
+  - name: etcd-client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  selector:
+    app.kubernetes.io/name: etcd
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+spec:
+  clusterIP: None
+  ports:
+  - port: 2379
+    name: client
+  - port: 2380
+    name: peer
+  selector:
+    app.kubernetes.io/name: etcd
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: etcd
+  labels:
+    app.kubernetes.io/name: etcd
+spec:
+  serviceName: etcd
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: etcd
+  template:
+    metadata:
+      name: etcd
+      labels:
+        app.kubernetes.io/name: etcd
+    spec:
+      containers:
+      - name: etcd
+        image: quay.io/coreos/etcd:v3.4.2
+        ports:
+        - containerPort: 2379
+          name: client
+        - containerPort: 2380
+          name: peer
+        volumeMounts:
+        - name: data
+          mountPath: /var/run/etcd
+        command:
+          - /bin/sh
+          - -c
+          - |
+            PEERS="etcd-0=http://etcd-0.etcd:2380"
+            exec etcd --name \$$HOSTNAME \
+              --listen-peer-urls http://0.0.0.0:2380 \
+              --listen-client-urls http://0.0.0.0:2379 \
+              --advertise-client-urls http://\$$HOSTNAME.etcd:2379 \
+              --initial-advertise-peer-urls http://\$$HOSTNAME:2380 \
+              --initial-cluster-token etcd-cluster-1 \
+              --initial-cluster \$$PEERS \
+              --initial-cluster-state new \
+              --data-dir /var/run/etcd/default.etcd
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      storageClassName: standard
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Mi
+EOF
+set -u
+
+kubectl apply -f etcd.yaml
+
+etcd_ip=$(kubectl get svc etcd-client -ojsonpath='{.spec.clusterIP}')
+
+# Install CoreDNS
+cat >coredns-values.yaml <<EOF
+isClusterService: false
+servers:
+- zones:
+  - zone: .
+  port: 53
+  plugins:
+  - name: errors
+  - name: health
+	configBlock: |-
+	  lameduck 5s
+  - name: ready
+  - name: kubernetes
+    parameters: cluster.local in-addr.arpa ip6.arpa
+    configBlock: |-
+      pods insecure
+      fallthrough in-addr.arpa ip6.arpa
+      ttl 30
+  - name: etcd
+	parameters: example.org
+	configBlock: |-
+	  stubzones
+	  path /skydns
+	  endpoint http://${etcd_ip}:2379
+  - name: forward
+    parameters: . /etc/resolv.conf
+  - name: reload
+  - name: loadbalance
+EOF
+helm repo add coredns https://coredns.github.io/helm
+helm install coredns coredns/coredns -f coredns-values.yaml
+
+# Install External DNS
+cat >external-dns-values.yaml <<EOF
+provider: coredns
+logLevel: debug
+env:
+- name: ETCD_URLS
+  value: http://${etcd_ip}:2379
+EOF
+helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
+helm install edns external-dns/external-dns -f external-dns-values.yaml
+
+sleep 10
+
+kubectl get ingressclass
+
+domain="foo.example.org"
+
+# apply the ingress
+cat >ingress.yaml <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dummy
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: ${domain}
+    http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: test
+            port:
+              number: 80
+EOF
+kubectl apply -f ingress.yaml
+
+# TODO: This sucks, but edns doesn't always forward the ingress request fast enough
+sleep 20
+
+ing_ip=$(kubectl get dummy -ojsonpath='{.status.loadBalancer.ingress[0].ip}')
+kubectl port-forward svc/coredns-coredns 5353:53 &
+
+max_attempts=10
+attempt=0
+while [[ $attempt -lt $max_attempts ]]; do
+	output=$(dig +short -p 5353 +tcp @localhost "$domain" A)
+
+	if [[ -n "$output" ]]; then
+		echo "A record found: $output"
+		break
+	fi
+
+	echo "Attempt $((attempt + 1)): No A record found yet"
+	((attempt++))
+	sleep 1
+done
+
+if [[ $attempt -ge $max_attempts ]]; then
+	echo "Maximum number of attempts reached. Unable to find A record for $domain"
+	exit 1
+fi
+
+digged=$(dig +short -p 5353 +tcp @localhost "$domain" A)
+[[ "$digged" == "$ing_ip" ]] || exit 1

--- a/images/kubernetes-csi-external-provisioner/tests/02-deploy.sh
+++ b/images/kubernetes-csi-external-provisioner/tests/02-deploy.sh
@@ -5,34 +5,34 @@
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 function preflight() {
-  if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-    echo "Must set IMAGE_REGISTRY environment variable. Exiting."
-    exit 1
-  fi
+	if [[ "${IMAGE_REGISTRY}" == "" ]]; then
+		echo "Must set IMAGE_REGISTRY environment variable. Exiting."
+		exit 1
+	fi
 
-  if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-    echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-    exit 1
-  fi
+	if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
+		echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
+		exit 1
+	fi
 
-  if [[ "${IMAGE_TAG}" == "" ]]; then
-    echo "Must set IMAGE_TAG environment variable. Exiting."
-    exit 1
-  fi
+	if [[ "${IMAGE_TAG}" == "" ]]; then
+		echo "Must set IMAGE_TAG environment variable. Exiting."
+		exit 1
+	fi
 }
 
 preflight
 
 function cleanup() {
-    # Print debug logs and status
-    kubectl get pods
-    kubectl describe pods
-    
-    # Seeing intermittent failures if we don't wait for a bit here
-    # The `rollout status`` below should wait for terminated pods to be removed
-    # However, we still occasionally see a terminating pod which fails when checking logs
-    sleep 10 
-    kubectl logs --selector app=csi-provisioner
+	# Print debug logs and status
+	kubectl get pods
+	kubectl describe pods
+
+	# Seeing intermittent failures if we don't wait for a bit here
+	# The `rollout status`` below should wait for terminated pods to be removed
+	# However, we still occasionally see a terminating pod which fails when checking logs
+	sleep 10
+	kubectl logs --selector app=csi-provisioner
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes:

Related: 

### Pre-review Checklist

<!--
PLEASE REMOVE THE CHECKLIST ITEMS OR THE ENTIRE CHECKLIST IF THEY DON'T APPLY.

This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**

#### For new image PRs only

If you have an apko.yaml file in this PR you need to follow this checklist, otherwise feel free to remove.
- [ ] Include tests, sufficient enough that you would trust this image running in production.
- [ ] The version included is the latest GA version of the software
- [ ] The latest tag points to the newest stable version
- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] The image runs as `nonroot` and GID/UID are set to 65532
  - [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] ENTRYPOINT
  - [ ] For applications/servers/utilities call main program with no arguments e.g. [redis-server]
  - [ ] For base images leave empty
  - [ ] For dev variants set to entrypoint script that falls back to system
- [ ] CMD:
  - [ ] For server applications give arguments to start in daemon mode (may be empty)
  - [ ] For utilities/tooling bring up help e.g. `–help`
  - [ ] For base images with a shell, call it e.g. [/bin/sh]
- [ ] Consider where and how the image deviates from popular alternatives. Is there a good reason and is it documented?
- [ ] Add annotations e.g:
```
annotations:
  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/ # use the academy site here
  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bazel # use github here
```
- [ ] Check if environment variables are needed e.g. to set data locations
- [ ] Ensure the image responds to SIGTERM
  - [ ] `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`
- [ ] Documentation. Let's make this excellent. Include usage example.
- [ ] Error logs write to stderr and normal logs to stdout. DO NOT write to file.
