### PR TITLE
Pick up apko 0.9.0 and container name improvement

### DIFF
--- a/tflib/publisher/check-reproducibility.sh
+++ b/tflib/publisher/check-reproducibility.sh
@@ -19,10 +19,8 @@ fi
 
 # TODO(mattmoor): switch this to cgr.dev/chainguard/crane registry serve
 # once we cut a release to make this listen on more than loopback.
-# Note: we expose the port here (even unused) to "claim" the port and
-# avoid naming collisions.
-container_name="registry-${RANDOM}.local"
-docker run -d -p ${FREE_PORT}:5000 --name "${container_name}" registry:2
+container_name="registry-$(hexdump -vn16 -e'4/4 "%08x" 1 "\n"' /dev/urandom).local"
+docker run -d --name "${container_name}" registry:2
 
 trap "docker rm -f ${container_name}" EXIT
 
@@ -31,7 +29,7 @@ REBUILT_IMAGE_NAME=$(docker run --rm \
    --link "${container_name}" \
    -v "${TMP}:/tmp/latest.apko.json" \
    -v ${PWD}:${PWD}:ro -w ${PWD} \
-   ghcr.io/wolfi-dev/apko:latest@sha256:4f747c533aa5b2bad01c64ec12e73a9c933510c2918d3c40a0e85b113e014ac3 \
+   ghcr.io/wolfi-dev/apko:latest@sha256:686ecf32c9a9b4c80ac0679c0db3b79e53f91238122ef5dd9181254a6b5e2939 \
    publish /tmp/latest.apko.json ${container_name}:5000/reproduction
 )
 

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     apko = {
       source  = "chainguard-dev/apko"
-      version = "0.8.10"
+      version = "0.9.0"
     }
     oci = {
       source  = "chainguard-dev/oci"


### PR DESCRIPTION
I thought I pulled in 0.9.0, but this only happened downstream.  This also picks up another downstream change to the random container naming to make collisions even less likely.