### PR TITLE
build multi-arch images in CI

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -50,7 +50,7 @@ runs:
         empty-workspace: ${{ inputs.melangeEmptyWorkspace }}
         workdir: ${{ inputs.melangeWorkdir }}
         sign-with-temporary-key: true
-        archs: x86_64 # To speed up CI, just build for x86_64 ${{ inputs.melangeArchs }}
+        archs: ${{ inputs.melangeArchs }}
         template: ${{ inputs.melangeTemplate }}
     - id: inject-build-options
       shell: bash


### PR DESCRIPTION
This makes CI slightly slower since it has to build for both archs even when it will only test the amd64 image. But, it should have caught recent errors involving multi-arch images, since some of those images would have been race-ily built incorrectly, and would have caught them before merging the apko bump.