### PR TITLE
Drop `apkoBuildOptions`

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -58,7 +58,6 @@ runs:
         package-append: ${{ inputs.apkoPackageAppend }}
         additional-tags: ${{ inputs.apkoAdditionalTags }}
         archs: x86_64 # To speed up CI, just build for x86_64
-        build-options: ${{ inputs.apkoBuildOptions }}
 
     - name: Smoke test
       id: smoketest

--- a/.github/actions/release-image/action.yml
+++ b/.github/actions/release-image/action.yml
@@ -121,7 +121,6 @@ runs:
         package-version-tag-stem: true
         package-version-tag-prefix: ${{ inputs.apkoPackageVersionTagPrefix }}
         stage_tags: apko.tags
-        build-options: ${{ inputs.apkoBuildOptions }}
         sbom-attest: true
         slsa-attest: ${{ inputs.slsaProvenanceCacheKey == '' }}
         generic-user: ${{ steps.cgrauth2.outputs.username }}

--- a/monopod/pkg/images/images.go
+++ b/monopod/pkg/images/images.go
@@ -27,7 +27,6 @@ type Image struct {
 	ApkoTargetTagSuffix         string `json:"apkoTargetTagSuffix"`
 	ApkoPackageVersionTag       string `json:"apkoPackageVersionTag"`
 	ApkoPackageVersionTagPrefix string `json:"apkoPackageVersionTagPrefix"`
-	ApkoBuildOptions            string `json:"apkoBuildOptions"`
 	ApkoPackageAppend           string `json:"apkoPackageAppend"`
 	TestCommandExe              string `json:"testCommandExe"`
 	TestCommandDir              string `json:"testCommandDir"`
@@ -165,7 +164,6 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 			apkoAdditionalTags := strings.Join(variant.Apko.Tags, ",")
 			apkoTargetTagSuffix := ""
 
-			apkoBuildOptions := strings.Join(iterator.Variant.Apko.Options, ",")
 			apkoPackageAppend := make([]string, 0, len(iterator.Variant.Apko.Options))
 			for _, opt := range iterator.Variant.Apko.Options {
 				// Look it up in the image's configuration first.
@@ -186,11 +184,6 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 			if subvariant.Suffix != "" {
 				apkoTargetTag = apkoTargetTag + subvariant.Suffix
 				apkoTargetTagSuffix = subvariant.Suffix
-				if apkoBuildOptions != "" {
-					apkoBuildOptions = strings.Join([]string{apkoBuildOptions, strings.Join(subvariant.Options, ",")}, ",")
-				} else {
-					apkoBuildOptions = strings.Join(subvariant.Options, ",")
-				}
 				for _, opt := range subvariant.Options {
 					// Look it up in the image's configuration first.
 					vp, ok := extraPackages(m, opt)
@@ -295,7 +288,6 @@ func ListAll(opts ...ListOption) ([]Image, error) {
 				ApkoAdditionalTags:          apkoAdditionalTags,
 				ApkoPackageVersionTag:       variant.Apko.ExtractTagsFrom.Package,
 				ApkoPackageVersionTagPrefix: variant.Apko.ExtractTagsFrom.Prefix,
-				ApkoBuildOptions:            apkoBuildOptions,
 				ApkoPackageAppend:           strings.Join(apkoPackageAppend, ","),
 				TestCommandExe:              testCommandExe,
 				TestCommandDir:              testCommandDir,


### PR DESCRIPTION
We stopped using these a while ago when we adopted `--packages-append` and removed the `yq` logic that mixed-in the options to the `apko` configuration files, but we never dropped this piece, which should now be superfluous.

This cleans up the remnants of `apkoBuildOptions` in images.