### PR TITLE
openai: fix dependency on py3-certifi

### DIFF
--- a/images/openai/configs/latest.apko.yaml
+++ b/images/openai/configs/latest.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - busybox
-    - openai
+    - py3-openai
 
 accounts:
   groups:

--- a/images/openai/main.tf
+++ b/images/openai/main.tf
@@ -33,7 +33,7 @@ module "latest-dev" {
 
 module "version-tags" {
   source  = "../../tflib/version-tags"
-  package = "openai"
+  package = "py3-openai"
   config  = module.latest.config
 }
 


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/4387 renamed the openai package to py3-openai and added a `provides: ['openai']`, but it reset the epoch, so depending on `openai` in the image config still gets the old version `0.27.8-r2`.

By explicitly depending on `py3-openai` we get `0.27.8-r0` which specifies runtime dependencies on the necessary python packages, avoiding a conflict on `py3-certifi` and others.