### PR TITLE
Remove configmap-reload helm_release test

### DIFF
--- a/images/configmap-reload/tests/main.tf
+++ b/images/configmap-reload/tests/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    oci  = { source = "chainguard-dev/oci" }
-    helm = { source = "hashicorp/helm" }
+    oci = { source = "chainguard-dev/oci" }
   }
 }
 
@@ -14,21 +13,4 @@ data "oci_string" "ref" { input = var.digest }
 data "oci_exec_test" "version" {
   digest = var.digest
   script = "docker run --rm $IMAGE_NAME -h"
-}
-
-resource "helm_release" "configmap-reload" {
-  name = "configmap-reload"
-
-  repository = "https://prometheus-community.github.io/helm-charts"
-  chart      = "alertmanager"
-
-  values = [jsonencode({
-    configmapReload = {
-      image = {
-        tag        = data.oci_string.ref.pseudo_tag
-        repository = data.oci_string.ref.registry_repo
-      }
-      enabled = true
-    }
-  })]
 }


### PR DESCRIPTION
This helm_release does not appear to test or exercise the package in any way.

Looking here, it appears that it is no longer used by that chart: https://github.com/prometheus-community/helm-charts/blob/cc2c507e4a4b625f561577bba13795b7f8bde40a/charts/prometheus/README.md#to-200