### PR TITLE
Revert #724 with multiple authorities

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ provider "apko" {
 
 module "image" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.3"
+  version = "0.0.4"
 
   target_repository = var.target_repository
   config            = file(var.apko_config_path)

--- a/policies/04-has-slsa-attestation.yaml
+++ b/policies/04-has-slsa-attestation.yaml
@@ -15,9 +15,16 @@ spec:
       ctlog:
         url: https://rekor.sigstore.dev
       attestations:
-        - name: must-have-slsa-attestation
+        # One of these must be true.
+        - name: must-have-slsa-attestation-v0.2
           predicateType: "https://slsa.dev/provenance/v0.2"
           policy:
             type: cue
             data: |
               predicateType: "https://slsa.dev/provenance/v0.2"
+        - name: must-have-slsa-attestation-v1
+          predicateType: "https://slsa.dev/provenance/v1"
+          policy:
+            type: cue
+            data: |
+              predicateType: "https://slsa.dev/provenance/v1"

--- a/policies/04-has-slsa-attestation.yaml
+++ b/policies/04-has-slsa-attestation.yaml
@@ -6,8 +6,7 @@ spec:
   images:
     - glob: cgr.dev/chainguard/*
   authorities:
-    - name: keyless-authority
-      keyless:
+    - keyless:
         url: https://fulcio.sigstore.dev
         identities:
           - issuer: https://token.actions.githubusercontent.com
@@ -15,14 +14,22 @@ spec:
       ctlog:
         url: https://rekor.sigstore.dev
       attestations:
-        # One of these must be true.
-        - name: must-have-slsa-attestation-v0.2
+        - name: must-have-slsa-attestation
           predicateType: "https://slsa.dev/provenance/v0.2"
           policy:
             type: cue
             data: |
               predicateType: "https://slsa.dev/provenance/v0.2"
-        - name: must-have-slsa-attestation-v1
+
+    - keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+      ctlog:
+        url: https://rekor.sigstore.dev
+      attestations:
+        - name: must-have-slsa-attestation
           predicateType: "https://slsa.dev/provenance/v1"
           policy:
             type: cue


### PR DESCRIPTION
This reverts #724 now that there is a new release of `tf-cosign` and switches the policy to use multiple authorities.

I was able to run this over one of the previously failing digests locally, which failed with the prior tf-cosign release:
```
TF_VAR_image_refs='["cgr.dev/chainguard/apko:latest","cgr.dev/chainguard/apko:latest@sha256:b843f830a353cb26fb8bd9e57d920a2d8e8f6b56190957a8c80ccaa6914e0a09","cgr.dev/chainguard/apko:latest@sha256:4f20fd165080e8169b8cc594216e1aa565d7e4e3496e97320a6c3a7ca88adc9f"]' terraform apply
```

