### PR TITLE
Bump terraform-provider-apko to v0.9.2

### DIFF
--- a/images/configmap-reload/tests/main.tf
+++ b/images/configmap-reload/tests/main.tf
@@ -16,7 +16,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME -h"
 }
 
-resource "helm_release" "dex" {
+resource "helm_release" "configmap-reload" {
   name = "configmap-reload"
 
   repository = "https://prometheus-community.github.io/helm-charts"

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     apko = {
       source  = "chainguard-dev/apko"
-      version = "0.9.1"
+      version = "0.9.2"
     }
     oci = {
       source  = "chainguard-dev/oci"


### PR DESCRIPTION
This release attempts to fix some flakiness we see while fetching APKs.