### PR TITLE
add lint check that TF builds don't specify unnecessary fields 

### DIFF
--- a/images/bazel/configs/latest.apko.yaml
+++ b/images/bazel/configs/latest.apko.yaml
@@ -1,8 +1,4 @@
 contents:
-  repositories:
-    - https://packages.wolfi.dev/os
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - ca-certificates-bundle
     - openjdk-17
@@ -12,7 +8,6 @@ contents:
     - gcc
     - git
     - bazel-6
-    - wolfi-baselayout
     - zip
     - file
 
@@ -32,10 +27,6 @@ environment:
   JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 work-dir: /home/bazel
-
-archs:
-  - x86_64
-  - aarch64
 
 annotations:
   "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"

--- a/images/clang/configs/latest.apko.yaml
+++ b/images/clang/configs/latest.apko.yaml
@@ -1,13 +1,8 @@
 contents:
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-  repositories:
-    - https://packages.wolfi.dev/os
   packages:
     - ca-certificates-bundle
     - build-base
     - busybox
-    - wolfi-baselayout
     - clang-15
 
 paths:
@@ -30,10 +25,6 @@ accounts:
 entrypoint:
   command: /usr/bin/clang
 cmd: --help
-
-archs:
-- x86_64
-- aarch64
 
 annotations:
   "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"

--- a/images/consul/configs/latest.apko.yaml
+++ b/images/consul/configs/latest.apko.yaml
@@ -1,11 +1,6 @@
 contents:
-  repositories:
-    - https://packages.wolfi.dev/os
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - ca-certificates-bundle
-    - wolfi-baselayout
     - consul
     - su-exec
     - busybox
@@ -46,10 +41,6 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-
-archs:
-  - x86_64
-  - aarch64
 
 annotations:
   "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"

--- a/images/crane/configs/latest.apko.yaml
+++ b/images/crane/configs/latest.apko.yaml
@@ -1,11 +1,6 @@
 contents:
-  repositories:
-    - https://packages.wolfi.dev/os
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - ca-certificates-bundle
-    - wolfi-baselayout
     - crane
 
 accounts:
@@ -20,10 +15,6 @@ accounts:
 
 entrypoint:
   command: /usr/bin/crane
-
-archs:
-- x86_64
-- aarch64
 
 annotations:
   "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"

--- a/images/ko/configs/latest.apko.yaml
+++ b/images/ko/configs/latest.apko.yaml
@@ -1,8 +1,4 @@
 contents:
-  repositories:
-    - https://packages.wolfi.dev/os
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - busybox
     - build-base
@@ -22,10 +18,6 @@ accounts:
 
 entrypoint:
   command: /usr/bin/ko
-
-archs:
-  - x86_64
-  - aarch64
 
 annotations:
   "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"

--- a/images/terraform/configs/latest.apko.yaml
+++ b/images/terraform/configs/latest.apko.yaml
@@ -1,11 +1,6 @@
 contents:
-  repositories:
-    - https://packages.wolfi.dev/os
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - terraform
-    - wolfi-baselayout
     - ca-certificates-bundle
 
 annotations:
@@ -26,7 +21,3 @@ entrypoint:
   command: /usr/bin/terraform
 
 cmd: --help
-
-archs:
-  - x86_64
-  - aarch64

--- a/monopod/go.mod
+++ b/monopod/go.mod
@@ -6,7 +6,6 @@ require (
 	chainguard.dev/apko v0.8.0
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1

--- a/monopod/pkg/lint/linter.go
+++ b/monopod/pkg/lint/linter.go
@@ -49,7 +49,7 @@ func (l *Linter) Lint() (Result, error) {
 			shouldEvaluate := true
 			if len(rule.ConditionFuncs) > 0 {
 				for _, cond := range rule.ConditionFuncs {
-					if !cond() {
+					if !cond(filepath.Join(l.options.Path, pkg.Filename)) {
 						shouldEvaluate = false
 						break
 					}

--- a/monopod/pkg/lint/types.go
+++ b/monopod/pkg/lint/types.go
@@ -9,7 +9,8 @@ import (
 type Function func(types.ImageConfiguration) error
 
 // ConditionFunc is a function that checks if a rule should be executed.
-type ConditionFunc func() bool
+// dir is the path to the detected apko YAML file.
+type ConditionFunc func(path string) bool
 
 // Severity is the severity of a rule.
 type Severity string


### PR DESCRIPTION
Based on https://github.com/chainguard-images/images/pull/836

This checks that TF-based builds don't specify `repositories`, `keyring`, `archs`, or baselayout packages added by the TF layer.

Opening as draft to discuss.