### PR TITLE
calico: add calico-csi

### DIFF
--- a/images/calico/configs/latest.csi.apko.yaml
+++ b/images/calico/configs/latest.csi.apko.yaml
@@ -1,0 +1,25 @@
+contents:
+  packages:
+    - calico-pod2daemon
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 0
+
+entrypoint:
+  command: /opt/cni/bin/calico-pod2daemon-csidriver
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin
+
+annotations:
+  "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/"
+  "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/calico/
+  "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/calico
+

--- a/images/calico/main.tf
+++ b/images/calico/main.tf
@@ -10,15 +10,18 @@ locals {
     "node",
     "kube-controllers",
     "cni",
+    "csi",
   ])
 
   // Normally the package is named like "calico-{component}"
   // But some packages are named differently:
   // - calicoctl -> calicoctl
+  // - calico-csi -> calico-pod2daemon
   packages = merge({
     for k, v in local.components : k => "calico-${k}"
     }, {
     "calicoctl" : "calicoctl",
+    "csi" : "calico-pod2daemon",
   })
 
   // Normally the repository is named like "calico-{component}"

--- a/images/calico/tests/install.sh
+++ b/images/calico/tests/install.sh
@@ -8,12 +8,16 @@ TMP="$(mktemp -d)"
 pushd "${TMP}"
 
 curl -o calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml
-
 sed -i.bak "s|docker.io/calico/node:.*|${NODE_IMAGE}|g" calico.yaml
 sed -i.bak "s|docker.io/calico/kube-controllers:.*|${KUBE_CONTROLLERS_IMAGE}|g" calico.yaml
 sed -i.bak "s|docker.io/calico/cni:.*|${CNI_IMAGE}|g" calico.yaml
-
 kubectl apply -f calico.yaml
+
+curl -o calico-csi.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/csi-driver.yaml
+sed -i.bak "s|docker.io/calico/csi:.*|${CSI_IMAGE}|g" calico-csi.yaml
+sed -i.bak "s|docker.io/calico/node-driver-registrar:.*|${CSI_NODE_DRIVER_REGISTRAR_IMAGE}|g" calico-csi.yaml
+kubectl apply -f calico-csi.yaml
 
 kubectl rollout status daemonset calico-node -n kube-system --timeout 60s
 kubectl rollout status deployment calico-kube-controllers -n kube-system --timeout 60s
+kubectl rollout status daemonset csi-node-driver -n calico-system --timeout 60s

--- a/images/calico/tests/main.tf
+++ b/images/calico/tests/main.tf
@@ -12,6 +12,7 @@ variable "digests" {
     calicoctl        = string
     cni              = string
     kube-controllers = string
+    csi              = string
   })
 }
 
@@ -30,5 +31,13 @@ data "oci_exec_test" "install" {
   env {
     name  = "KUBE_CONTROLLERS_IMAGE"
     value = var.digests["kube-controllers"]
+  }
+  env {
+    name  = "CSI_IMAGE"
+    value = var.digests["csi"]
+  }
+  env {
+    name  = "CSI_NODE_DRIVER_REGISTRAR_IMAGE"
+    value = "cgr.dev/chainguard/kubernetes-csi-node-driver-registrar:latest"
   }
 }


### PR DESCRIPTION
This adds an equivalent image to `calico/csi` and tests that it can be used in the DaemonSet along with the upstream K8s CSI node driver registrar

https://docs.tigera.io/calico/latest/getting-started/kubernetes/hardway/istio-integration