### PR TITLE
Image: Bazel: Add file & zip binaries

### DIFF
--- a/images/bazel/configs/latest.apko.yaml
+++ b/images/bazel/configs/latest.apko.yaml
@@ -13,6 +13,8 @@ contents:
     - git
     - bazel-6
     - wolfi-baselayout
+    - zip
+    - file
 
 accounts:
   groups:


### PR DESCRIPTION
Official bazel distribution assumes presence of 2 tools in the underlying environment: 
  - zip (https://github.com/bazelbuild/bazel/blob/85dcafeba92479bee5b2cd2cb3f33f84be7de7f7/tools/test/test-setup.sh#L430)
  - file (https://github.com/bazelbuild/bazel/blob/85dcafeba92479bee5b2cd2cb3f33f84be7de7f7/tools/test/test-setup.sh#L396)
 
Neither of them is provided by `busybox`:

```
[2023-06-05 07:30:49] external/bazel_tools/tools/test/test-setup.sh: line 391: file: command not found
[2023-06-05 07:30:49] Could not create "/home/host_user/out/bazel_out/f8087e59fd95af1ae29e8fcb7ff1a3dc/sandbox/processwrapper-sandbox/26/execroot/{redacted}/bazel-out/k8-fastbuild/testlogs/projects/shared/test_module/test.outputs/outputs.zip": zip not found or failed
```

Fixes:
Address https://github.com/chainguard-images/images/issues/796. 

Related: 

### Pre-review Checklist

- [ ] **IMPORTANT: 'image-request' tag has been applied if this PR is adding any images, including new versions or variants**

#### Quality Requirements for Images PRs
The items in this checklist should all be checked in the PR with exceptions clearly documented.
The general idea is that to the extent possible, the image should be a drop-in replacement to its public counterpart.
- [ ] Image is a smaller size than its common public counterpart, or if not, the reason why should be explained
- [ ] Image should be scanned for CVEs and should return 0 or near-0 results. Exceptions should be explained.
- [ ] The software in the image should be able to be installed and work as expected
  - [ ] The image should start in a cluster
  - [ ] The application should be accessible to the user/cluster/etc. as expected
- [ ] If there is an open source helm chart provided, the image should be able to be used with the chart. If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] build for x86_64 and aarch64 if possible, document exceptions