### PR TITLE
Revert "Revert "Pass through extra packages.""

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -85,8 +85,7 @@ runs:
         tag: ${{ inputs.imageName }}:${{ github.sha }}-${{ inputs.apkoTargetTag }}
         keyring-append: ${{ inputs.apkoKeyringAppend }}
         repository-append: ${{ inputs.apkoRepositoryAppend }}
-        # TODO(https://github.com/chainguard-dev/apko/pull/703): plumb this through
-        # package-append: ${{ inputs.apkoPackageAppend }}
+        package-append: ${{ inputs.apkoPackageAppend }}
         additional-tags: ${{ inputs.apkoAdditionalTags }}
         archs: x86_64 # To speed up CI, just build for x86_64 ${{ inputs.melangeArchs }}
         build-options: ${{ inputs.apkoBuildOptions }}

--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -145,8 +145,7 @@ runs:
         target-tag: ${{ inputs.apkoTargetTag }}
         keyring-append: ${{ inputs.apkoKeyringAppend }}
         repository-append: ${{ inputs.apkoRepositoryAppend }}
-        # TODO(https://github.com/chainguard-dev/apko/pull/703): plumb this through
-        # package-append: ${{ inputs.apkoPackageAppend }}
+        package-append: ${{ inputs.apkoPackageAppend }}
         additional-tags: ${{ inputs.apkoAdditionalTags }}
         package-version-tag: ${{ inputs.apkoPackageVersionTag }}
         package-version-tag-stem: true


### PR DESCRIPTION
Reverts chainguard-images/images#742

This should roll forward the support for `--package-append` in our `apko` image: https://github.com/chainguard-images/images/pull/746