### PR TITLE
ci: terraform: print diff to stdout if check fails

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - run: terraform fmt -check -recursive
+      - run: terraform fmt -check -recursive -diff
 
       - id: files
         uses: tj-actions/changed-files@e1754a427f478b8778d349341b8f1d80f1f47f44 # v36.4.0


### PR DESCRIPTION
Currently, in case `terraform` format check fails, it does not print the _diff_ to output. It'd be nice to display diffs of formatting changes in CI (in case if fail).

Actual output:
```
Run terraform fmt -check -recursive
  terraform fmt -check -recursive
  shell: /usr/bin/bash -e {0}
images/proxysql/tests/main.tf
Error: Process completed with exit code 3.
```