### PR TITLE
Drop double slack post

### DIFF
--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -1,7 +1,5 @@
 name: release-image-terraform
 inputs:
-  slackWebhookUrl:
-    default: ''
   gcsBucketName:
     default: ''
 runs:
@@ -160,36 +158,6 @@ runs:
       shell: bash
       run: |
         trap "rm -f BADGINATOR-5000.sh" EXIT && bash -e BADGINATOR-5000.sh success
-
-    # There is currently no way to obtain the job ID for a single matrix leg, so we have to
-    # try to hit the GitHub API and match the job based on the name, then extract the html_url
-    # See the following issue for more details: https://github.com/orgs/community/discussions/40291
-    - shell: bash
-      if: failure() && inputs.slackWebhookUrl != ''
-      id: slacklink
-      run: |
-        function get_actions_job_url {
-          curl -s -L -H "Authorization: Bearer ${{ github.token }}" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
-            | jq -r ".jobs[] | select(.name | contains(\"${1}\")) | .html_url"
-        }
-        # TODO: support specific matrix leg for subvariants (they have same apkoConfig input as parent)
-        ACTIONS_URL=""
-        if [[ "${{ inputs.apkoTargetTagSuffix }}" == "" ]]; then
-          ACTIONS_URL="$(get_actions_job_url ${{ inputs.apkoConfig }})"
-        fi
-        ACTIONS_URL="${ACTIONS_URL:-https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}}"
-        echo "link=${ACTIONS_URL}" >> $GITHUB_OUTPUT
-
-    # Slack notification if build failing
-    - uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
-      if: failure() && inputs.slackWebhookUrl != ''
-      id: slack
-      with:
-        payload: '{"text": "[release-image] ${{ inputs.imageName }} ${{ inputs.apkoTargetTag }} failed: ${{ steps.slacklink.outputs.link }}"}'
-      env:
-        SLACK_WEBHOOK_URL: ${{ inputs.slackWebhookUrl }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     # Upload badges from ./badges-output/
     - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1


### PR DESCRIPTION
As I added the previous slack post, I missed that we already had one buried in our actions workflow.

This strips the old version of the slack post to avoid double-posting here and downstream (where I also added this).
