### PR TITLE
hugo: use `hugo-extended` package, add `-dev` dependencies

### DIFF
--- a/images/hugo/configs/latest.apko.yaml
+++ b/images/hugo/configs/latest.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-    - hugo
+    - hugo-extended
 
 entrypoint:
   command: /usr/bin/hugo

--- a/images/hugo/main.tf
+++ b/images/hugo/main.tf
@@ -17,6 +17,14 @@ module "latest" {
 
 module "dev" { source = "../../tflib/dev-subvariant" }
 
+locals {
+  hugo_dev_packages = concat(module.dev.extra_packages, [
+    "git",
+    "go",
+    "nodejs"
+  ])
+}
+
 module "latest-dev" {
   source = "../../tflib/publisher"
 
@@ -24,7 +32,7 @@ module "latest-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = module.dev.extra_packages
+  extra_packages = local.hugo_dev_packages
 }
 
 module "version-tags" {


### PR DESCRIPTION
See related discussion in https://github.com/chainguard-images/images/pull/905#discussion_r1256346793

Original plan was to include `go` and `git` in the default variant, but the `go` package is huge so I've just thrown everything into the `-dev` variant for now.

cc @mattmoor 