### PR TITLE
[cloudwatch-exporter] add new verification test

### DIFF
--- a/images/prometheus/tests/check-cloudwatch-exporter.sh
+++ b/images/prometheus/tests/check-cloudwatch-exporter.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset -o errtrace -o pipefail -x
-
-# Sadly Helm doesn't wait for things to report as ready,
-# so we have to do it ourselves.
-kubectl wait -n prometheus-cloudwatch-exporter --for=condition=ready pod --selector app=prometheus-cloudwatch-exporter

--- a/images/prometheus/tests/check-cloudwatch-exporter.sh
+++ b/images/prometheus/tests/check-cloudwatch-exporter.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Sadly Helm doesn't wait for things to report as ready,
+# so we have to do it ourselves.
+kubectl wait -n prometheus-cloudwatch-exporter --for=condition=ready pod --selector app=prometheus-cloudwatch-exporter

--- a/images/prometheus/tests/check-kube-prometheus-stack.sh
+++ b/images/prometheus/tests/check-kube-prometheus-stack.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset -o errtrace -o pipefail -x
-
-# Sadly Helm doesn't wait for things to report as ready,
-# so we have to do it ourselves.
-kubectl wait -n prometheus --for=condition=ready pod --selector app.kubernetes.io/instance=prometheus

--- a/images/prometheus/tests/main.tf
+++ b/images/prometheus/tests/main.tf
@@ -148,15 +148,8 @@ resource "helm_release" "kube-prometheus-stack" {
   }
 }
 
-data "oci_exec_test" "check-prometheus" {
-  digest      = var.digests["core"]
-  script      = "./check-kube-prometheus-stack.sh"
-  working_dir = path.module
-  depends_on  = [helm_release.kube-prometheus-stack]
-}
-
 data "oci_exec_test" "node-runs" {
-  depends_on = [data.oci_exec_test.check-prometheus]
+  depends_on = [resource.helm_release.kube-prometheus-stack]
 
   digest      = var.digests["node-exporter"]
   script      = "./node-runs.sh"
@@ -179,11 +172,4 @@ resource "helm_release" "cloudwatch-exporter" {
     name  = "image.tag"
     value = "latest"
   }
-}
-
-data "oci_exec_test" "check-cloudwatch-exporter" {
-  digest      = var.digests["cloudwatch-exporter"]
-  script      = "./check-cloudwatch-exporter.sh"
-  working_dir = path.module
-  depends_on  = [helm_release.cloudwatch-exporter]
 }

--- a/images/prometheus/tests/main.tf
+++ b/images/prometheus/tests/main.tf
@@ -170,6 +170,6 @@ resource "helm_release" "cloudwatch-exporter" {
   }
   set {
     name  = "image.tag"
-    value = "latest"
+    value = format("latest@%s", data.oci_string.ref["cloudwatch-exporter"].digest)
   }
 }

--- a/images/prometheus/tests/main.tf
+++ b/images/prometheus/tests/main.tf
@@ -162,3 +162,28 @@ data "oci_exec_test" "node-runs" {
   script      = "./node-runs.sh"
   working_dir = path.module
 }
+
+resource "helm_release" "cloudwatch-exporter" {
+  name       = "cloudwatch-exporter"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus-cloudwatch-exporter"
+
+  namespace        = "prometheus-cloudwatch-exporter"
+  create_namespace = true
+
+  set {
+    name  = "image.repository"
+    value = data.oci_string.ref["cloudwatch-exporter"].registry_repo
+  }
+  set {
+    name  = "image.tag"
+    value = "latest"
+  }
+}
+
+data "oci_exec_test" "check-cloudwatch-exporter" {
+  digest      = var.digests["cloudwatch-exporter"]
+  script      = "./check-cloudwatch-exporter.sh"
+  working_dir = path.module
+  depends_on  = [helm_release.cloudwatch-exporter]
+}


### PR DESCRIPTION
Add installation of cloudwatch-exporter to the Terraform template and create new shell script to check it runs successfully with our newly built image.

## Chainguard Images Pull Request Template

### Image Size

Notes: No changes to the image itself.

### Image Vulnerabilities

Notes: No changes to the image itself.

### Basic Testing - K8s cluster

Notes: No changes to the image itself.

### Basic Testing - Package/Application

Notes: No changes to the image itself.

### Helm

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes: Added a new Helm chart to the tests for verification of the cloudwatch-exporter component.

### Processor Architectures

Notes: No changes to the image itself.

### Functional Testing + Documentation

Notes: No changes to the image itself.

### Environment Testing + Documentation

Notes: No changes to the image itself.

### Version

Notes: No changes to the image itself.

### Dev Tag Availability

Notes: No changes to the image itself.

### Access Control + Authentication

No changes in access control or auth.

### ENTRYPOINT

No changes for entrypoint.

### CMD

No changes for CMD.

### Environment Variables

No changes for environment variables.

### SIGTERM

No changes to the image itself.

### Logs

No changes to logging.

### Documentation - README

No specific changes that warrant updates to README.
