### PR TITLE
change ffmpeg test to use working_dir

### DIFF
--- a/images/ffmpeg/tests/02-convert.sh
+++ b/images/ffmpeg/tests/02-convert.sh
@@ -8,7 +8,7 @@ if [[ "${IMAGE_NAME}" == "" ]]; then
 fi
 
 docker run --rm \
-    -v "${PWD}/images/ffmpeg/tests:/work" \
+    -v "${PWD}:/work" \
     -w /work \
     "${IMAGE_NAME}" \
     -i sample.mov \

--- a/images/ffmpeg/tests/main.tf
+++ b/images/ffmpeg/tests/main.tf
@@ -9,11 +9,13 @@ variable "digest" {
 }
 
 data "oci_exec_test" "help" {
-  digest = var.digest
-  script = "${path.module}/01-help.sh"
+  digest      = var.digest
+  script      = "./01-help.sh"
+  working_dir = path.module
 }
 
 data "oci_exec_test" "convert" {
-  digest = var.digest
-  script = "${path.module}/02-convert.sh"
+  digest      = var.digest
+  script      = "./02-convert.sh"
+  working_dir = path.module
 }


### PR DESCRIPTION
Tested with

```
terraform init
terraform apply -var=digest=cgr.dev/chainguard/ffmpeg@sha256:10b2e21bd859b9386779474daab1ad19700ccac006500d41dadda133b80c93c0
```

from `./images/ffmpeg/tests/`