### PR TITLE
fix cloudwatch-exporter java paths and explicitly specify jre

### DIFF
--- a/images/prometheus-cloudwatch-exporter/configs/latest.apko.yaml
+++ b/images/prometheus-cloudwatch-exporter/configs/latest.apko.yaml
@@ -6,6 +6,8 @@ contents:
   packages:
     - ca-certificates-bundle
     - busybox
+    - openjdk-17-jre
+    - openjdk-17-default-jvm
     - cloudwatch-exporter
     - wolfi-baselayout
 


### PR DESCRIPTION
Fix : fix cloudwatch-exporter java paths and explicitly specify jre

