### PR TITLE
chase openjdk 17 changes in wolfi

### DIFF
--- a/images/bazel/configs/latest.apko.yaml
+++ b/images/bazel/configs/latest.apko.yaml
@@ -6,6 +6,7 @@ contents:
   packages:
     - ca-certificates-bundle
     - openjdk-17
+    - openjdk-17-default-jvm
     - bash
     - busybox
     - gcc
@@ -26,7 +27,7 @@ entrypoint:
   command: /usr/bin/bazel
 
 environment:
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 work-dir: /home/bazel
 

--- a/images/gradle/configs/latest.apko.yaml
+++ b/images/gradle/configs/latest.apko.yaml
@@ -10,6 +10,7 @@ contents:
     - gradle-8
     - wolfi-baselayout
     - openjdk-17
+    - openjdk-17-default-jvm
 
 accounts:
   groups:
@@ -28,7 +29,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 paths:
   - path: /home/build

--- a/images/jdk/configs/latest.apko.yaml
+++ b/images/jdk/configs/latest.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - glibc-locale-en
     - busybox
     - openjdk-17
+    - openjdk-17-default-jvm
     - libstdc++
 
 accounts:
@@ -25,7 +26,7 @@ work-dir: /home/build
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 paths:
   - path: /home/build

--- a/images/jenkins/configs/latest.apko.yaml
+++ b/images/jenkins/configs/latest.apko.yaml
@@ -9,6 +9,7 @@ contents:
     - glibc-locale-en
     - jenkins
     - openjdk-17-jre
+    - openjdk-17-default-jvm
     - bash
     - coreutils
     - busybox
@@ -31,7 +32,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   JENKINS_HOME: /var/jenkins_home
 
 paths:

--- a/images/jre/configs/latest.apko.yaml
+++ b/images/jre/configs/latest.apko.yaml
@@ -8,6 +8,7 @@ contents:
     - wolfi-baselayout
     - glibc-locale-en
     - openjdk-17-jre
+    - openjdk-17-default-jvm
     - libstdc++
 
 accounts:
@@ -26,7 +27,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 archs:
   - x86_64

--- a/images/maven/configs/latest.apko.yaml
+++ b/images/maven/configs/latest.apko.yaml
@@ -10,6 +10,7 @@ contents:
     - busybox
     - maven
     - openjdk-17
+    - openjdk-17-default-jvm
 
 accounts:
   groups:
@@ -28,7 +29,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 paths:
   - path: /home/build

--- a/images/pulumi/configs/latest.apko.yaml
+++ b/images/pulumi/configs/latest.apko.yaml
@@ -37,6 +37,7 @@ contents:
     - pulumi-language-java
     - glibc-locale-en
     - openjdk-17-jre
+    - openjdk-17-default-jvm
     - openjdk-17
     - libstdc++
     - maven

--- a/images/zookeeper/configs/latest.apko.yaml
+++ b/images/zookeeper/configs/latest.apko.yaml
@@ -11,6 +11,7 @@ contents:
     - bash
     - zookeeper
     - openjdk-17-jre
+    - openjdk-17-default-jvm
 
 accounts:
   groups:
@@ -35,7 +36,7 @@ paths:
 
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/openjdk
+  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 archs:
   - x86_64


### PR DESCRIPTION
Use `openjdk-17-default-jvm` where appropriate and update `JAVA_HOME`.