### PR TITLE
Bump terraform-provider-cosign to v0.0.10

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cosign = {
       source  = "chainguard-dev/cosign"
-      version = "0.0.9"
+      version = "0.0.10"
     }
     apko = {
       source  = "chainguard-dev/apko"


### PR DESCRIPTION
This picks up more precise client-side rate limiting.
