### PR TITLE
Add default cmd.

### DIFF
--- a/images/prometheus/configs/latest.core.apko.yaml
+++ b/images/prometheus/configs/latest.core.apko.yaml
@@ -3,7 +3,9 @@ contents:
     - prometheus
 
 entrypoint:
-  command: prometheus
+  command: /usr/bin/prometheus
+
+cmd: --config.file /etc/prometheus/prometheus.yml
 
 annotations:
   "org.opencontainers.image.url": https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus/


### PR DESCRIPTION
I think this makes it a little easier to get started with the image - you can run `docker inspect` and see where the config file is. It also matches the `prom/prometheus` image.

Closes #161 

