### PR TITLE
Add a KinD test for minio and minio-client

### DIFF
--- a/images/minio/main.tf
+++ b/images/minio/main.tf
@@ -57,6 +57,12 @@ module "test-latest" {
   digests = { for k, v in module.latest : k => module.latest[k].image_ref }
 }
 
+module "test-latest-dev" {
+  source    = "./tests"
+  check-dev = true
+  digests   = { for k, v in module.latest-dev : k => module.latest-dev[k].image_ref }
+}
+
 module "tagger" {
   for_each = local.packages
   source   = "../../tflib/tagger"

--- a/images/minio/tests/100-namespace.yaml
+++ b/images/minio/tests/100-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: minio

--- a/images/minio/tests/200-configmap.yaml
+++ b/images/minio/tests/200-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minio
+  namespace: minio
+data:
+  init-buckets: test

--- a/images/minio/tests/200-secret.yaml
+++ b/images/minio/tests/200-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: minio
+type: kubernetes.io/basic-auth
+stringData:
+  host: minio.minio.svc.cluster.local
+  username: defaultuser
+  password: defaultpass

--- a/images/minio/tests/300-deploy.yaml
+++ b/images/minio/tests/300-deploy.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: minio
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+      - image: MINIO_IMAGE
+        name: minio
+        ports:
+        - name: http1
+          containerPort: 9000
+        args: ["server", "/data"]
+        env:
+          - name: MINIO_ROOT_USER
+            valueFrom:
+              secretKeyRef:
+                name: minio
+                key: username
+          - name: MINIO_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: minio
+                key: password
+        volumeMounts:
+          - name: data
+            mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/images/minio/tests/300-service.yaml
+++ b/images/minio/tests/300-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  selector:
+    app: minio
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9000
+  type: ClusterIP

--- a/images/minio/tests/400-job.yaml
+++ b/images/minio/tests/400-job.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test
+  namespace: minio
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: create-bucket
+        image: MC_IMAGE
+        args:
+          - mb
+          - --ignore-existing
+          - minio/bucket
+        env:
+        - name: MC_HOST_minio
+          value: "http://defaultuser:defaultpass@minio.minio.svc.cluster.local"
+      containers:
+      - name: stat-bucket
+        image: MC_IMAGE
+        args:
+          - stat
+          - minio/bucket
+        env:
+        - name: MC_HOST_minio
+          value: "http://defaultuser:defaultpass@minio.minio.svc.cluster.local"

--- a/images/minio/tests/main.tf
+++ b/images/minio/tests/main.tf
@@ -12,9 +12,34 @@ variable "digests" {
   })
 }
 
+variable "check-dev" {
+  default     = false
+  description = "Whether to check for dev extensions"
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
 data "oci_exec_test" "version" {
   for_each = var.digests
   digest   = each.value
 
   script = "docker run --rm $IMAGE_NAME --version"
+}
+
+data "oci_exec_test" "test" {
+  count  = var.check-dev ? 1 : 0
+  digest = var.digests["minio"]
+  script = "${path.module}/test.sh"
+  env {
+    name  = "MINIO_IMAGE"
+    value = var.digests["minio"]
+  }
+
+  env {
+    name  = "MC_IMAGE"
+    value = var.digests["minio-client"]
+  }
 }

--- a/images/minio/tests/test.sh
+++ b/images/minio/tests/test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+kubectl apply -f $SCRIPT_DIR/100-namespace.yaml
+kubectl apply -f $SCRIPT_DIR/200-configmap.yaml
+kubectl apply -f $SCRIPT_DIR/200-secret.yaml
+
+sed "s|MINIO_IMAGE|$MINIO_IMAGE|g" $SCRIPT_DIR/300-deploy.yaml | kubectl apply -f -
+kubectl apply -f $SCRIPT_DIR/300-service.yaml
+
+# Wait for the server to be up and running.
+#
+# We need to wrap with retry loop because`kubectl wait` fails immediately if the
+# resource has not show up.
+for i in {1..5}; do
+  kubectl wait --for=condition=ready --timeout=30s \
+      pod -n minio -l app=minio && s=0 && break
+  s=$?
+  sleep 15
+done
+
+if [ $s -ne 0 ]; then
+  exit $s
+fi
+
+# Run the test job to create a bucket and stat it.
+sed "s|MC_IMAGE|$MC_IMAGE|g" $SCRIPT_DIR/400-job.yaml | kubectl apply -f -
+
+for i in {1..5}; do
+  kubectl wait --for=condition=complete --timeout=30s \
+     job -n minio test && s=0 && break
+  s=$?
+  sleep 15
+done
+
+if [ $s -ne 0 ]; then
+  exit $s
+fi


### PR DESCRIPTION
We cannot use the official Helm chart because they invoke `minio` with `/bin/sh -ce minio` instead of just running `minio` directly. This is a workaround until we can send one upstream to fix the upstream Helm chart.