### PR TITLE
go: promote 1.21 to latest

### DIFF
--- a/images/go/main.tf
+++ b/images/go/main.tf
@@ -21,16 +21,15 @@ module "tagger" {
 
   tags = merge(
     # 1.19
-    { for t in toset(module.version-tags-19.tag_list) : t => module.nineteen.image_ref },
-    { for t in toset(module.version-tags-19.tag_list) : "${t}-dev" => module.nineteen-dev.image_ref },
-
-    # 1.21
-    # TODO(mattmoor): Move this below (and switch latest) once 1.21 is no longer an "RC"
-    { for t in toset(module.version-tags-21.tag_list) : t => module.twenty-one.image_ref },
-    { for t in toset(module.version-tags-21.tag_list) : "${t}-dev" => module.twenty-one-dev.image_ref },
+    { for t in module.version-tags-19.tag_list : t => module.nineteen.image_ref },
+    { for t in module.version-tags-19.tag_list : "${t}-dev" => module.nineteen-dev.image_ref },
 
     # 1.20
-    { for t in toset(concat(["latest"], module.version-tags-20.tag_list)) : t => module.twenty.image_ref },
-    { for t in toset(concat(["latest"], module.version-tags-20.tag_list)) : "${t}-dev" => module.twenty-dev.image_ref },
+    { for t in module.version-tags-20.tag_list : t => module.twenty.image_ref },
+    { for t in module.version-tags-20.tag_list : "${t}-dev" => module.twenty-dev.image_ref },
+
+    # 1.21
+    { for t in concat(["latest"], module.version-tags-21.tag_list) : t => module.twenty-one.image_ref },
+    { for t in concat(["latest"], module.version-tags-21.tag_list) : "${t}-dev" => module.twenty-one-dev.image_ref },
   )
 }


### PR DESCRIPTION
Go 1.21 was released, making it the latest.

This also drops some unnecessary `toset` wrapping for better readability.

As a followup we need to move 1.19 out of the public image set, which I'll do in another PR.