### PR TITLE
node: explicitly lock the nodejs:18 variant to the nodejs-18 version stream

### DIFF
--- a/images/node/configs/18.apko.yaml
+++ b/images/node/configs/18.apko.yaml
@@ -2,7 +2,7 @@ contents:
   packages:
     - busybox
     - nghttp2
-    - nodejs
+    - nodejs-18
 
 # By convention, Node apps run in an /app directory, which should be owned by
 # the non-root node user.


### PR DESCRIPTION
Right now, it depends on `nodejs`, which is being turned into a version stream.