### PR TITLE
Add missing annotations to all images

### DIFF
--- a/images/apko/configs/latest.apko.yaml
+++ b/images/apko/configs/latest.apko.yaml
@@ -24,3 +24,8 @@ cmd: --help
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/apko/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/apko

--- a/images/aspnet-runtime/configs/latest.apko.yaml
+++ b/images/aspnet-runtime/configs/latest.apko.yaml
@@ -26,3 +26,8 @@ archs:
 entrypoint:
   command: /usr/bin/dotnet
 cmd: --help
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/aspnet-runtime/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/aspnet-runtime

--- a/images/bash/configs/latest.apko.yaml
+++ b/images/bash/configs/latest.apko.yaml
@@ -16,3 +16,8 @@ entrypoint:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/bash/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bash

--- a/images/bazel/configs/latest.apko.yaml
+++ b/images/bazel/configs/latest.apko.yaml
@@ -34,3 +34,8 @@ work-dir: /home/bazel
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/bazel/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/bazel

--- a/images/busybox/configs/latest-glibc.apko.yaml
+++ b/images/busybox/configs/latest-glibc.apko.yaml
@@ -20,3 +20,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/busybox

--- a/images/busybox/configs/latest.apko.yaml
+++ b/images/busybox/configs/latest.apko.yaml
@@ -22,3 +22,8 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/busybox/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/busybox

--- a/images/cc-dynamic/configs/latest.apko.yaml
+++ b/images/cc-dynamic/configs/latest.apko.yaml
@@ -22,3 +22,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/cc-dynamic/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/cc-dynamic

--- a/images/clang/configs/latest.apko.yaml
+++ b/images/clang/configs/latest.apko.yaml
@@ -34,3 +34,8 @@ cmd: --help
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/clang/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/clang

--- a/images/cluster-autoscaler/configs/latest.apko.yaml
+++ b/images/cluster-autoscaler/configs/latest.apko.yaml
@@ -25,3 +25,8 @@ work-dir: /
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/cluster-autoscaler/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/cluster-autoscaler

--- a/images/cosign/configs/latest.apko.yaml
+++ b/images/cosign/configs/latest.apko.yaml
@@ -27,3 +27,8 @@ cmd: help
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/cosign

--- a/images/curl/configs/latest.apko.yaml
+++ b/images/curl/configs/latest.apko.yaml
@@ -25,3 +25,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/curl/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/curl

--- a/images/deno/configs/latest.apko.yaml
+++ b/images/deno/configs/latest.apko.yaml
@@ -37,3 +37,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/deno/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/deno

--- a/images/dotnet-runtime/configs/latest.apko.yaml
+++ b/images/dotnet-runtime/configs/latest.apko.yaml
@@ -26,3 +26,8 @@ archs:
 entrypoint:
   command: /usr/bin/dotnet
 cmd: --help
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/dotnet-runtime/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/dotnet-runtime

--- a/images/dotnet-sdk/configs/latest.apko.yaml
+++ b/images/dotnet-sdk/configs/latest.apko.yaml
@@ -26,3 +26,8 @@ archs:
   - aarch64
 
 cmd: /bin/sh -l
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/dotnet-sdk/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/dotnet-sdk

--- a/images/envoy/configs/latest.apko.yaml
+++ b/images/envoy/configs/latest.apko.yaml
@@ -34,3 +34,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/envoy/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/envoy

--- a/images/etcd/configs/latest.apko.yaml
+++ b/images/etcd/configs/latest.apko.yaml
@@ -33,3 +33,8 @@ entrypoint:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/etcd/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/etcd

--- a/images/fluent-bit/configs/latest.apko.yaml
+++ b/images/fluent-bit/configs/latest.apko.yaml
@@ -30,3 +30,8 @@ cmd: -c /fluent-bit/etc/fluent-bit.conf
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/fluent-bit/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/fluent-bit

--- a/images/gcc-glibc/configs/latest.apko.yaml
+++ b/images/gcc-glibc/configs/latest.apko.yaml
@@ -23,3 +23,8 @@ cmd: --help
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/gcc-glibc/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/gcc-glibc

--- a/images/gcc-musl/configs/latest.apko.yaml
+++ b/images/gcc-musl/configs/latest.apko.yaml
@@ -19,3 +19,8 @@ work-dir: /work
 entrypoint:
   command: /usr/bin/gcc
 cmd: --help
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/gcc-musl/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/gcc-musl

--- a/images/git/configs/latest-glibc-root.apko.yaml
+++ b/images/git/configs/latest-glibc-root.apko.yaml
@@ -27,3 +27,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/git/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/git

--- a/images/git/configs/latest-glibc.apko.yaml
+++ b/images/git/configs/latest-glibc.apko.yaml
@@ -28,3 +28,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/git/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/git

--- a/images/git/configs/latest-root.apko.yaml
+++ b/images/git/configs/latest-root.apko.yaml
@@ -23,3 +23,8 @@ accounts:
     - username: git
       uid: 65532
       gid: 65532
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/git/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/git

--- a/images/git/configs/latest.apko.yaml
+++ b/images/git/configs/latest.apko.yaml
@@ -24,3 +24,8 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/git/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/git

--- a/images/glibc-dynamic/configs/latest.apko.yaml
+++ b/images/glibc-dynamic/configs/latest.apko.yaml
@@ -13,3 +13,8 @@ contents:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/glibc-dynamic/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/glibc-dynamic

--- a/images/go/configs/1.19.apko.yaml
+++ b/images/go/configs/1.19.apko.yaml
@@ -30,3 +30,8 @@ cmd: help
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/go/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/go

--- a/images/go/configs/latest.apko.yaml
+++ b/images/go/configs/latest.apko.yaml
@@ -33,3 +33,8 @@ cmd: help
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/go/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/go

--- a/images/graalvm-native/configs/latest.apko.yaml
+++ b/images/graalvm-native/configs/latest.apko.yaml
@@ -24,3 +24,8 @@ accounts:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/graalvm-native/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/graalvm-native

--- a/images/gradle/configs/latest.apko.yaml
+++ b/images/gradle/configs/latest.apko.yaml
@@ -41,3 +41,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/gradle/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/gradle

--- a/images/haproxy/configs/latest.apko.yaml
+++ b/images/haproxy/configs/latest.apko.yaml
@@ -37,3 +37,8 @@ entrypoint:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/haproxy/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/haproxy

--- a/images/helm/configs/latest.apko.yaml
+++ b/images/helm/configs/latest.apko.yaml
@@ -27,3 +27,8 @@ cmd: help
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/helm/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/helm

--- a/images/hugo/configs/latest.apko.yaml
+++ b/images/hugo/configs/latest.apko.yaml
@@ -31,3 +31,8 @@ accounts:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/hugo

--- a/images/jdk/configs/latest.apko.yaml
+++ b/images/jdk/configs/latest.apko.yaml
@@ -38,3 +38,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/jdk/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/jdk

--- a/images/jdk/configs/openjdk-11.apko.yaml
+++ b/images/jdk/configs/openjdk-11.apko.yaml
@@ -38,3 +38,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/jdk/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/jdk

--- a/images/jenkins/configs/latest.apko.yaml
+++ b/images/jenkins/configs/latest.apko.yaml
@@ -45,3 +45,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/jenkins/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/jenkins

--- a/images/jre/configs/latest.apko.yaml
+++ b/images/jre/configs/latest.apko.yaml
@@ -32,3 +32,8 @@ environment:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/jre/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/jre

--- a/images/jre/configs/openjdk-11.apko.yaml
+++ b/images/jre/configs/openjdk-11.apko.yaml
@@ -32,3 +32,8 @@ environment:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/jre/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/jre

--- a/images/keda-adapter/configs/latest.apko.yaml
+++ b/images/keda-adapter/configs/latest.apko.yaml
@@ -27,3 +27,8 @@ entrypoint:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/keda-adapter/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/keda-adapter

--- a/images/keda-admission-webhooks/configs/latest.apko.yaml
+++ b/images/keda-admission-webhooks/configs/latest.apko.yaml
@@ -26,3 +26,8 @@ entrypoint:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/keda-admission-webhooks/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/keda-admission-webhooks

--- a/images/keda/configs/latest.apko.yaml
+++ b/images/keda/configs/latest.apko.yaml
@@ -26,3 +26,8 @@ entrypoint:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/keda/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/keda

--- a/images/ko/configs/latest.apko.yaml
+++ b/images/ko/configs/latest.apko.yaml
@@ -18,3 +18,8 @@ accounts:
 
 entrypoint:
   command: /usr/bin/ko
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/ko/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/ko

--- a/images/kubectl/configs/latest.apko.yaml
+++ b/images/kubectl/configs/latest.apko.yaml
@@ -27,3 +27,8 @@ cmd: help
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/kubectl/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/kubectl

--- a/images/mariadb/configs/latest.apko.yaml
+++ b/images/mariadb/configs/latest.apko.yaml
@@ -46,3 +46,8 @@ paths:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/mariadb/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/mariadb

--- a/images/maven/configs/latest.apko.yaml
+++ b/images/maven/configs/latest.apko.yaml
@@ -41,3 +41,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/maven/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/maven

--- a/images/maven/configs/openjdk-11.apko.yaml
+++ b/images/maven/configs/openjdk-11.apko.yaml
@@ -41,3 +41,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/maven/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/maven

--- a/images/melange/configs/latest.apko.yaml
+++ b/images/melange/configs/latest.apko.yaml
@@ -26,3 +26,8 @@ cmd: --help
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/melange/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/melange

--- a/images/memcached/configs/latest.apko.yaml
+++ b/images/memcached/configs/latest.apko.yaml
@@ -22,3 +22,8 @@ entrypoint:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/memcached/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/memcached

--- a/images/musl-dynamic/configs/latest.apko.yaml
+++ b/images/musl-dynamic/configs/latest.apko.yaml
@@ -6,3 +6,8 @@ contents:
     - alpine-release
     - ca-certificates-bundle
     - musl
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/musl-dynamic/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/musl-dynamic

--- a/images/netcat/configs/latest.apko.yaml
+++ b/images/netcat/configs/latest.apko.yaml
@@ -24,3 +24,8 @@ work-dir: /home/nc
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/netcat/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/netcat

--- a/images/nginx/configs/latest.apko.yaml
+++ b/images/nginx/configs/latest.apko.yaml
@@ -51,3 +51,8 @@ stop-signal: SIGQUIT
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/nginx/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/nginx

--- a/images/nginx/configs/next.apko.yaml
+++ b/images/nginx/configs/next.apko.yaml
@@ -51,3 +51,8 @@ stop-signal: SIGQUIT
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/nginx/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/nginx

--- a/images/node/configs/19.apko.yaml
+++ b/images/node/configs/19.apko.yaml
@@ -46,3 +46,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/node/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/node

--- a/images/node/configs/20.apko.yaml
+++ b/images/node/configs/20.apko.yaml
@@ -46,3 +46,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/node/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/node

--- a/images/node/configs/latest.apko.yaml
+++ b/images/node/configs/latest.apko.yaml
@@ -46,3 +46,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/node/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/node

--- a/images/php/configs/latest.apko.yaml
+++ b/images/php/configs/latest.apko.yaml
@@ -37,3 +37,8 @@ accounts:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/php/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/php

--- a/images/postgres/configs/latest.apko.yaml
+++ b/images/postgres/configs/latest.apko.yaml
@@ -44,3 +44,8 @@ paths:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/postgres/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/postgres

--- a/images/powershell/configs/latest-root.apko.yaml
+++ b/images/powershell/configs/latest-root.apko.yaml
@@ -24,3 +24,8 @@ archs:
 
 entrypoint:
   command: /usr/bin/pwsh
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/powershell/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/powershell

--- a/images/powershell/configs/latest.apko.yaml
+++ b/images/powershell/configs/latest.apko.yaml
@@ -24,3 +24,8 @@ archs:
 
 entrypoint:
   command: /usr/bin/pwsh
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/powershell/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/powershell

--- a/images/prometheus-alertmanager/configs/latest.apko.yaml
+++ b/images/prometheus-alertmanager/configs/latest.apko.yaml
@@ -31,3 +31,8 @@ cmd: --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanag
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-alertmanager/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/prometheus-alertmanager

--- a/images/prometheus-elasticsearch-exporter/configs/latest.apko.yaml
+++ b/images/prometheus-elasticsearch-exporter/configs/latest.apko.yaml
@@ -25,3 +25,8 @@ entrypoint:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-elasticsearch-exporter/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/prometheus-elasticsearch-exporter

--- a/images/prometheus-mysqld-exporter/configs/latest.apko.yaml
+++ b/images/prometheus-mysqld-exporter/configs/latest.apko.yaml
@@ -25,3 +25,8 @@ entrypoint:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-mysqld-exporter/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/prometheus-mysqld-exporter

--- a/images/prometheus-node-exporter/configs/latest.apko.yaml
+++ b/images/prometheus-node-exporter/configs/latest.apko.yaml
@@ -23,3 +23,8 @@ entrypoint:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-node-exporter/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/prometheus-node-exporter

--- a/images/prometheus/configs/latest.apko.yaml
+++ b/images/prometheus/configs/latest.apko.yaml
@@ -13,3 +13,8 @@ entrypoint:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/prometheus

--- a/images/python/configs/3.10.apko.yaml
+++ b/images/python/configs/3.10.apko.yaml
@@ -24,3 +24,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/python/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/python

--- a/images/python/configs/latest.apko.yaml
+++ b/images/python/configs/latest.apko.yaml
@@ -25,3 +25,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/python/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/python

--- a/images/rabbitmq/configs/latest.apko.yaml
+++ b/images/rabbitmq/configs/latest.apko.yaml
@@ -72,3 +72,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/rabbitmq/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/rabbitmq

--- a/images/redis/configs/latest.apko.yaml
+++ b/images/redis/configs/latest.apko.yaml
@@ -32,3 +32,8 @@ entrypoint:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/redis/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/redis

--- a/images/rust/configs/latest.apko.yaml
+++ b/images/rust/configs/latest.apko.yaml
@@ -34,3 +34,8 @@ cmd: --help
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/rust/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/rust

--- a/images/skaffold/configs/latest.apko.yaml
+++ b/images/skaffold/configs/latest.apko.yaml
@@ -39,3 +39,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/skaffold/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/skaffold

--- a/images/static/configs/latest-glibc.apko.yaml
+++ b/images/static/configs/latest-glibc.apko.yaml
@@ -21,3 +21,8 @@ accounts:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/static/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/static

--- a/images/static/configs/latest.apko.yaml
+++ b/images/static/configs/latest.apko.yaml
@@ -16,3 +16,8 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/static/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/static

--- a/images/traefik/configs/latest.apko.yaml
+++ b/images/traefik/configs/latest.apko.yaml
@@ -27,3 +27,8 @@ entrypoint:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/traefik/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/traefik

--- a/images/wait-for-it/configs/latest.apko.yaml
+++ b/images/wait-for-it/configs/latest.apko.yaml
@@ -23,3 +23,8 @@ accounts:
 archs:
   - x86_64
   - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/wait-for-it/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/wait-for-it

--- a/images/weaviate/configs/latest.apko.yaml
+++ b/images/weaviate/configs/latest.apko.yaml
@@ -30,3 +30,8 @@ accounts:
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/weaviate/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/weaviate

--- a/images/wolfi-base/configs/latest.apko.yaml
+++ b/images/wolfi-base/configs/latest.apko.yaml
@@ -13,3 +13,8 @@ cmd: /bin/sh -l
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/wolfi-base/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/wolfi-base

--- a/images/zot/configs/latest.apko.yaml
+++ b/images/zot/configs/latest.apko.yaml
@@ -34,3 +34,8 @@ cmd: --help
 archs:
 - x86_64
 - aarch64
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/zot/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/zot


### PR DESCRIPTION
This was generated with:
```
for x in $(diff <(find . -name '*.apko.yaml' | sort) <(grep org.opencontainers.image.source $(find . -name '*.apko.yaml') | cut -d':' -f 1 | sort) | grep '^<' | cut -d' ' -f 2); do
cat >> $x <<EOF

annotations:
  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/$(echo $(dirname $(dirname $x)) | cut -d'/' -f 3-)/
  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/$(echo $(dirname $(dirname $x)) | cut -d'/' -f 2-)
EOF
done
```

