### PR TITLE
mount the bucket to /gcsfuse and symlink os/

### DIFF
--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -51,9 +51,10 @@ runs:
       run: |
         mkdir -p "${{ github.workspace }}/packages"
 
-        # Install gcsfuse and mount the bucket to ./packages/
+        # Install gcsfuse and mount the $BUCKET/os/ to ./packages/ via symlink
         go install github.com/googlecloudplatform/gcsfuse@latest
-        gcsfuse "${{ inputs.gcsFetchBucketName }}" "${{ github.workspace }}/packages"
+        gcsfuse "${{ inputs.gcsFetchBucketName }}" /gcsfuse
+        ln -s /gcsfuse/os/ "${{ github.workspace }}/packages"
         ls -al "${{ github.workspace }}/packages/"
 
     # Run custom melange build if necessary


### PR DESCRIPTION
gcsfuse can only mount a whole bucket, but we only need `os/`, so we'll mount the bucket to `/gcsfuse` and symlink `/gcsfuse/os/` -> `./packages/`