### PR TITLE
enable signoff for digestbot job

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -20,3 +20,4 @@ jobs:
       - uses: chainguard-dev/actions/digesta-bot@main
         with:
           token: ${{ secrets.DIGEST_BOT_CHAINGUARD_IMAGES_PAT }}
+          signoff: true


### PR DESCRIPTION
- enable signoff for digestbot job
the PRs from digestbot is failing the DCO check, this should fix that