### PR TITLE
fix csi-attacher, csi-resizer, vpa, metrics-server tests

### DIFF
--- a/images/external-attacher/tests/02-deploy.sh
+++ b/images/external-attacher/tests/02-deploy.sh
@@ -26,7 +26,7 @@ function TEST_basic_kubectl_apply() {
   tmpdir=$(mktemp -d); cd "${tmpdir}"
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/deployment.yaml
 
-  sed -i "s|gcr.io/k8s-staging-sig-storage/csi-attacher:canary|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}|g" deployment.yaml
+  sed -i "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:canary|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}|g" deployment.yaml
 
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/rbac.yaml
   

--- a/images/external-resizer/tests/02-deploy.sh
+++ b/images/external-resizer/tests/02-deploy.sh
@@ -26,7 +26,7 @@ function TEST_basic_kubectl_apply() {
   tmpdir=$(mktemp -d); cd "${tmpdir}"
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/deploy/kubernetes/deployment.yaml
 
-  sed -i "s|gcr.io/k8s-staging-sig-storage/csi-resizer:canary|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}|g" deployment.yaml
+  sed -i "s|gcr.io/k8s-staging-sig-storage/csi-resizer:canary|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}|g" deployment.yaml
 
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/deploy/kubernetes/rbac.yaml
   

--- a/images/metrics-server/tests/02-helm.sh
+++ b/images/metrics-server/tests/02-helm.sh
@@ -28,7 +28,8 @@ helm upgrade --install metrics-server metrics-server/metrics-server \
 	--namespace metrics-server \
 	--create-namespace \
 	--set image.repository="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}" \
-	--set image.tag="${IMAGE_TAG}"
+	--set image.tag="${IMAGE_TAG}" \
+	--set "args[0]=--kubelet-insecure-tls"
 
 sleep 3
 

--- a/images/vertical-pod-autoscaler-admission-controller/tests/02-helm.sh
+++ b/images/vertical-pod-autoscaler-admission-controller/tests/02-helm.sh
@@ -35,13 +35,13 @@ helm upgrade --install vpa cowboysysop/vertical-pod-autoscaler \
 	--set admissionController.image.registry="${IMAGE_REGISTRY}" \
 	--set admissionController.image.repository="${IMAGE_REPOSITORY}" \
 	--set admissionController.image.tag="${IMAGE_TAG}" \
-	--set recommender.image.registry="${IMAGE_REGISTRY}" \
+	--set recommender.image.registry=cgr.dev \
 	--set recommender.image.repository=chainguard/vertical-pod-autoscaler-recommender \
 	--set recommender.image.tag=latest \
-	--set updater.image.registry="${IMAGE_REGISTRY}" \
+	--set updater.image.registry=cgr.dev \
 	--set updater.image.repository=chainguard/vertical-pod-autoscaler-updater \
 	--set updater.image.tag=latest \
-	--set crds.image.registry="${IMAGE_REGISTRY}" \
+	--set crds.image.registry=cgr.dev \
 	--set crds.image.repository=chainguard/kubectl \
 	--set crds.image.tag=latest
 


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com><!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes:

Related: 

### Pre-review Checklist

<!--
PLEASE REMOVE THE CHECKLIST ITEMS OR THE ENTIRE CHECKLIST IF THEY DON'T APPLY.

This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**

#### For new image PRs only

If you have an apko.yaml file in this PR you need to follow this checklist, otherwise feel free to remove.
- [ ] Include tests, sufficient enough that you would trust this image running in production.
- [ ] The version included is the latest GA version of the software
- [ ] The latest tag points to the newest stable version
- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] The image runs as `nonroot` and GID/UID are set to 65532
  - [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] ENTRYPOINT
  - [ ] For applications/servers/utilities call main program with no arguments e.g. [redis-server]
  - [ ] For base images leave empty
  - [ ] For dev variants set to entrypoint script that falls back to system
- [ ] CMD:
  - [ ] For server applications give arguments to start in daemon mode (may be empty)
  - [ ] For utilities/tooling bring up help e.g. `–help`
  - [ ] For base images with a shell, call it e.g. [/bin/sh]
- [ ] Consider where and how the image deviates from popular alternatives. Is there a good reason and is it documented?
- [ ] Add annotations e.g:
```
annotations:
  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/ # use the academy site here
  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bazel # use github here
```
- [ ] Check if environment variables are needed e.g. to set data locations
- [ ] Ensure the image responds to SIGTERM
  - [ ] `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`
- [ ] Documentation. Let's make this excellent. Include usage example.
- [ ] Error logs write to stderr and normal logs to stdout. DO NOT write to file.
