### PR TITLE
Increase timeout on coredns test for readiness.

### DIFF
--- a/images/coredns/tests/03-helm.sh
+++ b/images/coredns/tests/03-helm.sh
@@ -37,4 +37,4 @@ helm install coredns coredns/coredns \
 	--set image.tag="${IMAGE_TAG}" \
 	--set isClusterService=false
 
-kubectl wait --for=condition=ready pod --selector app.kubernetes.io/instance=coredns
+kubectl wait --for=condition=ready pod --selector app.kubernetes.io/instance=coredns --timeout=120s


### PR DESCRIPTION
This passed on my laptop but took slightly over 30s.

It also passed in CI: https://github.com/dlorenc/images/actions/runs/5155693539

Fixes:

Related: 

### Pre-review Checklist
