### PR TITLE
Fix: fixing entry point for php-fpm image

### DIFF
--- a/images/php/configs/latest-fpm.apko.yaml
+++ b/images/php/configs/latest-fpm.apko.yaml
@@ -18,7 +18,7 @@ contents:
 entrypoint:
   type: service-bundle
   services:
-    php-fpm: /usr/bin/php-fpm -p /
+    php-fpm: /usr/sbin/php-fpm -p /
 
 environment:
   PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/images/php/tests/main.tf
+++ b/images/php/tests/main.tf
@@ -32,5 +32,5 @@ data "oci_exec_test" "composer" {
 data "oci_exec_test" "fpm" {
   count  = var.check-fpm ? 1 : 0
   digest = var.digest
-  script = " docker run --entrypoint php-fpm --rm $IMAGE_NAME -v"
+  script = "docker run --rm $IMAGE_NAME -v"
 }


### PR DESCRIPTION
This PR fixes the entrypoint for the `php-fpm` image, which had a slight change in recent updates from `/usr/bin/php-fpm` to `/usr/sbin/php-fpm` to comply with standard path locations.
