### PR TITLE
Fix conda entrypoint

### DIFF
--- a/images/conda/configs/latest.apko.yaml
+++ b/images/conda/configs/latest.apko.yaml
@@ -14,6 +14,6 @@ accounts:
   run-as: 65532
 
 entrypoint:
-  command: /opt/conda/bin/conda
+  command: /usr/bin/conda
 cmd: --help
 


### PR DESCRIPTION
Looks like this changed in https://github.com/wolfi-dev/os/pull/4397

```
$ curl -s https://packages.wolfi.dev/os/aarch64/conda-23.7.2-r1.apk | tar -tvz opt
tar: opt: Not found in archive
tar: Error exit delayed from previous errors.
```

```
$ curl -s https://packages.wolfi.dev/os/aarch64/conda-23.7.2-r1.apk | tar -tvz | grep usr/bin
drwxr-xr-x  0 root   root        0 Aug 11 14:40 usr/bin
-rwxr-xr-x  0 root   root      217 Aug 11 14:40 usr/bin/conda
```

Previously:

```
$ curl -s https://packages.wolfi.dev/os/aarch64/conda-23.7.2-r0.apk | tar -tvz opt/conda/bin/conda
-rwxrwxr-x  0 root   root      511 Jul 27 13:19 opt/conda/bin/conda
```

cc @wlynch 