### PR TITLE
Path to vault binary moved.

### DIFF
--- a/images/vault/configs/latest.apko.yaml
+++ b/images/vault/configs/latest.apko.yaml
@@ -19,7 +19,7 @@ accounts:
   recursive: true
 
 entrypoint:
-  command: /usr/sbin/vault
+  command: /usr/bin/vault
 cmd: server -dev
 
 archs:


### PR DESCRIPTION
The path to vault in the underlying package will be moved by https://github.com/wolfi-dev/os/pull/2321

This update corrects the path but *does not* add the fixes for upstream helm chart compatibility (we'll do that separately).

Don't merge this until https://github.com/wolfi-dev/os/pull/2321 lands (will mark draft).
