### PR TITLE
fix: revert unintentional change to image_refs

### DIFF
--- a/policies/main.tf
+++ b/policies/main.tf
@@ -11,7 +11,7 @@ terraform {
   }
 }
 
-variable "image_res" {
+variable "image_refs" {
   type        = list(string)
   description = "The image references to verify against our policies."
 }


### PR DESCRIPTION
I don't know how https://github.com/chainguard-images/images/pull/844 changed this.

https://github.com/chainguard-images/images/pull/844/files#diff-fca177b110cc5fa26d2af01a0af48c27a288f9c24de2ebef21c036dfe3114cf8