### PR TITLE
Use kubernetes-csi-node-driver-registrar-compat

### DIFF
--- a/images/kubernetes-csi-node-driver-registrar/configs/latest.apko.yaml
+++ b/images/kubernetes-csi-node-driver-registrar/configs/latest.apko.yaml
@@ -1,6 +1,7 @@
 contents:
   packages:
     - kubernetes-csi-node-driver-registrar
+    - kubernetes-csi-node-driver-registrar-compat
 
 accounts:
   groups:


### PR DESCRIPTION
This fixes incompatibility with a helm chart that hardcode a binary.

https://github.com/wolfi-dev/os/pull/4279

https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml#L49C34-L49C43