### PR TITLE
Start to use the computed "extra packages" from monopod.

### DIFF
--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -52,31 +52,6 @@ runs:
         sign-with-temporary-key: true
         archs: x86_64 # To speed up CI, just build for x86_64 ${{ inputs.melangeArchs }}
         template: ${{ inputs.melangeTemplate }}
-    - id: inject-build-options
-      shell: bash
-      run: |
-        yaml_files_with_options_key="globals.yaml"
-        # If the repo using this action doesn't have an globals.yaml, use the public chainguard one
-        if [[ ! -f "globals.yaml" ]]; then
-          curl -sLO https://raw.githubusercontent.com/chainguard-images/images/main/globals.yaml
-        fi
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} images/${{ inputs.imageName }}/image.yaml"
-        fi
-        if [[ "$(cat ${{ inputs.apkoConfig }} | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} ${{ inputs.apkoConfig }}"
-        fi
-        echo "Combining options sourced from the following file(s): ${yaml_files_with_options_key}"
-        # Use yq to combine all files' options sections together
-        yq -M eval-all '.options as $item ireduce ({}; . * $item)' ${yaml_files_with_options_key} > tmp.yaml
-        # If the original file has options, remove them before appending
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yq -M 'del(.options)' "${{ inputs.apkoConfig }}" > "${{ inputs.apkoConfig }}.tmp"
-          mv "${{ inputs.apkoConfig }}.tmp" "${{ inputs.apkoConfig }}"
-        fi
-        echo "" >> "${{ inputs.apkoConfig }}" # For configs missing trailing newline
-        yq -M '{"options": .}' tmp.yaml >> "${{ inputs.apkoConfig }}"
-        rm -f tmp.yaml
 
     - uses: chainguard-dev/actions/setup-registry@main
       with:
@@ -114,7 +89,6 @@ runs:
         TF_VAR_apko_config_path: ${{ inputs.apkoConfig }}
         TF_VAR_target_repository: ${{ steps.target-repository.outputs.target-repository }}
         TF_VAR_extract_package: ${{ inputs.apkoPackageVersionTag }}
-        TF_VAR_build_options: ${{ inputs.apkoBuildOptions }}
       run: |
         set -x
         env | grep '^TF_VAR_'

--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -109,32 +109,6 @@ runs:
         REGISTRY_HOSTNAME="$(echo ${{ inputs.apkoBaseTag }} | cut -d / -f 1)"
         gcloud auth configure-docker "${REGISTRY_HOSTNAME}"
 
-    - id: inject-build-options
-      shell: bash
-      run: |
-        yaml_files_with_options_key="globals.yaml"
-        # If the repo using this action doesn't have an globals.yaml, use the public chainguard one
-        if [[ ! -f "globals.yaml" ]]; then
-          curl -sLO https://raw.githubusercontent.com/chainguard-images/images/main/globals.yaml
-        fi
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} images/${{ inputs.imageName }}/image.yaml"
-        fi
-        if [[ "$(cat ${{ inputs.apkoConfig }} | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} ${{ inputs.apkoConfig }}"
-        fi
-        echo "Combining options sourced from the following file(s): ${yaml_files_with_options_key}"
-        # Use yq to combine all files' options sections together
-        yq -M eval-all '.options as $item ireduce ({}; . * $item)' ${yaml_files_with_options_key} > tmp.yaml
-        # If the original file has options, remove them before appending
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yq -M 'del(.options)' "${{ inputs.apkoConfig }}" > "${{ inputs.apkoConfig }}.tmp"
-          mv "${{ inputs.apkoConfig }}.tmp" "${{ inputs.apkoConfig }}"
-        fi
-        echo "" >> "${{ inputs.apkoConfig }}" # For configs missing trailing newline
-        yq -M '{"options": .}' tmp.yaml >> "${{ inputs.apkoConfig }}"
-        rm -f tmp.yaml
-
     # Needed in step below to login to registry (if cgr.dev), and also for SLSA attestation
     - name: Setup cosign
       uses: sigstore/cosign-installer@v3
@@ -185,7 +159,6 @@ runs:
         TF_VAR_apko_config_path: ${{ inputs.apkoConfig }}
         TF_VAR_target_repository: ${{ inputs.apkoBaseTag }}
         TF_VAR_extract_package: ${{ inputs.apkoPackageVersionTag }}
-        TF_VAR_build_options: ${{ inputs.apkoBuildOptions }}
         DOCKER_CONFIG: .docker-rumble
       run: |
         set -x

--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -36,13 +36,11 @@ jobs:
           EXTRA_INPUT_APKO_IMAGE: ghcr.io/wolfi-dev/apko:latest@sha256:66443587f3f2f5d9262bcfff35a2f26e1615e90c4b9dbef8ae295cc9c1daeb48
           EXTRA_INPUT_APKO_REPOSITORY_APPEND: https://packages.wolfi.dev/os
           EXTRA_INPUT_APKO_KEYRING_APPEND: https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-          EXTRA_INPUT_APKO_PACKAGE_APPEND: wolfi-baselayout
         run: |
           # Do not append out repo/keyring/package to Alpine images.
           if grep 'alpinelinux\.org' "${{ matrix.apkoConfig }}" &>/dev/null; then
             unset EXTRA_INPUT_APKO_REPOSITORY_APPEND
             unset EXTRA_INPUT_APKO_KEYRING_APPEND
-            unset EXTRA_INPUT_APKO_PACKAGE_APPEND
           fi
 
           # convert env vars beginning with "EXTRA_INPUT_"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,13 +128,11 @@ jobs:
           EXTRA_INPUT_SLSA_PROVENANCE_CACHE_KEY: ${{ needs.generate-slsa-provenance.outputs.slsa-provenance-cache-key }}
           EXTRA_INPUT_APKO_REPOSITORY_APPEND: https://packages.wolfi.dev/os
           EXTRA_INPUT_APKO_KEYRING_APPEND: https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-          EXTRA_INPUT_APKO_PACKAGE_APPEND: wolfi-baselayout
         run: |
           # Do not append out repo/keyring/package to Alpine images.
           if grep 'alpinelinux\.org' "${{ matrix.apkoConfig }}" &>/dev/null; then
             unset EXTRA_INPUT_APKO_REPOSITORY_APPEND
             unset EXTRA_INPUT_APKO_KEYRING_APPEND
-            unset EXTRA_INPUT_APKO_PACKAGE_APPEND
           fi
 
           # convert env vars beginning with "EXTRA_INPUT_"

--- a/images/crane/image.yaml
+++ b/images/crane/image.yaml
@@ -1,3 +1,6 @@
+# Opt-in to the new terraform-based release
+terraform: true
+
 status: experimental
 versions:
   - apko:

--- a/monopod/pkg/images/images.go
+++ b/monopod/pkg/images/images.go
@@ -33,7 +33,7 @@ type Image struct {
 	ApkoPackageVersionTag       string `json:"apkoPackageVersionTag"`
 	ApkoPackageVersionTagPrefix string `json:"apkoPackageVersionTagPrefix"`
 	ApkoBuildOptions            string `json:"apkoBuildOptions"`
-	ApkoPackagesAppend          string `json:"apkoPackagesAppend"`
+	ApkoPackageAppend           string `json:"apkoPackageAppend"`
 	TestCommandExe              string `json:"testCommandExe"`
 	TestCommandDir              string `json:"testCommandDir"`
 	ExcludeTags                 string `json:"excludeTags"`
@@ -166,18 +166,18 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 			apkoTargetTagSuffix := ""
 
 			apkoBuildOptions := strings.Join(iterator.Variant.Apko.Options, ",")
-			apkoPackagesAppend := make([]string, 0, len(iterator.Variant.Apko.Options))
+			apkoPackageAppend := make([]string, 0, len(iterator.Variant.Apko.Options))
 			for _, opt := range iterator.Variant.Apko.Options {
 				// Look it up in the image's configuration first.
 				vp, ok := extraPackages(m, opt)
 				if ok {
-					apkoPackagesAppend = append(apkoPackagesAppend, vp...)
+					apkoPackageAppend = append(apkoPackageAppend, vp...)
 					continue
 				}
 				// Then look it up in the global configuration.
 				gp, ok := extraPackages(g, opt)
 				if ok {
-					apkoPackagesAppend = append(apkoPackagesAppend, gp...)
+					apkoPackageAppend = append(apkoPackageAppend, gp...)
 					continue
 				}
 				return nil, fmt.Errorf("could not find variant option %q", opt)
@@ -195,13 +195,13 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 					// Look it up in the image's configuration first.
 					vp, ok := extraPackages(m, opt)
 					if ok {
-						apkoPackagesAppend = append(apkoPackagesAppend, vp...)
+						apkoPackageAppend = append(apkoPackageAppend, vp...)
 						continue
 					}
 					// Then look it up in the global configuration.
 					gp, ok := extraPackages(g, opt)
 					if ok {
-						apkoPackagesAppend = append(apkoPackagesAppend, gp...)
+						apkoPackageAppend = append(apkoPackageAppend, gp...)
 						continue
 					}
 					return nil, fmt.Errorf("could not find subvariant option %q", opt)
@@ -332,7 +332,7 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 				ApkoPackageVersionTag:       variant.Apko.ExtractTagsFrom.Package,
 				ApkoPackageVersionTagPrefix: variant.Apko.ExtractTagsFrom.Prefix,
 				ApkoBuildOptions:            apkoBuildOptions,
-				ApkoPackagesAppend:          strings.Join(apkoPackagesAppend, ","),
+				ApkoPackageAppend:           strings.Join(apkoPackageAppend, ","),
 				TestCommandExe:              testCommandExe,
 				TestCommandDir:              testCommandDir,
 				ExcludeTags:                 strings.Join(variant.Apko.ExtractTagsFrom.Exclude, ","),


### PR DESCRIPTION
Currently only the terraform workflows are sensitive to this, so I'm adding `crane` (which has a `dev` variant) into the set of things we build with TF.
