### PR TITLE
kubectl: move busybox to -dev variant

### DIFF
--- a/images/kubectl/configs/latest.apko.yaml
+++ b/images/kubectl/configs/latest.apko.yaml
@@ -5,7 +5,6 @@ contents:
     - https://packages.wolfi.dev/os
   packages:
     - ca-certificates-bundle
-    - busybox
     - kubectl
     - wolfi-baselayout
 

--- a/images/kubectl/image.yaml
+++ b/images/kubectl/image.yaml
@@ -3,3 +3,7 @@ versions:
       config: configs/latest.apko.yaml
       extractTagsFrom:
         package: kubectl
+      subvariants:
+        - suffix: -dev
+          options:
+            - dev


### PR DESCRIPTION
Move busybox to -dev variant, with wolfi-dev/os#2452 merged, this brings the kubectl image down to 47MB on ARM, or ~5MB smaller than the official k8s image.  It also aligns our image contents with that of the official one.