### PR TITLE
Add bash as default cmd.

### DIFF
--- a/images/bash/configs/latest.apko.yaml
+++ b/images/bash/configs/latest.apko.yaml
@@ -7,6 +7,8 @@ contents:
 entrypoint:
   command: /bin/bash -c
 
+cmd: bash
+
 annotations:
   "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
   "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/bash/

--- a/images/bash/tests/01-runs.sh
+++ b/images/bash/tests/01-runs.sh
@@ -3,3 +3,5 @@
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 docker run --rm $IMAGE_NAME ls > /dev/null
+#shouldn't error if run without cmd
+docker run --rm $IMAGE_NAME


### PR DESCRIPTION
Update to make `docker run -it cgr.dev/chainguard/bash` work as expected.

