### PR TITLE
Fix: Set the correct argo-cd package name

### DIFF
--- a/images/argocd/image.yaml
+++ b/images/argocd/image.yaml
@@ -2,7 +2,7 @@ versions:
   - apko:
       config: configs/latest.apko.yaml
       extractTagsFrom:
-        package: argocd
+        package: argo-cd
       subvariants:
         - suffix: -dev
           options:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes:

The argocd image only had the `latest` tags, no version tags were extracted and published
