### PR TITLE
fix gcsfuse again again again

### DIFF
--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -48,13 +48,15 @@ runs:
     - shell: bash
       if: inputs.gcsFetchBucketName != ''
       run: |
+        set -x
         mkdir -p "${{ github.workspace }}/packages"
         mkdir -p /tmp/gcsfuse
 
         # Install gcsfuse and mount the $BUCKET/os/ to ./packages/ via symlink
         go install github.com/googlecloudplatform/gcsfuse@latest
         gcsfuse "${{ inputs.gcsFetchBucketName }}" /tmp/gcsfuse
-        ln -s /tmp/gcsfuse/os/ "${{ github.workspace }}/packages"
+        ln -s /tmp/gcsfuse/os/ "${{ github.workspace }}/packages/"
+        ls -al /tmp/gcsfuse/os/
         ls -al "${{ github.workspace }}/packages/"
 
     # Run custom melange build if necessary


### PR DESCRIPTION
`/tmp/gcsfuse/os/` should symlink to `./packages/`, not `./packages`, where it then contains a `./packages/os/` directory where the good stuff is.

Please let me know if I got this wrong again again.