### PR TITLE
readd dev packages to wolfi git image

### DIFF
--- a/images/git/alpine.tf
+++ b/images/git/alpine.tf
@@ -43,5 +43,6 @@ module "test-latest-alpine-dev" {
   for_each = local.accounts
   source   = "./tests"
 
-  digest = module.latest-alpine-dev[each.key].image_ref
+  digest    = module.latest-alpine-dev[each.key].image_ref
+  check-dev = true
 }

--- a/images/git/tests/main.tf
+++ b/images/git/tests/main.tf
@@ -8,9 +8,20 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
+variable "check-dev" {
+  default = false
+}
+
 data "oci_exec_test" "version" {
   digest = var.digest
-  script = "${path.module}/version.sh"
+  script = "docker run --rm $IMAGE_NAME --version"
+}
+
+data "oci_exec_test" "submodule" {
+  count = var.check-dev ? 1 : 0
+
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME submodule -h"
 }
 
 data "oci_exec_test" "clone" {

--- a/images/git/tests/version.sh
+++ b/images/git/tests/version.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset -o errtrace -o pipefail -x
-
-docker run --rm "${IMAGE_NAME}" --version

--- a/images/git/wolfi.tf
+++ b/images/git/wolfi.tf
@@ -12,6 +12,7 @@ module "latest-wolfi-dev" {
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.wolfi.${each.key}.apko.yaml")
+  extra_packages    = module.dev.extra_packages
 }
 
 module "version-tags-wolfi" {
@@ -33,5 +34,6 @@ module "test-latest-wolfi-dev" {
   for_each = local.accounts
   source   = "./tests"
 
-  digest = module.latest-wolfi-dev[each.key].image_ref
+  digest    = module.latest-wolfi-dev[each.key].image_ref
+  check-dev = true
 }


### PR DESCRIPTION
This seems to have been dropped in https://github.com/chainguard-images/images/pull/960, and not tested except via hugo's tests, which check that the -dev image can be used to run `git submodule`.

This PR also adds tests, which only run on the dev images, to check that `git submodule` works.