### PR TITLE
prevent the reproducability script from erroring due to UNBOUND_VARIABLE

### DIFF
--- a/tflib/publisher/check-reproducibility.sh
+++ b/tflib/publisher/check-reproducibility.sh
@@ -4,9 +4,6 @@ set -o errexit -o nounset -o errtrace -o pipefail
 
 TMP=$(mktemp)
 
-# This ensures the variable is set before skipping the test.
-echo "apko image: ${APKO_IMAGE}"
-
 if ! cosign download attestation \
    --predicate-type https://apko.dev/image-configuration \
   "${IMAGE_NAME}" | jq -r .payload | base64 -d | jq .predicate > "${TMP}" ; then


### PR DESCRIPTION
prevents erroring when `APKO_IMAGE` is unset (such as in local dev)

```
tflib/publisher/check-reproducibility.sh: line 8: APKO_IMAGE: unbound variable
```