### PR TITLE
csi-node-driver-registrar: fix command

### DIFF
--- a/images/kubernetes-csi-node-driver-registrar/configs/latest.apko.yaml
+++ b/images/kubernetes-csi-node-driver-registrar/configs/latest.apko.yaml
@@ -19,7 +19,7 @@ accounts:
   run-as: 65532
       
 entrypoint:
-  command: csi-node-driver-registrar
+  command: /usr/bin/csi-node-driver-registrar
     
 archs:
   - x86_64


### PR DESCRIPTION
The [package](https://github.com/wolfi-dev/os/blob/main/kubernetes-csi-node-driver-registrar.yaml) puts the binary at `/usr/bin` and the image had been invoking it as if it was in `/`.

@ajayk found this

We need better kind tests for these images.