### PR TITLE
Bump terraform-provider-cosign to 0.0.9

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cosign = {
       source  = "chainguard-dev/cosign"
-      version = "0.0.6"
+      version = "0.0.9"
     }
     apko = {
       source  = "chainguard-dev/apko"


### PR DESCRIPTION
This should help with fulcio and rekor 429s.
