### PR TITLE
Use `${FREE_PORT}` for unique container naming

### DIFF
--- a/images/helm-chartmuseum/tests/01-helm-repo-add.sh
+++ b/images/helm-chartmuseum/tests/01-helm-repo-add.sh
@@ -4,7 +4,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-CONTAINER_NAME=${CONTAINER_NAME:-"chartmuseum-test-$(date +%s)"}
+CONTAINER_NAME=${CONTAINER_NAME:-"chartmuseum-test-${FREE_PORT}"}
 
 TMPDIR="$(mktemp -d)"
 trap "rm -rf ${TMPDIR} && \

--- a/images/nginx/tests/02-welcome-page.sh
+++ b/images/nginx/tests/02-welcome-page.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-CONTAINER_NAME=${CONTAINER_NAME:-"nginx-smoketest-$(date +%s)"}
+CONTAINER_NAME=${CONTAINER_NAME:-"nginx-smoketest-${FREE_PORT}"}
 
 docker run -p "${FREE_PORT}:8080" -d --name $CONTAINER_NAME $IMAGE_NAME
 trap "docker logs $CONTAINER_NAME && docker rm -f $CONTAINER_NAME" EXIT

--- a/images/postgres/tests/02-query.sh
+++ b/images/postgres/tests/02-query.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-CONTAINER_NAME=${CONTAINER_NAME:-"postgres-$(date +%s)"}
+CONTAINER_NAME=${CONTAINER_NAME:-"postgres-${FREE_PORT}"}
 
 docker run --network=host -e POSTGRES_PASSWORD=password -d --name $CONTAINER_NAME $IMAGE_NAME
 trap "docker logs $CONTAINER_NAME && docker rm -f $CONTAINER_NAME" EXIT

--- a/images/postgres/tests/03-locale.sh
+++ b/images/postgres/tests/03-locale.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-CONTAINER_NAME=${CONTAINER_NAME:-"postgres-$(date +%s)"}
+CONTAINER_NAME=${CONTAINER_NAME:-"postgres-${FREE_PORT}"}
 
 docker run -e POSTGRES_PASSWORD=password -d --name $CONTAINER_NAME $IMAGE_NAME
 trap "docker logs $CONTAINER_NAME && docker rm -f $CONTAINER_NAME" EXIT

--- a/images/prometheus/tests/02-healthy.sh
+++ b/images/prometheus/tests/02-healthy.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-CONTAINER_NAME=${CONTAINER_NAME:-"prometheus-smoketest-$(date +%s)"}
+CONTAINER_NAME=${CONTAINER_NAME:-"prometheus-smoketest-${FREE_PORT}"}
 
 docker run -p 9090:9090 -d --name $CONTAINER_NAME $IMAGE_NAME --config.file=/etc/prometheus/prometheus.yml
 trap "docker logs $CONTAINER_NAME && docker rm -f $CONTAINER_NAME" EXIT

--- a/images/redis/tests/02-server.sh
+++ b/images/redis/tests/02-server.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-CONTAINER_NAME=${CONTAINER_NAME:-"redis-smoketest-$(date +%s)"}
+CONTAINER_NAME=${CONTAINER_NAME:-"redis-smoketest-${FREE_PORT}"}
 
 # Run two containers on the same network (just use host for simplicity)
 # The server should start up and listen, and the client will run ping

--- a/images/zookeeper/tests/02-runs.sh
+++ b/images/zookeeper/tests/02-runs.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-CONTAINER_NAME=${CONTAINER_NAME:-"zookeeper-status-$(date +%s)"}
+CONTAINER_NAME=${CONTAINER_NAME:-"zookeeper-status-${FREE_PORT}"}
 docker run -d --rm --name ${CONTAINER_NAME} "${IMAGE_NAME}"
 
 # Wait for zookeeper to start


### PR DESCRIPTION
I keep hitting instances where the `date` pattern we use hits races because two tests run concurrently, so I went through and scrubbed all the occurrences I could find.