### PR TITLE
Have the reproducibility script take the `APKO_IMAGE` via env var.

### DIFF
--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -59,6 +59,7 @@ runs:
         TF_VAR_target_repository: registry.local:5000/testing
         TF_VAR_target_tag: ${{ inputs.apkoTargetTag }}
         TF_VAR_tag_suffix: ${{ inputs.apkoTargetTagSuffix }}
+        APKO_IMAGE: ghcr.io/wolfi-dev/apko:latest@sha256:686ecf32c9a9b4c80ac0679c0db3b79e53f91238122ef5dd9181254a6b5e2939
       run: |
         set -x
         env | grep '^TF_VAR_'

--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -88,6 +88,7 @@ runs:
       env:
         TF_VAR_target_tag: ${{ inputs.apkoTargetTag }}
         TF_VAR_tag_suffix: ${{ inputs.apkoTargetTagSuffix }}
+        APKO_IMAGE: ghcr.io/wolfi-dev/apko:latest@sha256:686ecf32c9a9b4c80ac0679c0db3b79e53f91238122ef5dd9181254a6b5e2939
       run: |
         set -x
         env | grep '^TF_VAR_'

--- a/tflib/publisher/check-reproducibility.sh
+++ b/tflib/publisher/check-reproducibility.sh
@@ -4,6 +4,9 @@ set -o errexit -o nounset -o errtrace -o pipefail
 
 TMP=$(mktemp)
 
+# This ensures the variable is set before skipping the test.
+echo "apko image: ${APKO_IMAGE}"
+
 if ! cosign download attestation \
    --predicate-type https://apko.dev/image-configuration \
   "${IMAGE_NAME}" | jq -r .payload | base64 -d | jq .predicate > "${TMP}" ; then
@@ -34,7 +37,7 @@ REBUILT_IMAGE_NAME=$(docker run --rm \
    -v ${PWD}:${PWD}:ro -w ${PWD} \
    -v ${XDG_CACHE_HOME:-$HOME/.cache}:/cache \
    -e XDG_CACHE_HOME=/cache \
-   ghcr.io/wolfi-dev/apko:latest@sha256:686ecf32c9a9b4c80ac0679c0db3b79e53f91238122ef5dd9181254a6b5e2939 \
+   "${APKO_IMAGE}" \
    publish /tmp/latest.apko.json ${container_name}:5000/reproduction
 )
 


### PR DESCRIPTION
This is so that downstream in tf-apko we can run these builds presubmit and make breaking changes, so long as APKO and tf-apko remain in sync wrt what's produced.
