### PR TITLE
ensure k3s-embedded variant is tagged appropriately

### DIFF
--- a/images/k3s/main.tf
+++ b/images/k3s/main.tf
@@ -67,8 +67,8 @@ module "tagger" {
   tags = merge(
     { for t in toset(concat(["latest"], module.version-tags.tag_list)) : t => module.latest.image_ref },
     { for t in toset(concat(["latest"], module.version-tags.tag_list)) : "${t}-dev" => module.latest-dev.image_ref },
-    { for t in toset(concat(["latest"], module.version-tags-embedded.tag_list)) : "${t}-embedded" => module.latest-embedded.image_ref },
     { for t in toset(concat(["latest"], module.version-tags.tag_list)) : "${t}-images" => module.latest-images.image_ref },
     { for t in toset(concat(["latest"], module.version-tags.tag_list)) : "${t}-images-dev" => module.latest-images-dev.image_ref },
+    { for t in toset(concat(["latest"], module.version-tags-embedded.tag_list)) : t => module.latest-embedded.image_ref },
   )
 }


### PR DESCRIPTION
this fixes:

```bash
# OLD
cgr.dev/chainguard/k3s-embedded:latest-embedded

# NEW
cgr.dev/chainguard/k3s-embedded:latest
```