### PR TITLE
Move towards dedicated TF modules per image

### DIFF
--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -43,12 +43,6 @@ runs:
       with:
         port: 5000
 
-    - name: Create target repository
-      id: target-repository
-      shell: bash
-      run: |
-        echo "target-repository=localhost:5000/testing/${{ github.sha }}--${{ inputs.imageName }}--${{ inputs.apkoTargetTag }}" >> $GITHUB_OUTPUT
-
     - name: Setup Terrafrom
       id: setup-terraform
       uses: hashicorp/setup-terraform@v2
@@ -71,12 +65,9 @@ runs:
     - name: Terraform apply (apko publish)
       id: terraform-apply
       shell: bash
+      working-directory: ${{ inputs.terraformDirectory }}
       env:
-        TF_VAR_apko_config_path: ${{ inputs.apkoConfig }}
-        TF_VAR_target_repository: ${{ steps.target-repository.outputs.target-repository }}
-        TF_VAR_extract_package: ${{ inputs.apkoPackageVersionTag }}
-        TF_VAR_test_dir: ${{ inputs.testCommandDir }}
-        TF_VAR_test_cmd: ${{ inputs.testCommandExe }}
+        TF_VAR_target_repository: localhost:5000/testing
         TF_VAR_target_tag: ${{ inputs.apkoTargetTag }}
         TF_VAR_tag_suffix: ${{ inputs.apkoTargetTagSuffix }}
       run: |

--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -64,12 +64,9 @@ runs:
     - name: Terraform apply (apko publish)
       id: terraform-apply
       shell: bash
+      working-directory: ${{ inputs.terraformDirectory }}
       env:
-        TF_VAR_apko_config_path: ${{ inputs.apkoConfig }}
         TF_VAR_target_repository: ${{ inputs.apkoBaseTag }}
-        TF_VAR_extract_package: ${{ inputs.apkoPackageVersionTag }}
-        TF_VAR_test_dir: ${{ inputs.testCommandDir }}
-        TF_VAR_test_cmd: ${{ inputs.testCommandExe }}
         TF_VAR_target_tag: ${{ inputs.apkoTargetTag }}
         TF_VAR_tag_suffix: ${{ inputs.apkoTargetTagSuffix }}
       run: |

--- a/images/bazel/main.tf
+++ b/images/bazel/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "tag_suffix" {
+  description = "The suffix to the tag for this image."
+}
+
+variable "extra_repositories" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os"]
+  description = "The list of additional repositories to append to the apko configuration."
+}
+
+variable "extra_keyring" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  description = "The list of additional keyring entries to append to the apko configuration."
+}
+
+variable "extra_packages" {
+  type        = list(string)
+  default     = ["wolfi-baselayout"]
+  description = "The list of additional packages to append to the apko configuration."
+}
+
+provider "apko" {
+  extra_repositories = var.extra_repositories
+  extra_keyring      = var.extra_keyring
+  default_archs      = ["x86_64", "aarch64"]
+}
+
+module "latest" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.3"
+
+  target_repository = var.target_repository
+  config            = file("${path.module}/configs/latest.apko.yaml")
+  extra_packages    = var.extra_packages
+}
+
+module "version-tags" {
+  source  = "../../tflib/version-tags"
+  package = "bazel-6"
+  config  = module.latest.config
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "version-tags" {
+  depends_on = [ module.test-latest ]
+  for_each   = toset(concat(["latest"], module.version-tags.tag_list))
+
+  digest_ref = module.latest.image_ref
+  tag        = "${each.key}${var.tag_suffix}"
+}

--- a/images/bazel/tests/main.tf
+++ b/images/bazel/tests/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "${path.module}/01-version.sh"
+}
+
+data "oci_exec_test" "build" {
+  digest = var.digest
+  script = "${path.module}/02-build.sh"
+}

--- a/images/clang/main.tf
+++ b/images/clang/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "tag_suffix" {
+  description = "The suffix to the tag for this image."
+}
+
+variable "extra_repositories" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os"]
+  description = "The list of additional repositories to append to the apko configuration."
+}
+
+variable "extra_keyring" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  description = "The list of additional keyring entries to append to the apko configuration."
+}
+
+variable "extra_packages" {
+  type        = list(string)
+  default     = ["wolfi-baselayout"]
+  description = "The list of additional packages to append to the apko configuration."
+}
+
+provider "apko" {
+  extra_repositories = var.extra_repositories
+  extra_keyring      = var.extra_keyring
+  default_archs      = ["x86_64", "aarch64"]
+}
+
+module "latest" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.3"
+
+  target_repository = var.target_repository
+  config            = file("${path.module}/configs/latest.apko.yaml")
+  extra_packages    = var.extra_packages
+}
+
+module "version-tags" {
+  source  = "../../tflib/version-tags"
+  package = "clang-15"
+  config  = module.latest.config
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "version-tags" {
+  depends_on = [ module.test-latest ]
+  for_each   = toset(concat(["latest"], module.version-tags.tag_list))
+
+  digest_ref = module.latest.image_ref
+  tag        = "${each.key}${var.tag_suffix}"
+}

--- a/images/clang/tests/main.tf
+++ b/images/clang/tests/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "${path.module}/01-version.sh"
+}
+
+data "oci_exec_test" "compile" {
+  digest = var.digest
+  script = "${path.module}/02-compile.sh"
+}

--- a/images/consul/main.tf
+++ b/images/consul/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "tag_suffix" {
+  description = "The suffix to the tag for this image."
+}
+
+variable "extra_repositories" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os"]
+  description = "The list of additional repositories to append to the apko configuration."
+}
+
+variable "extra_keyring" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  description = "The list of additional keyring entries to append to the apko configuration."
+}
+
+variable "extra_packages" {
+  type        = list(string)
+  default     = ["wolfi-baselayout"]
+  description = "The list of additional packages to append to the apko configuration."
+}
+
+provider "apko" {
+  extra_repositories = var.extra_repositories
+  extra_keyring      = var.extra_keyring
+  default_archs      = ["x86_64", "aarch64"]
+}
+
+module "latest" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.3"
+
+  target_repository = var.target_repository
+  config            = file("${path.module}/configs/latest.apko.yaml")
+  extra_packages    = var.extra_packages
+}
+
+module "version-tags" {
+  source  = "../../tflib/version-tags"
+  package = "consul"
+  config  = module.latest.config
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "version-tags" {
+  depends_on = [ module.test-latest ]
+  for_each   = toset(concat(["latest"], module.version-tags.tag_list))
+
+  digest_ref = module.latest.image_ref
+  tag        = "${each.key}${var.tag_suffix}"
+}

--- a/images/consul/tests/main.tf
+++ b/images/consul/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "${path.module}/01-version.sh"
+}

--- a/images/crane/main.tf
+++ b/images/crane/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "tag_suffix" {
+  description = "The suffix to the tag for this image."
+}
+
+variable "extra_repositories" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os"]
+  description = "The list of additional repositories to append to the apko configuration."
+}
+
+variable "extra_keyring" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  description = "The list of additional keyring entries to append to the apko configuration."
+}
+
+variable "extra_packages" {
+  type        = list(string)
+  default     = ["wolfi-baselayout"]
+  description = "The list of additional packages to append to the apko configuration."
+}
+
+provider "apko" {
+  extra_repositories = var.extra_repositories
+  extra_keyring      = var.extra_keyring
+  default_archs      = ["x86_64", "aarch64"]
+}
+
+module "latest" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.3"
+
+  target_repository = var.target_repository
+  config            = file("${path.module}/configs/latest.apko.yaml")
+  extra_packages    = var.extra_packages
+}
+
+module "version-tags" {
+  source  = "../../tflib/version-tags"
+  package = "crane"
+  config  = module.latest.config
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "version-tags" {
+  depends_on = [ module.test-latest ]
+  for_each   = toset(concat(["latest"], module.version-tags.tag_list))
+
+  digest_ref = module.latest.image_ref
+  tag        = "${each.key}${var.tag_suffix}"
+}

--- a/images/crane/tests/main.tf
+++ b/images/crane/tests/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "${path.module}/01-version.sh"
+}
+
+data "oci_exec_test" "manifest" {
+  digest = var.digest
+  script = "${path.module}/02-manifest.sh"
+}
+
+data "oci_exec_test" "digest" {
+  digest = var.digest
+  script = "${path.module}/03-digest.sh"
+}
+
+data "oci_exec_test" "ls" {
+  digest = var.digest
+  script = "${path.module}/04-ls.sh"
+}
+
+data "oci_exec_test" "config" {
+  digest = var.digest
+  script = "${path.module}/05-config.sh"
+}

--- a/images/ko/configs/latest.apko.yaml
+++ b/images/ko/configs/latest.apko.yaml
@@ -1,4 +1,8 @@
 contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - busybox
     - build-base
@@ -18,6 +22,10 @@ accounts:
 
 entrypoint:
   command: /usr/bin/ko
+
+archs:
+  - x86_64
+  - aarch64
 
 annotations:
   "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"

--- a/images/ko/main.tf
+++ b/images/ko/main.tf
@@ -1,40 +1,12 @@
-/*
-Copyright 2023 Chainguard, Inc.
-SPDX-License-Identifier: Apache-2.0
-*/
-
 terraform {
   required_providers {
-    apko = {
-      source = "chainguard-dev/apko"
-    }
-    cosign = {
-      source = "chainguard-dev/cosign"
-    }
-    oci = {
-      source = "chainguard-dev/oci"
-    }
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
   }
-}
-
-variable "apko_config_path" {
-  description = "The path to the apko image config file."
-}
-
-variable "test_dir" {
-  description = "The directory from which to run tests."
-}
-
-variable "test_cmd" {
-  description = "The command to run to invoke tests."
 }
 
 variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
-}
-
-variable "target_tag" {
-  description = "The target tag for this image."
 }
 
 variable "tag_suffix" {
@@ -59,44 +31,36 @@ variable "extra_packages" {
   description = "The list of additional packages to append to the apko configuration."
 }
 
-variable "extract_package" {
-  description = "TODO."
-}
-
 provider "apko" {
   extra_repositories = var.extra_repositories
   extra_keyring      = var.extra_keyring
   default_archs      = ["x86_64", "aarch64"]
 }
 
-module "image" {
+module "latest" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.4"
+  version = "0.0.3"
 
   target_repository = var.target_repository
-  config            = file(var.apko_config_path)
+  config            = file("${path.module}/configs/latest.apko.yaml")
   extra_packages    = var.extra_packages
 }
 
-data "oci_exec_test" "this" {
-  digest = module.image.image_ref
-  script = <<EOF
-    export IMAGE_TAG_SUFFIX="${var.tag_suffix}"
-    cd "${path.module}/${var.test_dir}"
-    ${var.test_cmd}
-  EOF
-}
-
 module "version-tags" {
-  source  = "./tflib/version-tags"
-  package = var.extract_package
-  config  = module.image.config
+  source  = "../../tflib/version-tags"
+  package = "ko"
+  config  = module.latest.config
 }
 
-resource "oci_tag" "this" {
-  depends_on = [ data.oci_exec_test.this ]
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "version-tags" {
+  depends_on = [ module.test-latest ]
   for_each   = toset(concat(["latest"], module.version-tags.tag_list))
 
-  digest_ref = module.image.image_ref
+  digest_ref = module.latest.image_ref
   tag        = "${each.key}${var.tag_suffix}"
 }

--- a/images/ko/tests/main.tf
+++ b/images/ko/tests/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "${path.module}/01-version.sh"
+}
+
+data "oci_exec_test" "build" {
+  digest = var.digest
+  script = "${path.module}/02-build.sh"
+}

--- a/images/terraform/main.tf
+++ b/images/terraform/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "tag_suffix" {
+  description = "The suffix to the tag for this image."
+}
+
+variable "extra_repositories" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os"]
+  description = "The list of additional repositories to append to the apko configuration."
+}
+
+variable "extra_keyring" {
+  type        = list(string)
+  default     = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  description = "The list of additional keyring entries to append to the apko configuration."
+}
+
+variable "extra_packages" {
+  type        = list(string)
+  default     = ["wolfi-baselayout"]
+  description = "The list of additional packages to append to the apko configuration."
+}
+
+provider "apko" {
+  extra_repositories = var.extra_repositories
+  extra_keyring      = var.extra_keyring
+  default_archs      = ["x86_64", "aarch64"]
+}
+
+module "latest" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.3"
+
+  target_repository = var.target_repository
+  config            = file("${path.module}/configs/latest.apko.yaml")
+  extra_packages    = var.extra_packages
+}
+
+module "version-tags" {
+  source  = "../../tflib/version-tags"
+  package = "terraform"
+  config  = module.latest.config
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "version-tags" {
+  depends_on = [ module.test-latest ]
+  for_each   = toset(concat(["latest"], module.version-tags.tag_list))
+
+  digest_ref = module.latest.image_ref
+  tag        = "${each.key}${var.tag_suffix}"
+}

--- a/images/terraform/tests/main.tf
+++ b/images/terraform/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "${path.module}/01-version.sh"
+}

--- a/monopod/pkg/images/images.go
+++ b/monopod/pkg/images/images.go
@@ -38,6 +38,7 @@ type Image struct {
 	TestCommandDir              string `json:"testCommandDir"`
 	ExcludeTags                 string `json:"excludeTags"`
 	UseTerraform                bool   `json:"useTerraform"`
+	TerraformDirectory          string `json:"terraformDirectory"`
 	ExcludeContact              bool   `json:"-"`
 }
 
@@ -314,6 +315,10 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 			}
 
 			useTerraform := m.Terraform
+			terraformDir := ""
+			if useTerraform {
+				terraformDir = filepath.Join(constants.ImagesDirName, imageName)
+			}
 
 			i := Image{
 				ImageName:                   imageName,
@@ -339,6 +344,7 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 				TestCommandDir:              testCommandDir,
 				ExcludeTags:                 strings.Join(variant.Apko.ExtractTagsFrom.Exclude, ","),
 				UseTerraform:                useTerraform,
+				TerraformDirectory:          terraformDir,
 				ExcludeContact:              imageExcludeContact,
 			}
 			allImages = append(allImages, i)


### PR DESCRIPTION
This breaks off a significant chunk of https://github.com/chainguard-images/images/pull/758

This iteration will let us do more interesting things with dedicated test modules (e.g. @imjasonh helm testing) but the dedicated modules are more verbose than I'd like and we don't shed any of the `image.yaml` configuration since these are still invoked individually per variant.