### PR TITLE
Remove spurious EXPERIMENTAL reference to telegraf README

### DIFF
--- a/images/telegraf/README.md
+++ b/images/telegraf/README.md
@@ -13,7 +13,7 @@
 ---
 <!--monopod:end-->
 
-Minimal image with Telegraf. **EXPERIMENTAL**
+Minimal image with Telegraf.
 
 ## Get It!
 


### PR DESCRIPTION
Telegraf is shown as stable on the [images](https://github.com/chainguard-images/images) page but the `README` still notes it as being EXPERIMENTAL. Removing reference in the `README`

- [x] Provide a README file, follow the [README template](readme-template.md) to include variants, tags, and usage examples
