### PR TITLE
Default to using terraform when unspecified.

### DIFF
--- a/images/apko/image.yaml
+++ b/images/apko/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/argocd-repo-server/image.yaml
+++ b/images/argocd-repo-server/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/argocd/image.yaml
+++ b/images/argocd/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/aspnet-runtime/image.yaml
+++ b/images/aspnet-runtime/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: stable
 versions:
   - apko:

--- a/images/aws-cli/image.yaml
+++ b/images/aws-cli/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/aws-ebs-csi-driver/image.yaml
+++ b/images/aws-ebs-csi-driver/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml
@@ -7,4 +10,3 @@ versions:
         - suffix: -dev
           options:
             - dev
-

--- a/images/aws-efs-csi-driver/image.yaml
+++ b/images/aws-efs-csi-driver/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml
@@ -7,4 +10,3 @@ versions:
         - suffix: -dev
           options:
             - dev
-

--- a/images/aws-load-balancer-controller/image.yaml
+++ b/images/aws-load-balancer-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/bash/image.yaml
+++ b/images/bash/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/buck2/image.yaml
+++ b/images/buck2/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/busybox/image.yaml
+++ b/images/busybox/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/cc-dynamic/image.yaml
+++ b/images/cc-dynamic/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: deprecated
 versions:
   - apko:

--- a/images/cert-manager-acmesolver/image.yaml
+++ b/images/cert-manager-acmesolver/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/cert-manager-cainjector/image.yaml
+++ b/images/cert-manager-cainjector/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/cert-manager-controller/image.yaml
+++ b/images/cert-manager-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/cert-manager-webhook/image.yaml
+++ b/images/cert-manager-webhook/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: stable
 versions:
   - apko:

--- a/images/cluster-autoscaler/image.yaml
+++ b/images/cluster-autoscaler/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/cluster-proportional-autoscaler/image.yaml
+++ b/images/cluster-proportional-autoscaler/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/coredns/image.yaml
+++ b/images/coredns/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/cosign/image.yaml
+++ b/images/cosign/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/curl/image.yaml
+++ b/images/curl/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/deno/image.yaml
+++ b/images/deno/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/dex/image.yaml
+++ b/images/dex/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/dive/image.yaml
+++ b/images/dive/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/dotnet-runtime/image.yaml
+++ b/images/dotnet-runtime/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: stable
 versions:
   - apko:

--- a/images/dotnet-sdk/image.yaml
+++ b/images/dotnet-sdk/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: stable
 versions:
   - apko:

--- a/images/envoy-ratelimit/image.yaml
+++ b/images/envoy-ratelimit/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/envoy/image.yaml
+++ b/images/envoy/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/etcd/image.yaml
+++ b/images/etcd/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/external-dns/image.yaml
+++ b/images/external-dns/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/external-secrets/image.yaml
+++ b/images/external-secrets/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/fluent-bit/image.yaml
+++ b/images/fluent-bit/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/fluentd/image.yaml
+++ b/images/fluentd/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/flux/image.yaml
+++ b/images/flux/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/gatekeeper/image.yaml
+++ b/images/gatekeeper/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/gcc-glibc/image.yaml
+++ b/images/gcc-glibc/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/git/image.yaml
+++ b/images/git/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/glibc-dynamic/image.yaml
+++ b/images/glibc-dynamic/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/go/image.yaml
+++ b/images/go/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/1.19.apko.yaml

--- a/images/google-cloud-sdk/image.yaml
+++ b/images/google-cloud-sdk/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/graalvm-native/image.yaml
+++ b/images/graalvm-native/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/gradle/image.yaml
+++ b/images/gradle/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/haproxy-ingress/image.yaml
+++ b/images/haproxy-ingress/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/haproxy/image.yaml
+++ b/images/haproxy/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/helm-chartmuseum/image.yaml
+++ b/images/helm-chartmuseum/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/helm-controller/image.yaml
+++ b/images/helm-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/helm/image.yaml
+++ b/images/helm/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/http-echo/image.yaml
+++ b/images/http-echo/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/hugo/image.yaml
+++ b/images/hugo/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/influxdb/image.yaml
+++ b/images/influxdb/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/jdk/image.yaml
+++ b/images/jdk/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/jenkins/image.yaml
+++ b/images/jenkins/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: stable
 versions:
   - apko:

--- a/images/jre/image.yaml
+++ b/images/jre/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/k8s-sidecar/image.yaml
+++ b/images/k8s-sidecar/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/k8sgpt-operator/image.yaml
+++ b/images/k8sgpt-operator/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/k8sgpt/image.yaml
+++ b/images/k8sgpt/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kafka/image.yaml
+++ b/images/kafka/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/karpenter/image.yaml
+++ b/images/karpenter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/keda-adapter/image.yaml
+++ b/images/keda-adapter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/keda-admission-webhooks/image.yaml
+++ b/images/keda-admission-webhooks/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/keda/image.yaml
+++ b/images/keda/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kube-bench/image.yaml
+++ b/images/kube-bench/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kube-downscaler/image.yaml
+++ b/images/kube-downscaler/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kube-state-metrics/image.yaml
+++ b/images/kube-state-metrics/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubectl/image.yaml
+++ b/images/kubectl/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-external-attacher/image.yaml
+++ b/images/kubernetes-csi-external-attacher/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-external-provisioner/image.yaml
+++ b/images/kubernetes-csi-external-provisioner/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-external-resizer/image.yaml
+++ b/images/kubernetes-csi-external-resizer/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-external-snapshot-controller/image.yaml
+++ b/images/kubernetes-csi-external-snapshot-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-external-snapshot-validation-webhook/image.yaml
+++ b/images/kubernetes-csi-external-snapshot-validation-webhook/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-external-snapshotter/image.yaml
+++ b/images/kubernetes-csi-external-snapshotter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-livenessprobe/image.yaml
+++ b/images/kubernetes-csi-livenessprobe/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-csi-node-driver-registrar/image.yaml
+++ b/images/kubernetes-csi-node-driver-registrar/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-dashboard-metrics-scraper/image.yaml
+++ b/images/kubernetes-dashboard-metrics-scraper/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-dashboard/image.yaml
+++ b/images/kubernetes-dashboard/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubernetes-ingress-defaultbackend/image.yaml
+++ b/images/kubernetes-ingress-defaultbackend/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kubewatch/image.yaml
+++ b/images/kubewatch/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kustomize-controller/image.yaml
+++ b/images/kustomize-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/kyverno-background-controller/image.yaml
+++ b/images/kyverno-background-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kyverno-cleanup-controller/image.yaml
+++ b/images/kyverno-cleanup-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kyverno-cli/image.yaml
+++ b/images/kyverno-cli/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kyverno-reports-controller/image.yaml
+++ b/images/kyverno-reports-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kyverno/image.yaml
+++ b/images/kyverno/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/kyvernopre/image.yaml
+++ b/images/kyvernopre/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/mariadb/image.yaml
+++ b/images/mariadb/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/maven/image.yaml
+++ b/images/maven/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/melange/image.yaml
+++ b/images/melange/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/memcached-exporter/image.yaml
+++ b/images/memcached-exporter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/memcached/image.yaml
+++ b/images/memcached/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/metacontroller/image.yaml
+++ b/images/metacontroller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/metrics-server/image.yaml
+++ b/images/metrics-server/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/minio-client/image.yaml
+++ b/images/minio-client/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/minio/image.yaml
+++ b/images/minio/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/nats/image.yaml
+++ b/images/nats/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/netcat/image.yaml
+++ b/images/netcat/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/newrelic-fluent-bit-output/image.yaml
+++ b/images/newrelic-fluent-bit-output/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/newrelic-k8s-events-forwarder/image.yaml
+++ b/images/newrelic-k8s-events-forwarder/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/newrelic-prometheus-configurator/image.yaml
+++ b/images/newrelic-prometheus-configurator/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/nginx/image.yaml
+++ b/images/nginx/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml
@@ -9,4 +12,3 @@ versions:
             - dev
   - apko:
       config: configs/next.apko.yaml
-

--- a/images/node/image.yaml
+++ b/images/node/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       extractTagsFrom:

--- a/images/notification-controller/image.yaml
+++ b/images/notification-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/nri-kube-events/image.yaml
+++ b/images/nri-kube-events/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/nri-kubernetes/image.yaml
+++ b/images/nri-kubernetes/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/nri-prometheus/image.yaml
+++ b/images/nri-prometheus/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/ntpd-rs/image.yaml
+++ b/images/ntpd-rs/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/nvidia-device-plugin/image.yaml
+++ b/images/nvidia-device-plugin/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/oauth2-proxy/image.yaml
+++ b/images/oauth2-proxy/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 ref: cgr.dev/chainguard/oauth2-proxy
 versions:
   - apko:

--- a/images/oidc-discovery-provider/image.yaml
+++ b/images/oidc-discovery-provider/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/openai/image.yaml
+++ b/images/openai/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/opensearch/image.yaml
+++ b/images/opensearch/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/paranoia/image.yaml
+++ b/images/paranoia/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/php/image.yaml
+++ b/images/php/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       extractTagsFrom:

--- a/images/postgres/image.yaml
+++ b/images/postgres/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/powershell/image.yaml
+++ b/images/powershell/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/prometheus-alertmanager/image.yaml
+++ b/images/prometheus-alertmanager/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/prometheus-cloudwatch-exporter/image.yaml
+++ b/images/prometheus-cloudwatch-exporter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/prometheus-config-reloader/image.yaml
+++ b/images/prometheus-config-reloader/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/prometheus-elasticsearch-exporter/image.yaml
+++ b/images/prometheus-elasticsearch-exporter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/prometheus-mysqld-exporter/image.yaml
+++ b/images/prometheus-mysqld-exporter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/prometheus-node-exporter/image.yaml
+++ b/images/prometheus-node-exporter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/prometheus-operator/image.yaml
+++ b/images/prometheus-operator/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 ref: cgr.dev/chainguard/prometheus-operator
 versions:
   - apko:

--- a/images/prometheus-postgres-exporter/image.yaml
+++ b/images/prometheus-postgres-exporter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/prometheus-redis-exporter/image.yaml
+++ b/images/prometheus-redis-exporter/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/prometheus/image.yaml
+++ b/images/prometheus/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/pulumi/image.yaml
+++ b/images/pulumi/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/python/image.yaml
+++ b/images/python/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/3.10.apko.yaml

--- a/images/rabbitmq/image.yaml
+++ b/images/rabbitmq/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/redis/image.yaml
+++ b/images/redis/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/rqlite/image.yaml
+++ b/images/rqlite/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/ruby/image.yaml
+++ b/images/ruby/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/rust/image.yaml
+++ b/images/rust/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/secrets-store-csi-driver-provider-gcp/image.yaml
+++ b/images/secrets-store-csi-driver-provider-gcp/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/secrets-store-csi-driver/image.yaml
+++ b/images/secrets-store-csi-driver/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/skaffold/image.yaml
+++ b/images/skaffold/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/source-controller/image.yaml
+++ b/images/source-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/spire-agent/image.yaml
+++ b/images/spire-agent/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/spire-server/image.yaml
+++ b/images/spire-server/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/stakater-reloader/image.yaml
+++ b/images/stakater-reloader/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/static/image.yaml
+++ b/images/static/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 excludeContact: true
 versions:
   - apko:

--- a/images/telegraf/image.yaml
+++ b/images/telegraf/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/thanos/image.yaml
+++ b/images/thanos/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/tigera-operator/image.yaml
+++ b/images/tigera-operator/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/traefik/image.yaml
+++ b/images/traefik/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/trust-manager/image.yaml
+++ b/images/trust-manager/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/vault-k8s/image.yaml
+++ b/images/vault-k8s/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: stable
 versions:
   - apko:

--- a/images/vault/image.yaml
+++ b/images/vault/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: stable
 versions:
   - apko:

--- a/images/vela-cli/image.yaml
+++ b/images/vela-cli/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/vertical-pod-autoscaler-admission-controller/image.yaml
+++ b/images/vertical-pod-autoscaler-admission-controller/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/vertical-pod-autoscaler-recommender/image.yaml
+++ b/images/vertical-pod-autoscaler-recommender/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/vertical-pod-autoscaler-updater/image.yaml
+++ b/images/vertical-pod-autoscaler-updater/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/vt/image.yaml
+++ b/images/vt/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/wait-for-it/image.yaml
+++ b/images/wait-for-it/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/wavefront-proxy/image.yaml
+++ b/images/wavefront-proxy/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/weaviate/image.yaml
+++ b/images/weaviate/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/wolfi-base/image.yaml
+++ b/images/wolfi-base/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 versions:
   - apko:
       config: configs/latest.apko.yaml

--- a/images/zookeeper/image.yaml
+++ b/images/zookeeper/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/images/zot/image.yaml
+++ b/images/zot/image.yaml
@@ -1,3 +1,6 @@
+# Opt-out of the new terraform-based release
+terraform: false
+
 status: experimental
 versions:
   - apko:

--- a/monopod/pkg/images/images.go
+++ b/monopod/pkg/images/images.go
@@ -46,7 +46,7 @@ type ImageManifest struct {
 	Ref            string                       `yaml:"ref"`
 	Status         string                       `yaml:"status"`
 	ExcludeContact bool                         `yaml:"excludeContact"`
-	Terraform      bool                         `yaml:"terraform"`
+	Terraform      *bool                        `yaml:"terraform,omitempty"`
 	Variants       []ImageManifestVariant       `yaml:"versions"`
 	Options        map[string]types.BuildOption `yaml:"options,omitempty"`
 }
@@ -322,7 +322,7 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 				melangeConfig = strings.Join(tmp, ",")
 			}
 
-			useTerraform := m.Terraform
+			useTerraform := m.Terraform == nil || *m.Terraform
 			terraformDir := ""
 			if useTerraform {
 				terraformDir = filepath.Join(constants.ImagesDirName, imageName)


### PR DESCRIPTION
The vast majority of this PR was generated with the following script:
```
#!/bin/bash -e

for x in $(find . -name 'image.yaml'); do

  cp $x $x.bak
  [ "$(grep 'terraform: ' $x)" != "" ] || cat > $x <<EOF
# Opt-out of the new terraform-based release
terraform: false

$(cat $x.bak)
EOF

  rm $x.bak
done
```

The one exception is `monopod/` where we default this field to true.
