### PR TITLE
WIP: add killability test

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -43,6 +43,13 @@ data "oci_exec_test" "check-reproducibility" {
   timeout_seconds = 600
 }
 
+data "oci_exec_test" "check-killability" {
+  digest = module.this.image_ref
+  script = "docker kill $(docker run -d --rm $${IMAGE_NAME})"
+
+  timeout_seconds = 30
+}
+
 output "image_ref" {
   value = data.oci_exec_test.check-reproducibility.tested_ref
 }


### PR DESCRIPTION
Today we have a PR checklist item that says:

> - [ ] Ensure the image responds to SIGTERM
>   - [ ] `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`

This seemed easy enough to add as a build test alongside check-reproducibility.sh, so I did that.

...And a bunch of images don't pass (`nginx` does at least).

Opening this to better understand this issue, and see if we can move this from a human checklist item into a computer presubmit check.