### PR TITLE
Use kubectl top to test metrics-server

### DIFF
--- a/images/metrics-server/tests/check-metrics-server.sh
+++ b/images/metrics-server/tests/check-metrics-server.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Sadly Helm doesn't wait for things to report as ready,
+# so we have to do it ourselves.
+kubectl wait -n metrics-server --for=condition=ready pod --selector app.kubernetes.io/instance=metrics-server
+
+# Give kubernetes a chance to observe the above and propagate the endpoints.
+sleep 5
+
+# These will error out if metrics-server is not running,
+# and by default KinD does not run one.
+kubectl top pods -A
+kubectl top nodes

--- a/images/metrics-server/tests/main.tf
+++ b/images/metrics-server/tests/main.tf
@@ -33,3 +33,10 @@ resource "helm_release" "metrics-server" {
     args = ["--kubelet-insecure-tls"]
   })]
 }
+
+data "oci_exec_test" "check-metrics-server" {
+  digest      = var.digest
+  script      = "./check-metrics-server.sh"
+  working_dir = path.module
+  depends_on  = [helm_release.metrics-server]
+}


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Basic Testing - K8s cluster
- [x] The container image was successfully loaded into a kind cluster.

### Basic Testing - Package/Application
- [x] The application is accessible to the user/cluster/etc. after start-up.

### Helm
- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image was built and tested for aarch64.

### Functional Testing + Documentation
- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.
