### PR TITLE
fix: use IMAGE_NAME for Gradle test script

### DIFF
--- a/images/gradle/tests/02-build.sh
+++ b/images/gradle/tests/02-build.sh
@@ -2,4 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
- docker run --rm --entrypoint "" cgr.dev/chainguard/gradle:latest sh -c "gradle init --type java-application --test-framework junit-jupiter && gradle build"
+docker run --rm --entrypoint "" "${IMAGE_NAME}" sh -c "gradle init --type java-application --test-framework junit-jupiter && gradle build"


### PR DESCRIPTION
Target image was previously hardcoded instead of using the current `IMAGE_NAME` environment variable. Updated to use the current `IMAGE_NAME` environment variable sent from Terraform.

I removed the checklist as this PR solely updates a test script.
