### PR TITLE
Updating PHP Images

### DIFF
--- a/images/php/configs/latest-fpm.apko.yaml
+++ b/images/php/configs/latest-fpm.apko.yaml
@@ -1,6 +1,18 @@
 contents:
   packages:
+    - ca-certificates
+    - curl
     - php
+    - php-curl
+    - php-openssl
+    - php-iconv
+    - php-mbstring
+    - php-mysqlnd
+    - php-pdo
+    - php-pdo_sqlite
+    - php-pdo_mysql
+    - php-sodium
+    - php-phar
     - php-fpm
 
 entrypoint:

--- a/images/php/configs/latest.apko.yaml
+++ b/images/php/configs/latest.apko.yaml
@@ -1,6 +1,18 @@
 contents:
   packages:
+    - ca-certificates
+    - curl
     - php
+    - php-curl
+    - php-openssl
+    - php-iconv
+    - php-mbstring
+    - php-mysqlnd
+    - php-pdo
+    - php-pdo_sqlite
+    - php-pdo_mysql
+    - php-sodium
+    - php-phar
 
 entrypoint:
   command: /bin/php


### PR DESCRIPTION
Currently, our PHP image has the following extensions built-in:

- php-curl
- php-openssl
- php-zlib
- pdo-mysql
- php-sodium

Total size: 43MB

With the [change in the Wolfi PHP package](https://github.com/wolfi-dev/os/pull/3211) compiling extensions as shared objects, we need to include some PHP extensions by default in order to keep backwards compatibility.

The new version with shared libraries is based on the [php:cli-alpine Dockerfile](https://github.com/docker-library/php/blob/d3fc8d9699726a2f6abbd7c4453bc81cf7fb6a2f/8.2-rc/alpine3.17/fpm/Dockerfile), it includes:

- php-curl
- php-openssl
- php-iconv
- php-mbstring
- php-mysqlnd
- php-pdo
- php-pdo_sqlite
- php-pdo_mysql
- php-sodium
- php-phar

Total size: 36.6MB 🤩

Meanwhile, the php:cli-alpine image is ~96MB 💁🏻‍♀️

The `latest-fpm` image includes additionally the `php-fpm` package for serving php with nginx.

The goal is making our image a drop-in replacement for the php:cli-alpine image (and fpm-alpine).