### PR TITLE
use apko publisher module 0.0.4

### DIFF
--- a/images/bazel/main.tf
+++ b/images/bazel/main.tf
@@ -39,7 +39,7 @@ provider "apko" {
 
 module "latest" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.3"
+  version = "0.0.4"
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")

--- a/images/clang/main.tf
+++ b/images/clang/main.tf
@@ -39,7 +39,7 @@ provider "apko" {
 
 module "latest" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.3"
+  version = "0.0.4"
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")

--- a/images/consul/main.tf
+++ b/images/consul/main.tf
@@ -39,7 +39,7 @@ provider "apko" {
 
 module "latest" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.3"
+  version = "0.0.4"
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")

--- a/images/crane/main.tf
+++ b/images/crane/main.tf
@@ -39,7 +39,7 @@ provider "apko" {
 
 module "latest" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.3"
+  version = "0.0.4"
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")

--- a/images/ko/main.tf
+++ b/images/ko/main.tf
@@ -39,7 +39,7 @@ provider "apko" {
 
 module "latest" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.3"
+  version = "0.0.4"
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")

--- a/images/terraform/main.tf
+++ b/images/terraform/main.tf
@@ -39,7 +39,7 @@ provider "apko" {
 
 module "latest" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.3"
+  version = "0.0.4"
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")


### PR DESCRIPTION
We should have dependabot do this, and probably have a script we can run manually to upgrade everything in the repo.

Matt says:
> I think I want a shim for the module in the repo to let us centrally manage that version
