### PR TITLE
Cancel concurrent PR jobs

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -1,5 +1,10 @@
 on:
   pull_request:
+
+concurrency:
+  group: presubmit-build-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   presubmit-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Given the high (potential) fanout, I suspect that this could potentially dramatically reduce the contention for runners if folks update their PRs.