### PR TITLE
update otelc test cases

### DIFF
--- a/images/opentelemetry-collector-contrib/configs/latest.apko.yaml
+++ b/images/opentelemetry-collector-contrib/configs/latest.apko.yaml
@@ -2,6 +2,8 @@ contents:
   packages:
     - opentelemetry-collector-contrib
     - opentelemetry-collector-contrib-compat
+    # Required for hostmetrics receivers and certain resourcedetection processors (like eks)
+    - busybox
 
 accounts:
   groups:

--- a/images/opentelemetry-collector-contrib/tests/custom-config.yaml
+++ b/images/opentelemetry-collector-contrib/tests/custom-config.yaml
@@ -1,7 +1,43 @@
 receivers:
   otlp:
     protocols:
+      http:
       grpc:
+
+  hostmetrics:
+    collection_interval: 10s
+    scrapers:
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+      disk:
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      load:
+      memory:
+      network:
+      processes:
+
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'opentelemetry-collector'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+
+  filelog:
+    include_file_path: true
+    poll_interval: 500ms
+    include:
+      - /var/log/**/*.log
 
 exporters:
   prometheus:
@@ -20,8 +56,28 @@ exporters:
     tls:
       insecure: true
 
+  # datadog:
+  #   api:
+  #     site: us5.datadoghq.com
+  #     key: ${DD_KEY}
+
 processors:
   batch:
+    send_batch_max_size: 100
+    send_batch_size: 10
+    timeout: 10s
+  resourcedetection:
+    # These warn when not applicable, so just include everything
+    detectors: 
+      - env
+      - eks
+      - ec2
+      - system
+      - docker
+    timeout: 10s
+    override: false
+  # adds various tags related to k8s
+  k8sattributes:
 
 extensions:
   health_check:
@@ -29,15 +85,50 @@ extensions:
     endpoint: :1888
   zpages:
     endpoint: :55679
+  memory_ballast:
+    size_in_percentage: 5
 
 service:
-  extensions: [pprof, zpages, health_check]
+  extensions: 
+    - pprof
+    - zpages
+    - health_check
+    - memory_ballast
   pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [logging, zipkin, jaeger]
     metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [logging, prometheus]
+      receivers: 
+        - otlp
+        - hostmetrics
+      processors: 
+        - resourcedetection
+        - k8sattributes
+        - batch
+      exporters: 
+        - logging
+        - prometheus
+        # - datadog
+
+    traces:
+      receivers: 
+        - otlp
+      processors: 
+        - resourcedetection
+        - k8sattributes
+        - batch
+      exporters: 
+        - logging
+        - zipkin # fails (with warning) without zipkin deployed
+        - jaeger # fails (with warning) without jaeger deployed
+        # - datadog
+
+    logs:
+      receivers: 
+        - filelog
+      processors: 
+        - resourcedetection
+        - k8sattributes
+        - batch
+      exporters: 
+        - logging
+        # - datadog
+

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,10 @@ provider "apko" {
   }
 }
 
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
 provider "helm" {
   kubernetes {
     config_path = "~/.kube/config"


### PR DESCRIPTION
Expanded the test sweeps we run for `otelc` into 2 groups (deployment and daemonset). Also turn on more receivers/exporters to allow for testing more things.

While many of these settings don't trigger an unhealthy startup, some spew actionable errors that we should be able to catch now with the future e2e tool.

Also adds `busybox` to the image to allow for configurations using certain receivers (like `eks`) to scrape host data, preventing errors like this:

```
2023-08-11T01:26:47.344Z    info    gohai/gohai.go:54    Failed to retrieve platform metadata    {"kind": "exporter", "data_type": "metrics", "name": "datadog", "error": " exec: \"uname\": executable file not found in $PATH"}                                                                                                                       
```