### PR TITLE
kube-fluentd-operator docs, add missing flag to create namespace with…

### DIFF
--- a/images/kube-fluentd-operator/README.md
+++ b/images/kube-fluentd-operator/README.md
@@ -32,7 +32,7 @@ With helm:
 
 ```
 git clone git@github.com:vmware/kube-fluentd-operator.git
-helm install kfo ./kube-fluentd-operator/charts/log-router \
+helm install --create-namespace kfo ./kube-fluentd-operator/charts/log-router \
   --set rbac.create=true \
   --set image.tag=latest \
   --set image.repository=cgr.dev/chainguard/kube-fluentd-operator


### PR DESCRIPTION
… helm
