### PR TITLE
Fix regex in test to capture any version string (it previously used t…

### DIFF
--- a/images/external-attacher/tests/02-deploy.sh
+++ b/images/external-attacher/tests/02-deploy.sh
@@ -26,7 +26,7 @@ function TEST_basic_kubectl_apply() {
   tmpdir=$(mktemp -d); cd "${tmpdir}"
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/deployment.yaml
 
-  sed -i "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:canary|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}|g" deployment.yaml
+  sed -i "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:.*|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}|g" deployment.yaml
 
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/rbac.yaml
   


### PR DESCRIPTION
…o say canary, but now the yaml is v3.5.0).
