### PR TITLE
remove monopod:tag:k8s tags from tests

### DIFF
--- a/images/calico/tests/install.sh
+++ b/images/calico/tests/install.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 TMP="$(mktemp -d)"

--- a/images/cluster-proportional-autoscaler/tests/helm.sh
+++ b/images/cluster-proportional-autoscaler/tests/helm.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 # add a test deployment to scale based on the cpa algorithm

--- a/images/kube-bench/tests/run.sh
+++ b/images/kube-bench/tests/run.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 app_name="kube-bench"

--- a/images/kube-downscaler/tests/run.sh
+++ b/images/kube-downscaler/tests/run.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 function cleanup() {

--- a/images/metacontroller/tests/helm.sh
+++ b/images/metacontroller/tests/helm.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 export HELM_EXPERIMENTAL_OCI=1

--- a/images/nvidia-device-plugin/tests/helm.sh
+++ b/images/nvidia-device-plugin/tests/helm.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 helm repo add nvdp https://nvidia.github.io/k8s-device-plugin

--- a/images/prometheus/tests/node-runs.sh
+++ b/images/prometheus/tests/node-runs.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 kubectl run prometheus-node-exporter --image=${IMAGE_NAME}

--- a/images/prometheus/tests/redis-installs.sh
+++ b/images/prometheus/tests/redis-installs.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 cat >deploy.yaml <<EOF

--- a/images/pulumi/tests/02-k8s-install-all-languages.sh
+++ b/images/pulumi/tests/02-k8s-install-all-languages.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# monopod:tag:k8s
-
 set -o errexit -o errtrace -o pipefail -x
 
 ONLY_TEST_LANG="${ONLY_TEST_LANG:-}"
@@ -87,7 +85,7 @@ function test_nginx {
 
 function main {
     d="$(date +%s)"
-    for lang in "dotnet" "go" "java" "nodejs" "yaml"; do
+    for lang in "dotnet" "go" "java" "nodejs" "python" "yaml"; do
         if [[ "${ONLY_TEST_LANG}" != "" && "${lang}" != "${ONLY_TEST_LANG}" ]]; then
             continue
         fi

--- a/images/pulumi/tests/02-k8s-install-all-languages.sh
+++ b/images/pulumi/tests/02-k8s-install-all-languages.sh
@@ -87,7 +87,7 @@ function test_nginx {
 
 function main {
     d="$(date +%s)"
-    for lang in "dotnet" "go" "java" "nodejs" "python" "yaml"; do
+    for lang in "dotnet" "go" "java" "nodejs" "yaml"; do
         if [[ "${ONLY_TEST_LANG}" != "" && "${lang}" != "${ONLY_TEST_LANG}" ]]; then
             continue
         fi


### PR DESCRIPTION
These are redundant now that we run the tests during build time in CI, and before tagging in releases.