### PR TITLE
Fix the consul package name to consul-1.16

### DIFF
--- a/images/consul/main.tf
+++ b/images/consul/main.tf
@@ -33,7 +33,7 @@ module "latest-dev" {
 
 module "version-tags" {
   source  = "../../tflib/version-tags"
-  package = "consul"
+  package = "consul-1.16"
   config  = module.latest.config
 }
 


### PR DESCRIPTION
This should be equivalent, but we replaced `consul` with slotted versions, so `consul` will become `consul-1.16` due to the `provides:` and we should use that for version tags.