### PR TITLE
ko-fips: demonstrate a fips variant framework

### DIFF
--- a/images/ko/main.tf
+++ b/images/ko/main.tf
@@ -28,12 +28,39 @@ module "test-latest" {
   digest = module.latest.image_ref
 }
 
+module "fips-config" {
+  source       = "../../tflib/fips-variant"
+  config       = yamldecode(file("${path.module}/configs/latest.apko.yaml"))
+  replacements = { "ko" = "ko-fips" }
+}
+
+module "fips-latest" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = var.target_repository
+  config            = yamlencode(module.fips-config.config)
+}
+
+module "fips-version-tags" {
+  source  = "../../tflib/version-tags"
+  package = "ko-fips"
+  config  = module.fips-latest.config
+}
+
+module "test-fips-latest" {
+  source = "./tests"
+  digest = module.fips-latest.image_ref
+}
+
 module "tagger" {
   source = "../../tflib/tagger"
 
-  depends_on = [module.test-latest]
+  depends_on = [module.test-latest, module.test-fips-latest]
 
   tags = merge(
     { for t in toset(concat(["latest"], module.version-tags.tag_list)) : t => module.latest.image_ref },
+    { for t in toset(concat(["fips-latest"], module.fips-version-tags.tag_list)) : "fips-${t}" => module.fips-latest.image_ref },
   )
 }

--- a/tflib/fips-variant/main.tf
+++ b/tflib/fips-variant/main.tf
@@ -1,0 +1,22 @@
+variable "config" {
+}
+
+variable "replacements" {
+  type = map(string)
+}
+
+locals {
+  replaced = merge(var.config,
+    {
+      contents = {
+        packages = [
+          for pkg in var.config.contents.packages : lookup(var.replacements, pkg, pkg)
+        ]
+      }
+    },
+  )
+}
+
+output "config" {
+  value = local.replaced
+}


### PR DESCRIPTION
Opening this mainly as an RFC on how we can modularize and standardize "replace `$package` with `$package-fips`" so that we can build more interesting fipsified images.

This produces an image tagged for example `ttl.sh/jason/ko:fips-0.14.1` ([link](https://oci.dag.dev/?image=ttl.sh%2Fjason%2Fko%3Afips-0.14.1))

```
$ terraform state show 'module.ko.module.fips-latest.module.this.cosign_attest.apko-configuration["amd64"]'           
...
    predicate      = jsonencode(
        {
            contents    = {
                packages     = [
                    "ko-fips=0.14.1-r0",
...
```