### PR TITLE
ensure flux source controller can write to its home

### DIFF
--- a/images/flux/configs/latest.source-controller.apko.yaml
+++ b/images/flux/configs/latest.source-controller.apko.yaml
@@ -15,6 +15,15 @@ accounts:
 entrypoint:
   command: /usr/bin/source-controller
 
+paths:
+  # Writes to /home/nonroot/ for caching things like rekor public keys (/home/nonroot/.sigstore)
+  - path: /home/nonroot
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
+
 annotations:
   "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/flux-source-controller/
   "org.opencontainers.image.source": https://github.com/chainguard-images/images/tree/main/images/flux-source-controller


### PR DESCRIPTION
this surfaces when attempting to use the `cosign.verify` feature of `OCIRepository`:

```
17s         Warning   VerificationError         ocirepository/root-source             failed to verify the signature using provider 'cosign keyless': unable to get Rekor public keys: creating cached local store: mkdir /home/nonroot/.sigstore: read-only file system
```