### PR TITLE
add the client libraries for guacamole

### DIFF
--- a/images/guacamole-server/configs/latest.apko.yaml
+++ b/images/guacamole-server/configs/latest.apko.yaml
@@ -4,12 +4,17 @@ contents:
     - busybox
     - ttf-dejavu
     - netcat-openbsd
+    - libguac-client-vnc
+    - libguac-client-telnet
+    - libguac-client-ssh
+    - libguac-client-rdp
 
 environment:
   LC_ALL: C.UTF-8
   LD_LIBRARY_PATH: /usr/lib
+  GUACD_LOG_LEVEL: info
 
-cmd: /usr/sbin/guacd  -b 0.0.0.0 -L info -f
+cmd: /bin/sh -c '/usr/sbin/guacd  -b 0.0.0.0 -L $GUACD_LOG_LEVEL -f'
 
 accounts:
   groups:

--- a/images/guacamole-server/tests/01-runs.sh
+++ b/images/guacamole-server/tests/01-runs.sh
@@ -6,4 +6,13 @@ container_name="guacamole-${RANDOM}"
 docker run --rm -d --name="${container_name}" "${IMAGE_NAME}"
 trap "docker rm -f ${container_name}" EXIT
 
-docker logs "${container_name}" 2>&1  | grep "Guacamole proxy daemon (guacd) version 1.5.2 started"
+# Poll the logs for the startup string
+for i in {1..5}; do
+  if docker logs "${container_name}" 2>&1  | grep "Guacamole proxy daemon (guacd) version 1.5.2 started"; then
+    exit 0
+  fi
+  sleep 1
+done
+
+# Fail if the startup string was not found
+exit 1


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Image: add ruby v3.1"
* "Fix: fix haproxy v2.6 running as root"
* "Feature: Generate development friendly variants for all images"
-->

<!--
Please include references to any related issues. 
 -->

Fixes:

Adds the missing client libraries for the guacd binary.
* vnc
* telnet
* rdp
* ssh

NOTE:

I don't think `busybox` is required here but for the sake of making incremental changes I'm not removing it right now. Once we do remove it, we should be able to set the guacamole log level through an xml file rather than in the CMD