### PR TITLE
Add a sleep after apply before wait

### DIFF
--- a/images/prometheus/tests/redis-installs.sh
+++ b/images/prometheus/tests/redis-installs.sh
@@ -54,7 +54,7 @@ spec:
 EOF
 
 kubectl apply -f deploy.yaml -n redis
-
+sleep 5 # Let the controllers do their thing
 kubectl wait --for=condition=ready pod --selector app=redis -n redis
 
 latest_pod_name="$(kubectl get pods --selector app=redis -n redis -o jsonpath="{.items[0].metadata.name}")"


### PR DESCRIPTION
One of the nightly builds flaked and it looks like the pods weren't created instantly from the Deployment (which is also unrealistic):
```
# kubectl wait --for=condition=ready pod --selector app=redis -n redis
error: no matching resources found
```