### PR TITLE
remove extraneous env var checks

### DIFF
--- a/images/apko/tests/01-version.sh
+++ b/images/apko/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME version

--- a/images/argocd-repo-server/tests/01-help.sh
+++ b/images/argocd-repo-server/tests/01-help.sh
@@ -2,10 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
-set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/argocd/tests/01-help.sh
+++ b/images/argocd/tests/01-help.sh
@@ -2,10 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
-set +o pipefail
 docker run --rm "${IMAGE_NAME}" argocd --help

--- a/images/aspnet-runtime/tests/01-runs.sh
+++ b/images/aspnet-runtime/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --info > /dev/null

--- a/images/aws-cli/tests/01-help.sh
+++ b/images/aws-cli/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version
 docker run --rm "${IMAGE_NAME}" help
 docker run --rm "${IMAGE_NAME}" ec2 help

--- a/images/aws-ebs-csi-driver/tests/01-runs.sh
+++ b/images/aws-ebs-csi-driver/tests/01-runs.sh
@@ -2,12 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
+set +o pipefail  # We expect the command to fail, but want its output anyway.
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"
 

--- a/images/aws-efs-csi-driver/tests/01-runs.sh
+++ b/images/aws-efs-csi-driver/tests/01-runs.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version
 

--- a/images/aws-load-balancer-controller/tests/01-runs.sh
+++ b/images/aws-load-balancer-controller/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
+set +o pipefail  # We expect the command to fail, but want its output anyway.
 
-# The image can't run off without a valid kuberentes cluster, so run it and make sure it at least throws the right error.
-set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load controller config"

--- a/images/bash/tests/01-runs.sh
+++ b/images/bash/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME ls > /dev/null

--- a/images/bazel/tests/01-version.sh
+++ b/images/bazel/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/bazel/tests/02-build.sh
+++ b/images/bazel/tests/02-build.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 TMPDIR="$(mktemp -d)"
 git clone --depth=1 https://github.com/bazelbuild/examples ${TMPDIR}
 

--- a/images/buck2/tests/01-help.sh
+++ b/images/buck2/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME help

--- a/images/buck2/tests/02-build.sh
+++ b/images/buck2/tests/02-build.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 pwd
 docker run -v $(pwd)/images/buck2:/work --rm -w /work --entrypoint=/bin/bash "${IMAGE_NAME}" /work/testdata/build-test.sh
 

--- a/images/busybox/tests/01-runs.sh
+++ b/images/busybox/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME ls > /dev/null
 
 # The image runs as nonroot by default.

--- a/images/cc-dynamic/tests/01-runs.sh
+++ b/images/cc-dynamic/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" /sbin/ldconfig --help

--- a/images/cert-manager-acmesolver/tests/01-help.sh
+++ b/images/cert-manager-acmesolver/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/cert-manager-cainjector/tests/01-help.sh
+++ b/images/cert-manager-cainjector/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/cert-manager-controller/tests/01-help.sh
+++ b/images/cert-manager-controller/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/cert-manager-webhook/tests/01-help.sh
+++ b/images/cert-manager-webhook/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/clang/tests/01-version.sh
+++ b/images/clang/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --version

--- a/images/clang/tests/02-compile.sh
+++ b/images/clang/tests/02-compile.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm -v "${PWD}/images/clang:/work" $IMAGE_NAME examples/hello/main.c -o hello

--- a/images/cluster-autoscaler/tests/01-version.sh
+++ b/images/cluster-autoscaler/tests/01-version.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep autoscaler

--- a/images/cluster-autoscaler/tests/01-version.sh
+++ b/images/cluster-autoscaler/tests/01-version.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep autoscaler

--- a/images/cluster-proportional-autoscaler/tests/01-version.sh
+++ b/images/cluster-proportional-autoscaler/tests/01-version.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep cluster-proportional-autoscaler

--- a/images/cluster-proportional-autoscaler/tests/01-version.sh
+++ b/images/cluster-proportional-autoscaler/tests/01-version.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep cluster-proportional-autoscaler

--- a/images/configmap-reload/tests/01-version.sh
+++ b/images/configmap-reload/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/consul/tests/01-version.sh
+++ b/images/consul/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/coredns/tests/01-version.sh
+++ b/images/coredns/tests/01-version.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -version |
 	grep -i '^CoreDNS'

--- a/images/coredns/tests/02-nslookup-with-Corefile.sh
+++ b/images/coredns/tests/02-nslookup-with-Corefile.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 # Find an unused udp port (for nslookup - using netstat because it's provided by busybox)
 port_num=53
 i=49152

--- a/images/cosign/tests/01-help.sh
+++ b/images/cosign/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run $IMAGE_NAME help

--- a/images/crane/tests/01-version.sh
+++ b/images/crane/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/crane/tests/02-manifest.sh
+++ b/images/crane/tests/02-manifest.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" manifest cgr.dev/chainguard/static

--- a/images/crane/tests/03-digest.sh
+++ b/images/crane/tests/03-digest.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" digest cgr.dev/chainguard/static

--- a/images/crane/tests/04-ls.sh
+++ b/images/crane/tests/04-ls.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" ls cgr.dev/chainguard/static

--- a/images/crane/tests/05-config.sh
+++ b/images/crane/tests/05-config.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" config cgr.dev/chainguard/static

--- a/images/curl/tests/01-version.sh
+++ b/images/curl/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/curl/tests/02-fetch-url.sh
+++ b/images/curl/tests/02-fetch-url.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 URL="https://raw.githubusercontent.com/chainguard-images/images/main/README.md"
 docker run --rm "${IMAGE_NAME}" -v "${URL}"

--- a/images/deno/tests/01-version.sh
+++ b/images/deno/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/dex/tests/01-version.sh
+++ b/images/dex/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" dex -h

--- a/images/dex/tests/02-runs.sh
+++ b/images/dex/tests/02-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 PORT=5556
 
 URL="http://127.0.0.1:${PORT}"

--- a/images/dive/tests/01-runs.sh
+++ b/images/dive/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --version > /dev/null
 
 TMPDIR="$(mktemp -d)"

--- a/images/dotnet-runtime/tests/01-runs.sh
+++ b/images/dotnet-runtime/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --info > /dev/null

--- a/images/dotnet-sdk/tests/01-runs.sh
+++ b/images/dotnet-sdk/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME dotnet --info > /dev/null

--- a/images/envoy-ratelimit/tests/01-runs.sh
+++ b/images/envoy-ratelimit/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
+set +o pipefail  # We expect the command to fail, but want its output anyway.
 
-# The image can't run off of redis-server, so run it and make sure it at least throws the right error.
-set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "creating redis connection error"

--- a/images/envoy/tests/01-version.sh
+++ b/images/envoy/tests/01-version.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" envoy --version \
     | grep '^envoy  version:'

--- a/images/etcd/tests/01-version.sh
+++ b/images/etcd/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/external-dns/tests/01-version.sh
+++ b/images/external-dns/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/external-secrets/tests/01-version.sh
+++ b/images/external-secrets/tests/01-version.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep external-secrets

--- a/images/external-secrets/tests/01-version.sh
+++ b/images/external-secrets/tests/01-version.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep external-secrets

--- a/images/external-secrets/tests/02-helm.sh
+++ b/images/external-secrets/tests/02-helm.sh
@@ -39,7 +39,7 @@ helm install external-secrets \
     --set image.repository="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}" \
     --set image.tag="${IMAGE_TAG}" \
     --create-namespace \
-    --wait 
+    --wait
 
 cat <<EOF > cluster-secret-store.yaml
 ---
@@ -62,8 +62,6 @@ spec:
           foo: example
           other: thing
 EOF
-
-
 
 kubectl apply -f cluster-secret-store.yaml
 
@@ -92,6 +90,6 @@ EOF
 
 kubectl apply -f external-secret.yaml
 
-sleep 5 
+sleep 5
 
 kubectl get secrets secret-to-be-created -n default -o jsonpath="{.data.foo_bar}" | base64 --decode | grep HELLO1

--- a/images/ffmpeg/tests/01-help.sh
+++ b/images/ffmpeg/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/ffmpeg/tests/02-convert.sh
+++ b/images/ffmpeg/tests/02-convert.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm \
     -v "${PWD}:/work" \
     -w /work \

--- a/images/fluent-bit/tests/01-version.sh
+++ b/images/fluent-bit/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/flux/tests/01-help.sh
+++ b/images/flux/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/flux/tests/02-flux-export.sh
+++ b/images/flux/tests/02-flux-export.sh
@@ -4,9 +4,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run ${IMAGE_NAME} install --export --registry "${IMAGE_REGISTRY}"

--- a/images/gatekeeper/tests/01-version.sh
+++ b/images/gatekeeper/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/gcc-glibc/tests/01-version.sh
+++ b/images/gcc-glibc/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --version

--- a/images/git/tests/01-version.sh
+++ b/images/git/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/git/tests/02-repo-clone.sh
+++ b/images/git/tests/02-repo-clone.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CLONE_URL=${CLONE_URL:-"https://github.com/chainguard-images/.github.git"}
 
 CLONEDIR="$(mktemp -d)"

--- a/images/go/tests/01-version.sh
+++ b/images/go/tests/01-version.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME version
 docker run --rm --entrypoint sh $IMAGE_NAME -c "go version"
 docker run --rm --entrypoint '' $IMAGE_NAME go version

--- a/images/google-cloud-sdk/tests/01-version.sh
+++ b/images/google-cloud-sdk/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" gcloud --version

--- a/images/graalvm-native/tests/01-runs.sh
+++ b/images/graalvm-native/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" /sbin/ldconfig --help

--- a/images/gradle/tests/01-version.sh
+++ b/images/gradle/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/gradle/tests/02-build.sh
+++ b/images/gradle/tests/02-build.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
  docker run --rm --entrypoint "" cgr.dev/chainguard/gradle:latest sh -c "gradle init --type java-application --test-framework junit-jupiter && gradle build"

--- a/images/haproxy-ingress/tests/01-run.sh
+++ b/images/haproxy-ingress/tests/01-run.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/haproxy-ingress/tests/01-run.sh
+++ b/images/haproxy-ingress/tests/01-run.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/haproxy-ingress/tests/02-helm.sh
+++ b/images/haproxy-ingress/tests/02-helm.sh
@@ -4,25 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-function preflight() {
-  if [[ "${IMAGE_REGISTRY}" == "" ]]; then
-    echo "Must set IMAGE_REGISTRY environment variable. Exiting."
-    exit 1
-  fi
-
-  if [[ "${IMAGE_REPOSITORY}" == "" ]]; then
-    echo "Must set IMAGE_REPOSITORY environment variable. Exiting."
-    exit 1
-  fi
-
-  if [[ "${IMAGE_TAG}" == "" ]]; then
-    echo "Must set IMAGE_TAG environment variable. Exiting."
-    exit 1
-  fi
-}
-
-preflight
-
 function cleanup() {
     # Get the logs from haproxy-ingress before exiting
     kubectl describe pod --selector "app.kubernetes.io/name=haproxy-ingress"

--- a/images/haproxy/tests/01-version.sh
+++ b/images/haproxy/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -v

--- a/images/helm-chartmuseum/tests/01-helm-repo-add.sh
+++ b/images/helm-chartmuseum/tests/01-helm-repo-add.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"chartmuseum-test-$(date +%s)"}
 
 TMPDIR="$(mktemp -d)"

--- a/images/helm-controller/tests/01-starts.sh
+++ b/images/helm-controller/tests/01-starts.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/helm-controller/tests/01-starts.sh
+++ b/images/helm-controller/tests/01-starts.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/helm/tests/01-help.sh
+++ b/images/helm/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME help

--- a/images/http-echo/tests/01-version.sh
+++ b/images/http-echo/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -version

--- a/images/http-echo/tests/02-echo.sh
+++ b/images/http-echo/tests/02-echo.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER=$(docker run -p ${FREE_PORT}:8080 -d --rm "${IMAGE_NAME}" -listen=:8080 -text="hello world")
 curl localhost:${FREE_PORT} | grep "hello world"
 docker kill $CONTAINER

--- a/images/hugo/tests/01-version.sh
+++ b/images/hugo/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/hugo/tests/02-quickstart.sh
+++ b/images/hugo/tests/02-quickstart.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # This test is designed to emulate the Hugo Quickstart application
 # which is outlined here:
 # https://gohugo.io/getting-started/quick-start/#commands

--- a/images/influxdb/tests/01-version.sh
+++ b/images/influxdb/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" influxd version

--- a/images/influxdb/tests/02-setup.sh
+++ b/images/influxdb/tests/02-setup.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"influx-setup-test-$(date +%s)"}
 docker run -d -p 8086:8086 --rm --name ${CONTAINER_NAME} "${IMAGE_NAME}"
 

--- a/images/jdk/tests/01-version.sh
+++ b/images/jdk/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" javac -version

--- a/images/jdk/tests/02-hello-world.sh
+++ b/images/jdk/tests/02-hello-world.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 cat > HelloWorld.java <<EOF
 class HelloWorld {
   public static void main(String[] args) {

--- a/images/jenkins/tests/01-version.sh
+++ b/images/jenkins/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/jre/tests/01-version.sh
+++ b/images/jre/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -version

--- a/images/k8s-sidecar/tests/01-runs.sh
+++ b/images/k8s-sidecar/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image needs to be in a cluster to run, so we'll look for the right error message.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "Starting collector"

--- a/images/k8s-sidecar/tests/01-runs.sh
+++ b/images/k8s-sidecar/tests/01-runs.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image needs to be in a cluster to run, so we'll look for the right error message.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "Starting collector"

--- a/images/k8sgpt-operator/tests/01-runs.sh
+++ b/images/k8sgpt-operator/tests/01-runs.sh
@@ -2,5 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm $IMAGE_NAME  2>&1 | grep "unable to load in-cluster config"

--- a/images/k8sgpt-operator/tests/01-runs.sh
+++ b/images/k8sgpt-operator/tests/01-runs.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 set +o pipefail
 docker run --rm $IMAGE_NAME  2>&1 | grep "unable to load in-cluster config"

--- a/images/k8sgpt/tests/01-runs.sh
+++ b/images/k8sgpt/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --help > /dev/null

--- a/images/kafka/tests/01-version.sh
+++ b/images/kafka/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/karpenter/tests/01-runs.sh
+++ b/images/karpenter/tests/01-runs.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep karpenter

--- a/images/karpenter/tests/01-runs.sh
+++ b/images/karpenter/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep karpenter

--- a/images/keda-adapter/tests/01-help.sh
+++ b/images/keda-adapter/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep keda

--- a/images/keda-adapter/tests/01-help.sh
+++ b/images/keda-adapter/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep keda

--- a/images/keda-admission-webhooks/tests/01-help.sh
+++ b/images/keda-admission-webhooks/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep keda

--- a/images/keda-admission-webhooks/tests/01-help.sh
+++ b/images/keda-admission-webhooks/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep keda

--- a/images/keda/tests/01-help.sh
+++ b/images/keda/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep keda

--- a/images/keda/tests/01-help.sh
+++ b/images/keda/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep keda

--- a/images/ko/tests/01-version.sh
+++ b/images/ko/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/ko/tests/02-build.sh
+++ b/images/ko/tests/02-build.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm \
     -v "${PWD}/images/ko/example:/work" \
     --workdir=/work \

--- a/images/kube-bench/tests/01-version.sh
+++ b/images/kube-bench/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/kube-bench/tests/02-run.sh
+++ b/images/kube-bench/tests/02-run.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 app_name="kube-bench"
 tmp="$(mktemp -d 'kube-bench-test-XXXXXX')"
 

--- a/images/kube-downscaler/tests/01-help.sh
+++ b/images/kube-downscaler/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/kube-downscaler/tests/02-deploy.sh
+++ b/images/kube-downscaler/tests/02-deploy.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 function cleanup() {
 	# Print debug logs and status
 	kubectl get pods

--- a/images/kube-state-metrics/tests/01-version.sh
+++ b/images/kube-state-metrics/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/kubectl/tests/01-help.sh
+++ b/images/kubectl/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME help

--- a/images/kubectl/tests/02-use.sh
+++ b/images/kubectl/tests/02-use.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 # Get the kind kubeconfig
 # Create a kubeconfig with admin access to kind (from inside docker network)
 

--- a/images/kubernetes-csi-external-attacher/tests/01-version.sh
+++ b/images/kubernetes-csi-external-attacher/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/kubernetes-csi-external-attacher/tests/02-deploy.sh
+++ b/images/kubernetes-csi-external-attacher/tests/02-deploy.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 function TEST_basic_kubectl_apply() {
   tmpdir=$(mktemp -d); cd "${tmpdir}"
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/deployment.yaml
@@ -16,9 +11,9 @@ function TEST_basic_kubectl_apply() {
   sed -i "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:.*|${IMAGE_NAME}|g" deployment.yaml
 
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/rbac.yaml
-  
+
   kubectl apply -f ${tmpdir}
-  
+
   # Wait for the update to apply
   sleep 3
 

--- a/images/kubernetes-csi-external-provisioner/tests/01-help.sh
+++ b/images/kubernetes-csi-external-provisioner/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 set +o pipefail
 
 # The log should show an error because we're not in a k8s cluster, but the container should get to this point

--- a/images/kubernetes-csi-external-provisioner/tests/01-help.sh
+++ b/images/kubernetes-csi-external-provisioner/tests/01-help.sh
@@ -2,7 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
 
-# The log should show an error because we're not in a k8s cluster, but the container should get to this point
 docker run --rm $IMAGE_NAME  2>&1 | grep "Failed to create config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"

--- a/images/kubernetes-csi-external-provisioner/tests/02-deploy.sh
+++ b/images/kubernetes-csi-external-provisioner/tests/02-deploy.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 function cleanup() {
 	# Print debug logs and status
 	kubectl get pods

--- a/images/kubernetes-csi-external-resizer/tests/01-version.sh
+++ b/images/kubernetes-csi-external-resizer/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/kubernetes-csi-external-resizer/tests/02-deploy.sh
+++ b/images/kubernetes-csi-external-resizer/tests/02-deploy.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 function TEST_basic_kubectl_apply() {
   tmpdir=$(mktemp -d); cd "${tmpdir}"
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/deploy/kubernetes/deployment.yaml
@@ -16,9 +11,9 @@ function TEST_basic_kubectl_apply() {
   sed -i "s|gcr.io/k8s-staging-sig-storage/csi-resizer:canary|${IMAGE_NAME}|g" deployment.yaml
 
   curl -sLO https://raw.githubusercontent.com/kubernetes-csi/external-resizer/master/deploy/kubernetes/rbac.yaml
-  
+
   kubectl apply -f ${tmpdir}
-  
+
   # Wait for the update to apply
   sleep 3
 

--- a/images/kubernetes-csi-external-snapshot-controller/tests/01-help.sh
+++ b/images/kubernetes-csi-external-snapshot-controller/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/kubernetes-csi-external-snapshot-controller/tests/01-help.sh
+++ b/images/kubernetes-csi-external-snapshot-controller/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/kubernetes-csi-external-snapshot-validation-webhook/tests/01-help.sh
+++ b/images/kubernetes-csi-external-snapshot-validation-webhook/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/kubernetes-csi-external-snapshotter/tests/01-help.sh
+++ b/images/kubernetes-csi-external-snapshotter/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/kubernetes-csi-external-snapshotter/tests/01-help.sh
+++ b/images/kubernetes-csi-external-snapshotter/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/kubernetes-csi-livenessprobe/tests/01-help.sh
+++ b/images/kubernetes-csi-livenessprobe/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/kubernetes-csi-node-driver-registrar/tests/01-version.sh
+++ b/images/kubernetes-csi-node-driver-registrar/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/kubernetes-dashboard-metrics-scraper/tests/01-help.sh
+++ b/images/kubernetes-dashboard-metrics-scraper/tests/01-help.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 set +o pipefail
 docker run --rm $IMAGE_NAME  2>&1 | grep "Unable to generate a client config"

--- a/images/kubernetes-dashboard-metrics-scraper/tests/01-help.sh
+++ b/images/kubernetes-dashboard-metrics-scraper/tests/01-help.sh
@@ -2,5 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm $IMAGE_NAME  2>&1 | grep "Unable to generate a client config"

--- a/images/kubernetes-dashboard/tests/01-help.sh
+++ b/images/kubernetes-dashboard/tests/01-help.sh
@@ -2,5 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm $IMAGE_NAME  2>&1 | grep "Starting overwatch"

--- a/images/kubernetes-dashboard/tests/01-help.sh
+++ b/images/kubernetes-dashboard/tests/01-help.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 set +o pipefail
 docker run --rm $IMAGE_NAME  2>&1 | grep "Starting overwatch"

--- a/images/kubernetes-dashboard/tests/02-deploy.sh
+++ b/images/kubernetes-dashboard/tests/02-deploy.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 function cleanup() {
     # Print debug logs and status
     kubectl get pods --namespace kubernetes-dashboard

--- a/images/kubernetes-ingress-defaultbackend/tests/01-help.sh
+++ b/images/kubernetes-ingress-defaultbackend/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h

--- a/images/kubernetes-ingress-defaultbackend/tests/02-runs.sh
+++ b/images/kubernetes-ingress-defaultbackend/tests/02-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 set +o pipefail
 
 URL="http://127.0.0.1:${FREE_PORT}"

--- a/images/kubernetes-ingress-defaultbackend/tests/02-runs.sh
+++ b/images/kubernetes-ingress-defaultbackend/tests/02-runs.sh
@@ -2,8 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-set +o pipefail
-
 URL="http://127.0.0.1:${FREE_PORT}"
 
 docker run --rm -d -p "$FREE_PORT:8080" $IMAGE_NAME

--- a/images/kubewatch/tests/01-help.sh
+++ b/images/kubewatch/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/kustomize-controller/tests/01-starts.sh
+++ b/images/kustomize-controller/tests/01-starts.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/kustomize-controller/tests/01-starts.sh
+++ b/images/kustomize-controller/tests/01-starts.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/kyverno-background-controller/tests/01-help-tests.sh
+++ b/images/kyverno-background-controller/tests/01-help-tests.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/kyverno-cleanup-controller/tests/01-help-tests.sh
+++ b/images/kyverno-cleanup-controller/tests/01-help-tests.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/kyverno-cli/tests/01-version.sh
+++ b/images/kyverno-cli/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/kyverno-reports-controller/tests/01-help-tests.sh
+++ b/images/kyverno-reports-controller/tests/01-help-tests.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/kyverno/tests/01-help-tests.sh
+++ b/images/kyverno/tests/01-help-tests.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/kyvernopre/tests/01-help-tests.sh
+++ b/images/kyvernopre/tests/01-help-tests.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/mariadb/tests/01-version.sh
+++ b/images/mariadb/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/mariadb/tests/02-runs.sh
+++ b/images/mariadb/tests/02-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # Start up the mariadb container in the background
 docker run -d --name mariadb -e MYSQL_ROOT_PASSWORD=secret "${IMAGE_NAME}"
 sleep 5

--- a/images/maven/tests/01-version.sh
+++ b/images/maven/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/mdbook/tests/01-help.sh
+++ b/images/mdbook/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/mdbook/tests/02-build-website.sh
+++ b/images/mdbook/tests/02-build-website.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm \
     -v "${PWD}":/work \
     -w /work \

--- a/images/melange/tests/01-version.sh
+++ b/images/melange/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME version

--- a/images/memcached-exporter/tests/01-version.sh
+++ b/images/memcached-exporter/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/memcached/tests/01-version.sh
+++ b/images/memcached/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/metacontroller/tests/01-version.sh
+++ b/images/metacontroller/tests/01-version.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep metacontroller

--- a/images/metacontroller/tests/01-version.sh
+++ b/images/metacontroller/tests/01-version.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep metacontroller

--- a/images/metacontroller/tests/02-helm.sh
+++ b/images/metacontroller/tests/02-helm.sh
@@ -196,7 +196,7 @@ EOF
 
 kubectl -n hello apply -f hello.yaml
 
-# Sleep  theh ello controller kicks in
+# Sleep the hello controller kicks in
 sleep 30
 
 kubectl get pods chainguard --output=jsonpath='{.status.phase}' -n hello | grep "Succeeded"

--- a/images/metacontroller/tests/02-helm.sh
+++ b/images/metacontroller/tests/02-helm.sh
@@ -144,8 +144,6 @@ EOF
 
 kubectl -n hello create configmap hello-controller --from-file=sync.py
 
-
-
 cat <<EOF > webhook.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -198,7 +196,7 @@ EOF
 
 kubectl -n hello apply -f hello.yaml
 
-# Sleep  theh ello controller kicks in 
+# Sleep  theh ello controller kicks in
 sleep 30
 
 kubectl get pods chainguard --output=jsonpath='{.status.phase}' -n hello | grep "Succeeded"

--- a/images/metrics-server/tests/01-runs.sh
+++ b/images/metrics-server/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --version

--- a/images/minio-client/tests/01-version.sh
+++ b/images/minio-client/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/minio/tests/01-version.sh
+++ b/images/minio/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/nats/tests/01-version.sh
+++ b/images/nats/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/nats/tests/02-healthy.sh
+++ b/images/nats/tests/02-healthy.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"nats-${FREE_PORT}"}
 
 docker run -p "${FREE_PORT}:8222" -d --name $CONTAINER_NAME $IMAGE_NAME

--- a/images/nats/tests/03-works.sh
+++ b/images/nats/tests/03-works.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"nats-${FREE_PORT}"}
 
 docker run -d --name $CONTAINER_NAME $IMAGE_NAME

--- a/images/netcat/tests/01-help.sh
+++ b/images/netcat/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run $IMAGE_NAME -h

--- a/images/netcat/tests/02-test-open-port.sh
+++ b/images/netcat/tests/02-test-open-port.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run $IMAGE_NAME -zv google.com 443 2>&1 | grep "443 port \[tcp/https\] succeeded"

--- a/images/newrelic-fluent-bit-output/tests/01-version.sh
+++ b/images/newrelic-fluent-bit-output/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/newrelic-infrastructure-bundle/tests/01-version.sh
+++ b/images/newrelic-infrastructure-bundle/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" /usr/bin/newrelic-infra --version | grep "New Relic Infrastructure Agent"

--- a/images/newrelic-k8s-events-forwarder/tests/01-help.sh
+++ b/images/newrelic-k8s-events-forwarder/tests/01-help.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
 
 docker run --rm "${IMAGE_NAME}" | grep "no license key"
 docker run --rm "${IMAGE_NAME}" newrelic-infra | grep "New Relic Infrastructure Agent"

--- a/images/newrelic-k8s-events-forwarder/tests/01-help.sh
+++ b/images/newrelic-k8s-events-forwarder/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 set +o pipefail
 
 docker run --rm "${IMAGE_NAME}" | grep "no license key"

--- a/images/newrelic-prometheus-configurator/tests/01-help.sh
+++ b/images/newrelic-prometheus-configurator/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/nginx/tests/01-version.sh
+++ b/images/nginx/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm --entrypoint /usr/sbin/nginx "${IMAGE_NAME}" -v

--- a/images/nginx/tests/02-welcome-page.sh
+++ b/images/nginx/tests/02-welcome-page.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"nginx-smoketest-$(date +%s)"}
 
 docker run -p 8080:8080 -d --name $CONTAINER_NAME $IMAGE_NAME

--- a/images/nginx/tests/03-shutdown.sh
+++ b/images/nginx/tests/03-shutdown.sh
@@ -2,16 +2,11 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # We want nginx to shutdown gracefully. It should get the SIGQUIT signal.
 LOGFILE=$(mktemp)
 ID=$(docker run --rm -d $IMAGE_NAME)
 docker attach $ID 2> $LOGFILE &
 sleep 5
-docker stop $ID 
+docker stop $ID
 grep "SIGQUIT" $LOGFILE
-grep "gracefully shutting down" $LOGFILE 
+grep "gracefully shutting down" $LOGFILE

--- a/images/nodetaint/tests/01-runs.sh
+++ b/images/nodetaint/tests/01-runs.sh
@@ -2,10 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
+set +o pipefail  # We expect the command to fail, but want its output anyway.
 
-set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep nodetaint

--- a/images/notification-controller/tests/01-starts.sh
+++ b/images/notification-controller/tests/01-starts.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/notification-controller/tests/01-starts.sh
+++ b/images/notification-controller/tests/01-starts.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/nri-kube-events/tests/01-help.sh
+++ b/images/nri-kube-events/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep nri-kube-events

--- a/images/nri-kubernetes/tests/01-help.sh
+++ b/images/nri-kubernetes/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep nri-kubernetes

--- a/images/nri-kubernetes/tests/01-help.sh
+++ b/images/nri-kubernetes/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep nri-kubernetes

--- a/images/nri-prometheus/tests/01-version.sh
+++ b/images/nri-prometheus/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep "nri-prometheus"

--- a/images/ntpd-rs/tests/01-help.sh
+++ b/images/ntpd-rs/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help

--- a/images/nvidia-device-plugin/tests/01-version.sh
+++ b/images/nvidia-device-plugin/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/oauth2-proxy/tests/01-version.sh
+++ b/images/oauth2-proxy/tests/01-version.sh
@@ -3,9 +3,4 @@
 #set -o errexit -o nounset -o errtrace -o pipefail -x
 set -o errexit -o nounset -o errtrace -o pipefail
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version | grep -i '^oauth2-proxy'

--- a/images/oauth2-proxy/tests/02-intercept.sh
+++ b/images/oauth2-proxy/tests/02-intercept.sh
@@ -3,11 +3,6 @@
 #set -o errexit -o nounset -o errtrace -o pipefail -x
 set -o errexit -o nounset -o errtrace -o pipefail
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # A complete e2e test would need GitHub (or other provider) account, trusted domain, and  oauth app.
 # This is a heavy setup lift (and IMO shouldn't be in the scope of one single test anyway) so here
 # I am testing only that the proxy does in fact intercept a call to a specified endpoint to demand

--- a/images/oidc-discovery-provider/tests/01-version.sh
+++ b/images/oidc-discovery-provider/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/openai/tests/01-help.sh
+++ b/images/openai/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME

--- a/images/opensearch/tests/01-version.sh
+++ b/images/opensearch/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm --entrypoint=/usr/bin/opensearch "${IMAGE_NAME}" --version

--- a/images/opensearch/tests/02-server.sh
+++ b/images/opensearch/tests/02-server.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"opensearch-smoketest-${FREE_PORT}"}
 
 docker run -p ${FREE_PORT}:9200 -e "discovery.type=single-node" -d --name $CONTAINER_NAME $IMAGE_NAME

--- a/images/paranoia/tests/01-version.sh
+++ b/images/paranoia/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep "Paranoia is a command-line tool"

--- a/images/paranoia/tests/02-list-certs.sh
+++ b/images/paranoia/tests/02-list-certs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" export alpine:latest

--- a/images/php/tests/01-version.sh
+++ b/images/php/tests/01-version.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
-
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
 IMAGE_TAG_SUFFIX=${IMAGE_TAG_SUFFIX:-""}
 
 docker run --entrypoint php --rm "${IMAGE_NAME}" --version

--- a/images/postgres/tests/01-version.sh
+++ b/images/postgres/tests/01-version.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version \
     | grep '^postgres (PostgreSQL) '

--- a/images/postgres/tests/02-query.sh
+++ b/images/postgres/tests/02-query.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"postgres-$(date +%s)"}
 
 docker run --network=host -e POSTGRES_PASSWORD=password -d --name $CONTAINER_NAME $IMAGE_NAME

--- a/images/postgres/tests/03-locale.sh
+++ b/images/postgres/tests/03-locale.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"postgres-$(date +%s)"}
 
 docker run -e POSTGRES_PASSWORD=password -d --name $CONTAINER_NAME $IMAGE_NAME

--- a/images/powershell/tests/01-runs.sh
+++ b/images/powershell/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME -NoLogo -Command 'Get-Host' > /dev/null

--- a/images/prometheus-alertmanager/tests/01-version.sh
+++ b/images/prometheus-alertmanager/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus-cloudwatch-exporter/tests/01-runs.sh
+++ b/images/prometheus-cloudwatch-exporter/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run -d -v ${PWD}/images/prometheus-cloudwatch-exporter:/config -p "${FREE_PORT}:9106" --rm $IMAGE_NAME /config/example/example.yml
 sleep 5
 curl localhost:${FREE_PORT}/metrics | grep cloudwatch_exporter_build_info

--- a/images/prometheus-config-reloader/tests/01-smoke.sh
+++ b/images/prometheus-config-reloader/tests/01-smoke.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus-elasticsearch-exporter/tests/01-version.sh
+++ b/images/prometheus-elasticsearch-exporter/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus-mysqld-exporter/tests/01-version.sh
+++ b/images/prometheus-mysqld-exporter/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus-node-exporter/tests/01-version.sh
+++ b/images/prometheus-node-exporter/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus-node-exporter/tests/02-runs.sh
+++ b/images/prometheus-node-exporter/tests/02-runs.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 kubectl run prometheus-node-exporter --image=${IMAGE_NAME}
 kubectl wait --for=condition=ready pod prometheus-node-exporter
 

--- a/images/prometheus-operator/tests/01-smoke.sh
+++ b/images/prometheus-operator/tests/01-smoke.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 #
 # kill_if_running checks to see if a container needs to be killed before
 # killing it.

--- a/images/prometheus-postgres-exporter/tests/01-version.sh
+++ b/images/prometheus-postgres-exporter/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus-redis-exporter/tests/01-version.sh
+++ b/images/prometheus-redis-exporter/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus-redis-exporter/tests/02-install.sh
+++ b/images/prometheus-redis-exporter/tests/02-install.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 cat >deploy.yaml <<EOF
 ---
 apiVersion: v1

--- a/images/prometheus/tests/01-version.sh
+++ b/images/prometheus/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/prometheus/tests/02-healthy.sh
+++ b/images/prometheus/tests/02-healthy.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"prometheus-smoketest-$(date +%s)"}
 
 docker run -p 9090:9090 -d --name $CONTAINER_NAME $IMAGE_NAME --config.file=/etc/prometheus/prometheus.yml

--- a/images/pulumi/tests/01-runs.sh
+++ b/images/pulumi/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CLONE_URL=${CLONE_URL:-"https://github.com/chainguard-images/.github.git"}
 
 docker run --rm $IMAGE_NAME version

--- a/images/pulumi/tests/02-k8s-install-all-languages.sh
+++ b/images/pulumi/tests/02-k8s-install-all-languages.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 ONLY_TEST_LANG="${ONLY_TEST_LANG:-}"
 
 KIND_IP="$(docker ps | grep 'control-plane' | awk '{print $1}' | xargs docker inspect | jq -r '.[0].NetworkSettings.Networks["kind"].IPAddress')"
@@ -49,7 +44,7 @@ function pulumi_up {
     name="${2}"
     pulumi_docker_exec "${lang}" "${name}" "login file://."
     pulumi_docker_exec "${lang}" "${name}" "stack init --non-interactive --stack ${name}"
-    
+
     # Specifically in the case of nodejs, preinstall the depends to prevent mystery error in CI:
     #
     #   error: It looks like the Pulumi SDK has not been installed. Have you run npm install or yarn install?

--- a/images/python/tests/01-version.sh
+++ b/images/python/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/python/tests/02-check-pip.sh
+++ b/images/python/tests/02-check-pip.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm --entrypoint /usr/bin/pip "${IMAGE_NAME}" --version

--- a/images/python/tests/03-check-numpy.sh
+++ b/images/python/tests/03-check-numpy.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run -u root --entrypoint sh --rm "${IMAGE_NAME}" -c "pip install numpy; python -c 'import numpy; print(numpy.__version__)'"

--- a/images/rabbitmq/tests/01-version.sh
+++ b/images/rabbitmq/tests/01-version.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # TODO: no way to get version from rabbitmq-server?
 docker run --rm --entrypoint rabbitmqctl "${IMAGE_NAME}" version

--- a/images/rabbitmq/tests/02-perf.sh
+++ b/images/rabbitmq/tests/02-perf.sh
@@ -2,21 +2,16 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-	echo "Must set IMAGE_NAME environment variable. Exiting."
-	exit 1
-fi
-
 cat >dev.conf <<EOF
 ## DEFAULT SETTINGS ARE NOT MEANT TO BE TAKEN STRAIGHT INTO PRODUCTION
 ## see https://www.rabbitmq.com/configure.html for further information
 ## on configuring RabbitMQ
-                                                                                                                                                               
+
 ## allow access to the guest user from anywhere on the network
 ## https://www.rabbitmq.com/access-control.html#loopback-users
 ## https://www.rabbitmq.com/production-checklist.html#users
 loopback_users.guest = false
-                                                                                                                                                               
+
 ## Send all logs to stdout/TTY. Necessary to see logs when running via
 ## a container
 log.console = true

--- a/images/redis/tests/01-version.sh
+++ b/images/redis/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/redis/tests/02-server.sh
+++ b/images/redis/tests/02-server.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"redis-smoketest-$(date +%s)"}
 
 # Run two containers on the same network (just use host for simplicity)

--- a/images/rqlite/tests/01-version.sh
+++ b/images/rqlite/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/ruby/tests/01-version.sh
+++ b/images/ruby/tests/01-version.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}"
 docker run --rm --entrypoint irb "${IMAGE_NAME}" -v

--- a/images/rust/tests/01-version.sh
+++ b/images/rust/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/rust/tests/02-dev.sh
+++ b/images/rust/tests/02-dev.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm --entrypoint rustup "${IMAGE_NAME}" --version

--- a/images/secrets-store-csi-driver-provider-gcp/tests/01-runs.sh
+++ b/images/secrets-store-csi-driver-provider-gcp/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # Help exits with 1 for some reason, so disable pipefail
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep secrets-store-csi-driver-provider-gcp

--- a/images/secrets-store-csi-driver-provider-gcp/tests/01-runs.sh
+++ b/images/secrets-store-csi-driver-provider-gcp/tests/01-runs.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# Help exits with 1 for some reason, so disable pipefail
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep secrets-store-csi-driver-provider-gcp

--- a/images/secrets-store-csi-driver/tests/01-runs.sh
+++ b/images/secrets-store-csi-driver/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # Help exits with 1 for some reason, so disable pipefail
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep secrets-store-csi

--- a/images/secrets-store-csi-driver/tests/01-runs.sh
+++ b/images/secrets-store-csi-driver/tests/01-runs.sh
@@ -2,8 +2,8 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# Help exits with 1 for some reason, so disable pipefail
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep secrets-store-csi
 
 # The image must have mount installed.

--- a/images/skaffold/tests/01-version.sh
+++ b/images/skaffold/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/source-controller/tests/01-starts.sh
+++ b/images/source-controller/tests/01-starts.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/source-controller/tests/01-starts.sh
+++ b/images/source-controller/tests/01-starts.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/spire-agent/tests/01-version.sh
+++ b/images/spire-agent/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm --entrypoint=/usr/bin/spire-agent "${IMAGE_NAME}" --version

--- a/images/spire-server/tests/01-version.sh
+++ b/images/spire-server/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm --entrypoint=/usr/bin/spire-server "${IMAGE_NAME}" --version

--- a/images/stakater-reloader/tests/01-help.sh
+++ b/images/stakater-reloader/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "Unable to create Kubernetes client error"

--- a/images/stakater-reloader/tests/01-help.sh
+++ b/images/stakater-reloader/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The help command exists with a non-zero exit code, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "Unable to create Kubernetes client error"

--- a/images/static/tests/01-multi-dockerfile-build.sh
+++ b/images/static/tests/01-multi-dockerfile-build.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 cd "$(dirname ${BASH_SOURCE[0]})/.."
 
 for lang in c golang rust; do

--- a/images/telegraf/tests/01-version.sh
+++ b/images/telegraf/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/terraform/tests/01-version.sh
+++ b/images/terraform/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/terraform/tests/02-plan.sh
+++ b/images/terraform/tests/02-plan.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 TMPDIR="$(mktemp -d)"
 chmod go+wrx "${TMPDIR}"
 cd "${TMPDIR}"

--- a/images/thanos/tests/01-version.sh
+++ b/images/thanos/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/tigera-operator/tests/01-version.sh
+++ b/images/tigera-operator/tests/01-version.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep "Usage of /usr/bin/operator"

--- a/images/tigera-operator/tests/01-version.sh
+++ b/images/tigera-operator/tests/01-version.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image fails if it can't connect to the k8s API, so we need to just make sure it fails correctly.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" --help 2>&1 | grep "Usage of /usr/bin/operator"

--- a/images/traefik/tests/01-version.sh
+++ b/images/traefik/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version

--- a/images/trust-manager/tests/01-version.sh
+++ b/images/trust-manager/tests/01-version.sh
@@ -2,10 +2,5 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "failed to create manager"

--- a/images/trust-manager/tests/01-version.sh
+++ b/images/trust-manager/tests/01-version.sh
@@ -2,5 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "failed to create manager"

--- a/images/vault-k8s/tests/01-version.sh
+++ b/images/vault-k8s/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/vault/tests/01-version.sh
+++ b/images/vault/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --cap-add IPC_LOCK --rm "${IMAGE_NAME}" --version

--- a/images/vault/tests/02-runs.sh
+++ b/images/vault/tests/02-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # Run the vault container in the background and make sure it works using the API
 docker run -d --name vault --cap-add IPC_LOCK -p 8200:8200 "${IMAGE_NAME}" server -dev -dev-root-token-id=root
 

--- a/images/vela-cli/tests/01-runs.sh
+++ b/images/vela-cli/tests/01-runs.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm $IMAGE_NAME --help > /dev/null

--- a/images/vertical-pod-autoscaler-admission-controller/tests/01-help.sh
+++ b/images/vertical-pod-autoscaler-admission-controller/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/vertical-pod-autoscaler-admission-controller/tests/01-help.sh
+++ b/images/vertical-pod-autoscaler-admission-controller/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/vertical-pod-autoscaler-recommender/tests/01-help.sh
+++ b/images/vertical-pod-autoscaler-recommender/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/vertical-pod-autoscaler-recommender/tests/01-help.sh
+++ b/images/vertical-pod-autoscaler-recommender/tests/01-help.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/vertical-pod-autoscaler-updater/tests/01-help.sh
+++ b/images/vertical-pod-autoscaler-updater/tests/01-help.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image can't run off of k8s, so run it and make sure it at least throws the right error.
 set +o pipefail
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"

--- a/images/vertical-pod-autoscaler-updater/tests/01-help.sh
+++ b/images/vertical-pod-autoscaler-updater/tests/01-help.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image can't run off of k8s, so run it and make sure it at least throws the right error.
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"
 

--- a/images/vt/tests/01-version.sh
+++ b/images/vt/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" version | grep vt-cli

--- a/images/wait-for-it/tests/01-ping-google.sh
+++ b/images/wait-for-it/tests/01-ping-google.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" -h google.com -p 80

--- a/images/wavefront-proxy/tests/01-version.sh
+++ b/images/wavefront-proxy/tests/01-version.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # The image fails to connect without a valid WAVEFRONT_API_TOKEN and WAVEFRONT_URL
 set +o pipefail
 docker run --rm  -e WAVEFRONT_URL=https://example.com/api -e WAVEFRONT_TOKEN="test" "${IMAGE_NAME}"  2>&1 | grep "Wavefront Proxy version"

--- a/images/wavefront-proxy/tests/01-version.sh
+++ b/images/wavefront-proxy/tests/01-version.sh
@@ -2,6 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# The image fails to connect without a valid WAVEFRONT_API_TOKEN and WAVEFRONT_URL
-set +o pipefail
+set +o pipefail  # We expect the command to fail, but want its output anyway.
+
 docker run --rm  -e WAVEFRONT_URL=https://example.com/api -e WAVEFRONT_TOKEN="test" "${IMAGE_NAME}"  2>&1 | grep "Wavefront Proxy version"

--- a/images/weaviate/tests/01-help.sh
+++ b/images/weaviate/tests/01-help.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --help | grep "Cloud-native, modular vector database"

--- a/images/weaviate/tests/02-install.sh
+++ b/images/weaviate/tests/02-install.sh
@@ -4,11 +4,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 helm repo add weaviate https://weaviate.github.io/weaviate-helm
 wget https://raw.githubusercontent.com/weaviate/weaviate-helm/v16.2.0/weaviate/values.yaml
 

--- a/images/wolfi-base/tests/01-runs.sh
+++ b/images/wolfi-base/tests/01-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 # Running with and without a command doesn't error
 docker run --rm $IMAGE_NAME
 docker run --rm $IMAGE_NAME apk --version | grep "apk-tools .*"

--- a/images/zookeeper/tests/01-version.sh
+++ b/images/zookeeper/tests/01-version.sh
@@ -2,9 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 docker run --rm "${IMAGE_NAME}" --version

--- a/images/zookeeper/tests/02-runs.sh
+++ b/images/zookeeper/tests/02-runs.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CONTAINER_NAME=${CONTAINER_NAME:-"zookeeper-status-$(date +%s)"}
 docker run -d --rm --name ${CONTAINER_NAME} "${IMAGE_NAME}"
 

--- a/images/zot/tests/01-push-pull-image.sh
+++ b/images/zot/tests/01-push-pull-image.sh
@@ -2,11 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-if [[ "${IMAGE_NAME}" == "" ]]; then
-    echo "Must set IMAGE_NAME environment variable. Exiting."
-    exit 1
-fi
-
 CRANE_IMAGE_NAME=${CRANE_IMAGE_NAME:-"cgr.dev/chainguard/crane:latest"}
 CRANE_CP_IMAGE_NAME=${CRANE_CP_IMAGE_NAME:-"cgr.dev/chainguard/wolfi-base:latest"}
 CONTAINER_NAME=${CONTAINER_NAME:-"zot-test-${FREE_PORT}"}


### PR DESCRIPTION
We already `set -o nounset` which fails when the variable is used but is not set. Removing this boilerplate before it can be copypasted again.