### PR TITLE
Drop the build options blender

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -52,31 +52,7 @@ runs:
         sign-with-temporary-key: true
         archs: x86_64 # To speed up CI, just build for x86_64 ${{ inputs.melangeArchs }}
         template: ${{ inputs.melangeTemplate }}
-    - id: inject-build-options
-      shell: bash
-      run: |
-        yaml_files_with_options_key="globals.yaml"
-        # If the repo using this action doesn't have an globals.yaml, use the public chainguard one
-        if [[ ! -f "globals.yaml" ]]; then
-          curl -sLO https://raw.githubusercontent.com/chainguard-images/images/main/globals.yaml
-        fi
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} images/${{ inputs.imageName }}/image.yaml"
-        fi
-        if [[ "$(cat ${{ inputs.apkoConfig }} | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} ${{ inputs.apkoConfig }}"
-        fi
-        echo "Combining options sourced from the following file(s): ${yaml_files_with_options_key}"
-        # Use yq to combine all files' options sections together
-        yq -M eval-all '.options as $item ireduce ({}; . * $item)' ${yaml_files_with_options_key} > tmp.yaml
-        # If the original file has options, remove them before appending
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yq -M 'del(.options)' "${{ inputs.apkoConfig }}" > "${{ inputs.apkoConfig }}.tmp"
-          mv "${{ inputs.apkoConfig }}.tmp" "${{ inputs.apkoConfig }}"
-        fi
-        echo "" >> "${{ inputs.apkoConfig }}" # For configs missing trailing newline
-        yq -M '{"options": .}' tmp.yaml >> "${{ inputs.apkoConfig }}"
-        rm -f tmp.yaml
+
     - id: apko
       uses: chainguard-images/actions/apko-build@main
       with:
@@ -89,6 +65,7 @@ runs:
         additional-tags: ${{ inputs.apkoAdditionalTags }}
         archs: x86_64 # To speed up CI, just build for x86_64 ${{ inputs.melangeArchs }}
         build-options: ${{ inputs.apkoBuildOptions }}
+
     - name: Smoke test
       id: smoketest
       if: inputs.testCommandExe != ''
@@ -99,6 +76,7 @@ runs:
         export IMAGE_TAG_SUFFIX="${{ inputs.apkoTargetTagSuffix }}"
         cd "${{ inputs.testCommandDir }}"
         ${{ inputs.testCommandExe }}
+
     - name: Touch actions file to prevent postrun failure
       if: always()
       shell: bash

--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -109,32 +109,6 @@ runs:
         REGISTRY_HOSTNAME="$(echo ${{ inputs.apkoBaseTag }} | cut -d / -f 1)"
         gcloud auth configure-docker "${REGISTRY_HOSTNAME}"
 
-    - id: inject-build-options
-      shell: bash
-      run: |
-        yaml_files_with_options_key="globals.yaml"
-        # If the repo using this action doesn't have an globals.yaml, use the public chainguard one
-        if [[ ! -f "globals.yaml" ]]; then
-          curl -sLO https://raw.githubusercontent.com/chainguard-images/images/main/globals.yaml
-        fi
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} images/${{ inputs.imageName }}/image.yaml"
-        fi
-        if [[ "$(cat ${{ inputs.apkoConfig }} | yq '.options')" != "null" ]]; then
-          yaml_files_with_options_key="${yaml_files_with_options_key} ${{ inputs.apkoConfig }}"
-        fi
-        echo "Combining options sourced from the following file(s): ${yaml_files_with_options_key}"
-        # Use yq to combine all files' options sections together
-        yq -M eval-all '.options as $item ireduce ({}; . * $item)' ${yaml_files_with_options_key} > tmp.yaml
-        # If the original file has options, remove them before appending
-        if [[ "$(cat "images/${{ inputs.imageName }}/image.yaml" | yq '.options')" != "null" ]]; then
-          yq -M 'del(.options)' "${{ inputs.apkoConfig }}" > "${{ inputs.apkoConfig }}.tmp"
-          mv "${{ inputs.apkoConfig }}.tmp" "${{ inputs.apkoConfig }}"
-        fi
-        echo "" >> "${{ inputs.apkoConfig }}" # For configs missing trailing newline
-        yq -M '{"options": .}' tmp.yaml >> "${{ inputs.apkoConfig }}"
-        rm -f tmp.yaml
-
     # Build and push
     - id: apko
       uses: chainguard-images/actions/apko-snapshot@main


### PR DESCRIPTION
We now plumb through `--package-append` or `TF_VAR_extra_packages` to our builds, so we no longer need to blend it into `apko.yaml`.

After `php-fpm` (thanks @erikaheidi 🙏 ) the only thing build options were used for was to add packages.

We still use `global.yaml` and `images.yaml` to seed the value passed to `--package-append`, but `apko` itself no longed needs this.