### PR TITLE
Do a cleanup pass over the terraform release action.

### DIFF
--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -39,20 +39,6 @@ runs:
         find "${{ github.workspace }}/packages" -print -exec touch \{} \;
         ls -al "${{ github.workspace }}/packages/"
 
-    - name: Setup QEMU
-      if: inputs.melangeConfig != ''
-      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
-    - id: melange
-      if: inputs.melangeConfig != ''
-      uses: chainguard-dev/actions/melange-build@main
-      with:
-        multi-config: ${{ inputs.melangeConfig }}
-        empty-workspace: ${{ inputs.melangeEmptyWorkspace }}
-        workdir: ${{ inputs.melangeWorkdir }}
-        sign-with-temporary-key: true
-        archs: x86_64 # To speed up CI, just build for x86_64 ${{ inputs.melangeArchs }}
-        template: ${{ inputs.melangeTemplate }}
-
     - uses: chainguard-dev/actions/setup-registry@main
       with:
         port: 5000
@@ -99,10 +85,8 @@ runs:
       id: apko
       shell: bash
       run: |
-        digest="$(terraform output --raw image_ref)"
-        output="digest-index=${digest}"
-        echo "Adding GitHub step output: ${output}"
-        echo "${output}" >> $GITHUB_OUTPUT
+        set -x
+        echo "digest-index=$(terraform output --raw image_ref)" >> $GITHUB_OUTPUT
 
     - name: Smoke test
       id: smoketest

--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -4,12 +4,6 @@ inputs:
     default: ''
   gcsBucketName:
     default: ''
-  runGrype:
-    default: 'true'
-  runSnyk:
-    default: 'false'
-  runTrivy:
-    default: 'true'
 runs:
   using: composite
   steps:
@@ -23,26 +17,22 @@ runs:
         repository: ${{ inputs.overrideCheckoutRepository }}
 
     # optionally fetch a gcs bucket to be used by melange and apko builds
-    - id: gcsfetchauth1
-      if: inputs.gcsFetchBucketName != ''
+    - if: inputs.gcsFetchBucketName != ''
       uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
       with:
         workload_identity_provider: ${{ inputs.gcsFetchAuthWorkloadIdentityProvider }}
         service_account: ${{ inputs.gcsFetchAuthServiceAccount }}
-    - id: gcsfetchauth2
-      if: inputs.gcsFetchBucketName != ''
+    - if: inputs.gcsFetchBucketName != ''
       uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
       with:
         project_id: ${{ inputs.gcsFetchAuthProjectId }}
-    - id: gcsfetchauth3
-      if: inputs.gcsFetchBucketName != ''
+    - if: inputs.gcsFetchBucketName != ''
       shell: bash
       name: 'Check that GCloud is properly configured'
       run: |
         gcloud info
         gcloud --quiet alpha storage ls
-    - id: rsync
-      shell: bash
+    - shell: bash
       if: inputs.gcsFetchBucketName != ''
       run: |
         mkdir -p "${{ github.workspace }}/packages"
@@ -50,72 +40,11 @@ runs:
         find "${{ github.workspace }}/packages" -print -exec touch \{} \;
         ls -al "${{ github.workspace }}/packages/"
 
-    # Run custom melange build if necessary
-    - name: Setup QEMU
-      if: inputs.melangeConfig != ''
-      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
-    - id: melange
-      if: inputs.melangeConfig != ''
-      uses: chainguard-dev/actions/melange-build@main
-      with:
-        multi-config: ${{ inputs.melangeConfig }}
-        empty-workspace: ${{ inputs.melangeEmptyWorkspace }}
-        workdir: ${{ inputs.melangeWorkdir }}
-        sign-with-temporary-key: true
-        archs: ${{ inputs.melangeArchs }}
-        template: ${{ inputs.melangeTemplate }}
-
-    # If publishing to Chainguard registry (cgr.dev), setup auth
-    - id: cgrauth1
-      if: contains(inputs.apkoBaseTag, 'cgr.dev/') && inputs.chainguardIdentity != ''
-      uses: chainguard-dev/actions/setup-chainctl@main
+    - uses: chainguard-dev/actions/setup-chainctl@main
       with:
         identity: ${{ inputs.chainguardIdentity }}
-    - id: cgrauth2
-      shell: bash
-      run: |
-        set +x
-        REGISTRY_HOSTNAME="$(echo ${{ inputs.apkoBaseTag }} | cut -d / -f 1)"
-        if [[ "${REGISTRY_HOSTNAME}" != "cgr.dev" ]]; then
-          echo "Target is not cgr.dev, skipping."
-          exit 0
-        fi
-        echo "Adding cgr.dev credentials to outputs."
-        CRED_HELPER_GET_RESPONSE="$(echo "cgr.dev" | docker-credential-cgr get)"
-        CGR_USER="$(echo "${CRED_HELPER_GET_RESPONSE}" | jq -r .Username)"
-        CGR_PASS="$(echo "${CRED_HELPER_GET_RESPONSE}" | jq -r .Secret)"
-        echo "::add-mask::${CGR_USER}"
-        echo "::add-mask::${CGR_PASS}"
-        echo "username=${CGR_USER}" >> $GITHUB_OUTPUT
-        echo "password=${CGR_PASS}" >> $GITHUB_OUTPUT
 
-    # If publishing to GCR, setup OIDC->SA auth
-    - id: gcrauth1
-      if: contains(inputs.apkoBaseTag, 'gcr.io/') || contains(inputs.apkoBaseTag, 'pkg.dev/')
-      uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
-      with:
-        workload_identity_provider: ${{ inputs.gcrAuthWorkloadIdentityProvider }}
-        service_account: ${{ inputs.gcrAuthServiceAccount }}
-    - id: gcrauth2
-      if: contains(inputs.apkoBaseTag, 'gcr.io/') || contains(inputs.apkoBaseTag, 'pkg.dev/')
-      uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
-      with:
-        project_id: ${{ inputs.gcrAuthProjectId }}
-        install_components: beta
-    - id: gcrauth3
-      if: contains(inputs.apkoBaseTag, 'gcr.io/') || contains(inputs.apkoBaseTag, 'pkg.dev/')
-      shell: bash
-      run: |
-        REGISTRY_HOSTNAME="$(echo ${{ inputs.apkoBaseTag }} | cut -d / -f 1)"
-        gcloud auth configure-docker "${REGISTRY_HOSTNAME}"
-
-    # Needed in step below to login to registry (if cgr.dev), and also for SLSA attestation
-    - name: Setup cosign
-      uses: sigstore/cosign-installer@v3
-
-    - name: Setup Terrafrom
-      id: setup-terraform
-      uses: hashicorp/setup-terraform@v2
+    - uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: '1.3.*'
         terraform_wrapper: false
@@ -145,40 +74,8 @@ runs:
         terraform init
         terraform apply -auto-approve
 
-    # Needed in step below to process arch-specific manifest digests etc.
-    - name: Setup crane
-      id: setup-crane
-      uses: imjasonh/setup-crane@v0.3
-
-    - name: Process Terraform outputs
-      id: apko
-      shell: bash
-      run: |
-        set -x
-
-        # Extra stuff related to output etc. used in remainder of pipeline
-        digest="$(terraform output --raw image_ref)"
-        output="digest-index=${digest}"
-        echo "Adding GitHub step output: ${output}"
-        echo "${output}" >> $GITHUB_OUTPUT
-        output="shortdigest-index=$(echo "${digest}" | cut -d@ -f 2)"
-        echo "Adding GitHub step output: ${output}"
-        echo "${output}" >> $GITHUB_OUTPUT
-
-        # If its an index, extract the platform digests too
-        CRANE_MANIFEST_OUTPUT="$(crane manifest ${digest})"
-        if [[ "$(echo $CRANE_MANIFEST_OUTPUT | jq -r .mediaType)" == "application/vnd.oci.image.index.v1+json" ]]; then
-          for combo in `echo $CRANE_MANIFEST_OUTPUT | jq -r '.manifests[] | .platform.architecture + .platform.variant + "_" + .digest'`; do
-            arch="$(echo "${combo}" | cut -d "_" -f1)"
-            digest="$(echo "${combo}" | cut -d "_" -f2)"
-            output="digest-${arch}=${{ inputs.apkoBaseTag }}@${digest}"
-            echo "Adding GitHub step output: ${output}"
-            echo "${output}" >> $GITHUB_OUTPUT
-            output="shortdigest-${arch}=${digest}"
-            echo "Adding GitHub step output: ${output}"
-            echo "${output}" >> $GITHUB_OUTPUT
-          done
-        fi
+        # Surface the resulting image_ref as a step output.
+        echo "image_ref=$(terraform output --raw image_ref)" >> $GITHUB_OUTPUT
 
     # The apko.tags file is needed in tagging below after all attestations and tests pass etc.
     - name: Create apko.tags file
@@ -201,52 +98,6 @@ runs:
         echo "Contents of apko.tags:"
         cat apko.tags
 
-    # SLSA attestation
-    # Originally found in apko-snapshot action
-    # TODO: do it in terraform
-    # See https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container
-    - name: Fetch SLSA provenance.json from cache
-      if: inputs.slsaProvenanceCacheKey != ''
-      uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-      with:
-        path: ./provenance.json
-        key: ${{ inputs.slsaProvenanceCacheKey }}
-    - name: 'SLSA: Generate provenance and attest'
-      if: inputs.slsaProvenanceCacheKey != ''
-      shell: bash
-      env:
-        COSIGN_EXPERIMENTAL: "true"
-        GENERATOR_REPOSITORY: slsa-framework/slsa-github-generator
-        GENERATOR_RELEASE_TAG: v1.5.0
-        GENERATOR_RELEASE_BINARY: slsa-generator-container-linux-amd64
-        GENERATOR_RELEASE_BINARY_SHA256: 6d8b83327ac2134aa8760e1e4f9cd5d3fdbcb56599e39be2cd965f1e04aa8ede
-        GH_TOKEN: "${{ github.token }}"
-        GITHUB_CONTEXT: "${{ toJSON(github) }}" # Needed by slsa-generator-container
-      run: |
-        set -x
-        echo "Provenance doc:"
-        cat provenance.json | jq
-
-        function attest_slsa {
-          arch="${1}"
-          digest="${2}"
-          echo "Attaching SLSA build provenance to ${digest} (arch: ${arch}) ..."
-          cosign attest --yes --type slsaprovenance --predicate="provenance.json" "${digest}"
-        }
-
-        # First attest the index
-        attest_slsa "index" "${{ steps.apko.outputs.digest-index }}"
-
-        # Next, for each architecture (if present)
-        [[ "${{ steps.apko.outputs.digest-amd64 }}" == "" ]] || attest_slsa "amd64" "${{ steps.apko.outputs.digest-amd64 }}"
-        [[ "${{ steps.apko.outputs.digest-arm64 }}" == "" ]] || attest_slsa "arm64" "${{ steps.apko.outputs.digest-arm64 }}"
-        [[ "${{ steps.apko.outputs.digest-386 }}" == "" ]] || attest_slsa "386" "${{ steps.apko.outputs.digest-386 }}"
-        [[ "${{ steps.apko.outputs.digest-armv6 }}" == "" ]] || attest_slsa "armv6" "${{ steps.apko.outputs.digest-armv6 }}"
-        [[ "${{ steps.apko.outputs.digest-armv7 }}" == "" ]] || attest_slsa "armv7" "${{ steps.apko.outputs.digest-armv7 }}"
-        [[ "${{ steps.apko.outputs.digest-ppc64le }}" == "" ]] || attest_slsa "ppc64le" "${{ steps.apko.outputs.digest-ppc64le }}"
-        [[ "${{ steps.apko.outputs.digest-riscv64 }}" == "" ]] || attest_slsa "riscv64" "${{ steps.apko.outputs.digest-riscv64 }}"
-        [[ "${{ steps.apko.outputs.digest-s390x }}" == "" ]] || attest_slsa "s390x" "${{ steps.apko.outputs.digest-s390x }}"
-
     # Test image
     - name: Smoke test
       id: smoketest
@@ -254,19 +105,20 @@ runs:
       shell: bash
       run: |
         set -x
-        export IMAGE_NAME="${{ steps.apko.outputs.digest-index }}"
+        export IMAGE_NAME="${{ steps.terraform-apply.outputs.image_ref }}"
         export IMAGE_TAG_SUFFIX="${{ inputs.apkoTargetTagSuffix }}"
         cd "${{ inputs.testCommandDir }}"
         ${{ inputs.testCommandExe }}
 
     # Tag the image last, after all tests passing and
     # SBOMs, attestations, etc. have all been attached
+    - uses: imjasonh/setup-crane@v0.3
     - name: Add image tags
       id: tag
       shell: bash
       run: |
         set -x
-        REF="${{ steps.apko.outputs.digest-index }}"
+        REF="${{ steps.terraform-apply.outputs.image_ref }}"
         EXCLUDE_TAGS="${{ inputs.excludeTags }}"
         for tag in `cat apko.tags`; do
           skip=0
@@ -278,11 +130,6 @@ runs:
           done
           if [[ "${skip}" == "0" ]]; then
             crane cp "${REF}" "${tag}"
-            # Mirror image to alternate destination
-            if [[ "${{ inputs.mirror }}" != "" ]]; then
-              MIRROR_REF="${{ inputs.mirror }}/$(basename "${tag}")"
-              cosign copy -f "${REF}" "${MIRROR_REF}"
-            fi
           else
             echo "Intentionally excluding copy to ${tag}."
           fi

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ provider "apko" {
 
 module "image" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.2"
+  version = "0.0.3"
 
   target_repository = var.target_repository
   config            = file(var.apko_config_path)


### PR DESCRIPTION
This cleans up legacy auth paths, mirror options, superfluous installations, unneeded `id:` fields, SLSA attestation, QEMU setup, and a bunch more.

This is intended to help get a complete picture of what's left wrt moving ~everything to terraform.
