### PR TITLE
fix kubernetes-dashboard helm test

### DIFF
--- a/images/kubernetes-dashboard/tests/main.tf
+++ b/images/kubernetes-dashboard/tests/main.tf
@@ -24,6 +24,9 @@ resource "helm_release" "kubernetes-dashboard" {
   repository = "https://kubernetes.github.io/dashboard/"
   chart      = "kubernetes-dashboard"
 
+  // After v6.0.8 the image tag is used as a K8s label, which has a max length of 63 characters.
+  version = "6.0.8"
+
   namespace        = "kubernetes-dashboard"
   create_namespace = true
 


### PR DESCRIPTION
v7 of the helm chart, released a few hours ago, uses the `image.tag` value as a k8s label, which has a max length of 63 characters. Our pseudo-tag (so we can test the image without tagging it) is longer than that.

https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard?modal=template&template=deployments/api.yaml

<img width="564" alt="Screenshot 2023-07-07 at 3 30 08 PM" src="https://github.com/chainguard-images/images/assets/210737/408ef635-8513-4f0a-a26e-9d2d2124a36b">

This change pins to the last release before v7.