### PR TITLE
Remove notice about authentication in April

### DIFF
--- a/images/php/README.md
+++ b/images/php/README.md
@@ -17,15 +17,13 @@ Minimalist Wolfi-based PHP images for building and running PHP applications. Inc
 - [Getting Started Guide](https://edu.chainguard.dev/chainguard/chainguard-images/reference/php/getting-started-php/)
 - [Provenance Information](https://edu.chainguard.dev/chainguard/chainguard-images/reference/php/provenance_info/)
 
-## Image Variants 
+## Image Variants
 
 Our `latest` tags use the most recent build of the [Wolfi PHP](https://github.com/wolfi-dev/os/blob/main/php.yaml) package. The following tagged variants are available without authentication:
 
 - `latest`: This is a distroless image for running command-line PHP applications. It does not include Composer or busybox, so no shell will be available.
 - `latest-dev`: This is a development / builder image that includes Composer, apk-tools, and busybox. This variant allows you to customize your final image with additional Wolfi packages.
-- `latest-fpm`: This is the distroless `php-fpm` image variant, designed to be used together with our [Nginx](https://edu.chainguard.dev/chainguard/chainguard-images/reference/nginx) image. 
-
-Starting in April, accessing older tags will require authentication.
+- `latest-fpm`: This is the distroless `php-fpm` image variant, designed to be used together with our [Nginx](https://edu.chainguard.dev/chainguard/chainguard-images/reference/nginx) image.
 
 ### PHP Version
 This will automatically pull the image to your local system and execute the command `php --version`:

--- a/images/redis/README.md
+++ b/images/redis/README.md
@@ -20,12 +20,10 @@ The data model is key-value, but many different kind of values are supported: St
 - [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/redis)
 - [Provenance Information](https://edu.chainguard.dev/chainguard/chainguard-images/reference/redis/provenance_info/)
 
-## Image Variants 
+## Image Variants
 
 Our `latest` tag use the most recent build of the [Wolfi Redis](https://github.com/wolfi-dev/os/blob/main/redis.yaml) package.
 The `latest` tagged variant is a distroless image for running Redis.
-
-Starting in April, accessing older tags will require authentication.
 
 ## Redis Version
 This will automatically pull the image to your local system and execute the command `redis --version`:


### PR DESCRIPTION
Removes the message "Starting in April, accessing older tags will require authentication." from the `redis` and `php` images.