### PR TITLE
tests: standardize on using IMAGE_NAME, where possible

### DIFF
--- a/images/external-attacher/tests/02-deploy.sh
+++ b/images/external-attacher/tests/02-deploy.sh
@@ -4,29 +4,16 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-  if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-    echo "Must set IMAGE_REGISTRY environment variable. Exiting."
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
     exit 1
-  fi
-
-  if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-    echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-    exit 1
-  fi
-
-  if [[ "${IMAGE_TAG}" == "" ]]; then
-    echo "Must set IMAGE_TAG environment variable. Exiting."
-    exit 1
-  fi
-}
-
+fi
 
 function TEST_basic_kubectl_apply() {
   tmpdir=$(mktemp -d); cd "${tmpdir}"
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/deployment.yaml
 
-  sed -i "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:.*|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}|g" deployment.yaml
+  sed -i "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:.*|${IMAGE_NAME}|g" deployment.yaml
 
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/rbac.yaml
   
@@ -46,5 +33,4 @@ function TEST_basic_kubectl_apply() {
   rm -rf "${tmpdir}"
 }
 
-preflight
 TEST_basic_kubectl_apply

--- a/images/external-resizer/tests/02-deploy.sh
+++ b/images/external-resizer/tests/02-deploy.sh
@@ -4,29 +4,16 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-  if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-    echo "Must set IMAGE_REGISTRY environment variable. Exiting."
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
     exit 1
-  fi
-
-  if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-    echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-    exit 1
-  fi
-
-  if [[ "${IMAGE_TAG}" == "" ]]; then
-    echo "Must set IMAGE_TAG environment variable. Exiting."
-    exit 1
-  fi
-}
-
+fi
 
 function TEST_basic_kubectl_apply() {
   tmpdir=$(mktemp -d); cd "${tmpdir}"
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/deploy/kubernetes/deployment.yaml
 
-  sed -i "s|gcr.io/k8s-staging-sig-storage/csi-resizer:canary|${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}|g" deployment.yaml
+  sed -i "s|gcr.io/k8s-staging-sig-storage/csi-resizer:canary|${IMAGE_NAME}|g" deployment.yaml
 
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/deploy/kubernetes/rbac.yaml
   
@@ -46,5 +33,4 @@ function TEST_basic_kubectl_apply() {
   rm -rf "${tmpdir}"
 }
 
-preflight
 TEST_basic_kubectl_apply

--- a/images/external-secrets/tests/02-helm.sh
+++ b/images/external-secrets/tests/02-helm.sh
@@ -36,7 +36,7 @@ helm repo add external-secrets https://charts.external-secrets.io
 helm install external-secrets \
    external-secrets/external-secrets \
     -n external-secrets \
-     --set image.repository="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}" \
+    --set image.repository="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}" \
     --set image.tag="${IMAGE_TAG}" \
     --create-namespace \
     --wait 

--- a/images/kube-bench/tests/02-run.sh
+++ b/images/kube-bench/tests/02-run.sh
@@ -4,24 +4,10 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-  if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-    echo "Must set IMAGE_REGISTRY environment variable. Exiting."
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
     exit 1
-  fi
-
-  if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-    echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-    exit 1
-  fi
-
-  if [[ "${IMAGE_TAG}" == "" ]]; then
-    echo "Must set IMAGE_TAG environment variable. Exiting."
-    exit 1
-  fi
-}
-
-preflight
+fi
 
 app_name="kube-bench"
 tmp="$(mktemp -d 'kube-bench-test-XXXXXX')"
@@ -43,7 +29,7 @@ job_file="$tmp/job.yaml"
 curl -sSL -o "$job_file" 'https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml'
 
 # Update the config to use our image
-yq -i ".spec.template.spec.containers[0].image |= \"${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}\"" "$job_file"
+yq -i ".spec.template.spec.containers[0].image |= \"${IMAGE_NAME}\"" "$job_file"
 
 kubectl apply -f "$job_file"
 

--- a/images/kube-downscaler/tests/02-deploy.sh
+++ b/images/kube-downscaler/tests/02-deploy.sh
@@ -4,24 +4,10 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-	if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-		echo "Must set IMAGE_REGISTRY environment variable. Exiting."
-		exit 1
-	fi
-
-	if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-		echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-		exit 1
-	fi
-
-	if [[ "${IMAGE_TAG}" == "" ]]; then
-		echo "Must set IMAGE_TAG environment variable. Exiting."
-		exit 1
-	fi
-}
-
-preflight
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
+    exit 1
+fi
 
 function cleanup() {
 	# Print debug logs and status
@@ -50,7 +36,7 @@ sleep 10
 kubectl wait --for=condition=ready pod --selector application=kube-downscaler --timeout=120s
 
 # Swap out the image
-kubectl set image deployment/kube-downscaler downscaler="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+kubectl set image deployment/kube-downscaler downscaler="${IMAGE_NAME}"
 
 # Wait for the replicaset to be ready and old pods to terminated
 kubectl rollout status deployment/kube-downscaler --timeout=120s

--- a/images/kubernetes-csi-external-provisioner/tests/02-deploy.sh
+++ b/images/kubernetes-csi-external-provisioner/tests/02-deploy.sh
@@ -4,24 +4,10 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-	if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-		echo "Must set IMAGE_REGISTRY environment variable. Exiting."
-		exit 1
-	fi
-
-	if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-		echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-		exit 1
-	fi
-
-	if [[ "${IMAGE_TAG}" == "" ]]; then
-		echo "Must set IMAGE_TAG environment variable. Exiting."
-		exit 1
-	fi
-}
-
-preflight
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
+    exit 1
+fi
 
 function cleanup() {
 	# Print debug logs and status
@@ -48,7 +34,7 @@ sleep 10
 kubectl wait --for=condition=ready pod --selector app=csi-provisioner --timeout=120s
 
 # Swap out the image
-kubectl set image deployment/csi-provisioner csi-provisioner="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+kubectl set image deployment/csi-provisioner csi-provisioner="${IMAGE_NAME}"
 
 # Wait for the replicaset to be ready and old pods to terminated
 kubectl rollout status deployment/csi-provisioner --timeout=120s

--- a/images/kubernetes-dashboard/tests/02-deploy.sh
+++ b/images/kubernetes-dashboard/tests/02-deploy.sh
@@ -4,24 +4,10 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-  if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-    echo "Must set IMAGE_REGISTRY environment variable. Exiting."
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
     exit 1
-  fi
-
-  if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-    echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-    exit 1
-  fi
-
-  if [[ "${IMAGE_TAG}" == "" ]]; then
-    echo "Must set IMAGE_TAG environment variable. Exiting."
-    exit 1
-  fi
-}
-
-preflight
+fi
 
 function cleanup() {
     # Print debug logs and status
@@ -35,7 +21,7 @@ trap cleanup EXIT
 # Deploy the dashboard yaml, then swap out the image and patch the pull policy
 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
-kubectl set image -n kubernetes-dashboard deployment/kubernetes-dashboard kubernetes-dashboard="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+kubectl set image -n kubernetes-dashboard deployment/kubernetes-dashboard kubernetes-dashboard="${IMAGE_NAME}"
 kubectl patch deployment -n kubernetes-dashboard kubernetes-dashboard --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Never"}]'
 
 # The pod can take a few seconds to appear after the deployment and the replicaset are all created and reconcile

--- a/images/prometheus-redis-exporter/tests/02-install.sh
+++ b/images/prometheus-redis-exporter/tests/02-install.sh
@@ -4,24 +4,10 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-	if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-		echo "Must set IMAGE_REGISTRY environment variable. Exiting."
-		exit 1
-	fi
-
-	if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-		echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-		exit 1
-	fi
-
-	if [[ "${IMAGE_TAG}" == "" ]]; then
-		echo "Must set IMAGE_TAG environment variable. Exiting."
-		exit 1
-	fi
-}
-
-preflight
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
+    exit 1
+fi
 
 cat >deploy.yaml <<EOF
 ---
@@ -58,7 +44,7 @@ spec:
         ports:
         - containerPort: 6379
       - name: redis-exporter
-        image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+        image: ${IMAGE_NAME}
         securityContext:
           runAsUser: 65532
           runAsGroup: 65532

--- a/images/weaviate/tests/02-install.sh
+++ b/images/weaviate/tests/02-install.sh
@@ -4,24 +4,10 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-  if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-    echo "Must set IMAGE_REGISTRY environment variable. Exiting."
+if [[ "${IMAGE_NAME}" == "" ]]; then
+    echo "Must set IMAGE_NAME environment variable. Exiting."
     exit 1
-  fi
-
-  if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-    echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-    exit 1
-  fi
-
-  if [[ "${IMAGE_TAG}" == "" ]]; then
-    echo "Must set IMAGE_TAG environment variable. Exiting."
-    exit 1
-  fi
-}
-
-preflight
+fi
 
 helm repo add weaviate https://weaviate.github.io/weaviate-helm
 wget https://raw.githubusercontent.com/weaviate/weaviate-helm/v16.2.0/weaviate/values.yaml
@@ -30,7 +16,7 @@ wget https://raw.githubusercontent.com/weaviate/weaviate-helm/v16.2.0/weaviate/v
 helm install  my-weaviate weaviate/weaviate \
     --version 16.2.0 \
     --values ./values.yaml \
-    --set image.repo="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}" --set image.tag="${IMAGE_TAG}" \
+    --set image.repo="${IMAGE_NAME}" \
     --dry-run | \
     sed  's/imagePullPolicy: Always/imagePullPolicy: Never/g' | \
     sed 's|docker.io/||g'  | tail -n +10 | \


### PR DESCRIPTION
`$IMAGE_NAME` will be populated with the just-built image reference by digest, which we should use wherever possible so we don't have to tag it first.

Unfortunately a lot of tests still require `$IMAGE_TAG` to be compatible with Helm charts 😭 