### PR TITLE
require base path name for annotations

### DIFF
--- a/images/slim-toolkit-debug/main.tf
+++ b/images/slim-toolkit-debug/main.tf
@@ -11,6 +11,7 @@ variable "target_repository" {
 module "slim-toolkit-debug-latest" {
   source = "../../tflib/publisher"
 
+  name              = basename(path.module)
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.apko.yaml")
 }

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -24,10 +24,7 @@ variable "extra_packages" {
   default = ["wolfi-baselayout"]
 }
 
-variable "name" {
-  type    = string
-  default = "TODO" // TODO remove this
-}
+variable "name" { type = string }
 
 output "path" {
   value = basename(path.cwd)
@@ -35,7 +32,6 @@ output "path" {
 
 locals {
   updated_config = merge(yamldecode(var.config),
-    var.name == "TODO" ? {} :
     { "annotations" = {
       "org.opencontainers.image.authors" : "Chainguard Team https://www.chainguard.dev/",
       "org.opencontainers.image.url" : "https://edu.chainguard.dev/chainguard/chainguard-images/reference/${var.name}/",


### PR DESCRIPTION
This makes it an error if you forget to specify `name`, and adds it the one place it wasn't already set.