### PR TITLE
Expand the list of images tested with prometheus helm chart

### DIFF
--- a/images/prometheus/tests/check-kube-prometheus-stack.sh
+++ b/images/prometheus/tests/check-kube-prometheus-stack.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Sadly Helm doesn't wait for things to report as ready,
+# so we have to do it ourselves.
+kubectl wait -n prometheus --for=condition=ready pod --selector app.kubernetes.io/instance=prometheus

--- a/images/prometheus/tests/node-runs.sh
+++ b/images/prometheus/tests/node-runs.sh
@@ -2,12 +2,8 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-kubectl run prometheus-node-exporter --image=${IMAGE_NAME}
-kubectl wait --for=condition=ready pod prometheus-node-exporter
-
-kubectl port-forward pod/prometheus-node-exporter ${FREE_PORT}:9100 &
+kubectl port-forward -n prometheus service/prometheus-prometheus-node-exporter ${FREE_PORT}:9100 &
 pid=$!
 trap "kill $pid" EXIT
 sleep 5
 curl http://localhost:${FREE_PORT}/metrics | grep "node_"
-


### PR DESCRIPTION
This deploys every image I could find referenced from the `kube-prometheus-stack` `values.yaml`, and I confirmed locally that things like `alertmanager` and `prometheus` spin up with this configuration, and that it is using our images.

I also made it use our public KSM image (and we should consider doing the same in the KSM test that spins up this same Helm chart).

However, despite standing up more stuff, this doesn't actually functionally test them still, but it should enable us to follow up and test things.  The one thing that IS tested is the `node-exporter` where I changed the test to hit the DaemonSet Service created by the Helm chart instead of spinning up its own pod.