### PR TITLE
group/collapse 'terraform init' output in CI logs

### DIFF
--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -71,15 +71,15 @@ runs:
         # When we have a "mega module", use it to invoke the module
         # for the appropriate image.
         if [ -f "main.tf" ]; then
-          ::group::terraform init
+          echo ::group::terraform init
           terraform init
-          ::endgroup::
+          echo ::endgroup::
           terraform apply -auto-approve "-target=module.${MODULE}" -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         else
           cd ${{ inputs.terraformDirectory }}
-          ::group::terraform init
+          echo ::group::terraform init
           terraform init
-          ::endgroup::
+          echo ::endgroup::
           terraform apply -auto-approve -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         fi
 

--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -71,11 +71,15 @@ runs:
         # When we have a "mega module", use it to invoke the module
         # for the appropriate image.
         if [ -f "main.tf" ]; then
+          ::group::terraform init
           terraform init
+          ::endgroup::
           terraform apply -auto-approve "-target=module.${MODULE}" -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         else
           cd ${{ inputs.terraformDirectory }}
+          ::group::terraform init
           terraform init
+          ::endgroup::
           terraform apply -auto-approve -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         fi
 

--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -100,12 +100,16 @@ runs:
         # for the appropriate image.
         if [ -f "main.tf" ]; then
           export TF_VAR_target_repository=$(dirname ${{ inputs.apkoBaseTag }})
+          ::group::terraform init
           terraform init
+          ::endgroup::
           terraform apply -auto-approve "-target=module.${MODULE}" -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         else
           cd ${{ inputs.terraformDirectory }}
           export TF_VAR_target_repository=${{ inputs.apkoBaseTag }}
+          ::group::terraform init
           terraform init
+          ::endgroup::
           terraform apply -auto-approve -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         fi
 

--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -100,16 +100,16 @@ runs:
         # for the appropriate image.
         if [ -f "main.tf" ]; then
           export TF_VAR_target_repository=$(dirname ${{ inputs.apkoBaseTag }})
-          ::group::terraform init
+          echo ::group::terraform init
           terraform init
-          ::endgroup::
+          echo ::endgroup::
           terraform apply -auto-approve "-target=module.${MODULE}" -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         else
           cd ${{ inputs.terraformDirectory }}
           export TF_VAR_target_repository=${{ inputs.apkoBaseTag }}
-          ::group::terraform init
+          echo ::group::terraform init
           terraform init
-          ::endgroup::
+          echo ::endgroup::
           terraform apply -auto-approve -json | tee /tmp/${MODULE}.tf.json | jq -r '.["@message"]'
         fi
 


### PR DESCRIPTION
`terraform init` output is long, and gets longer with each new module we define. There isn't usually much useful information in there, just lots of identical lines about what versions of what providers are installed. Save our scrolling fingers.

See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines