### PR TITLE
Drop vestigial dependency on apk-tools

### DIFF
--- a/images/apko/configs/latest.apko.yaml
+++ b/images/apko/configs/latest.apko.yaml
@@ -1,8 +1,8 @@
 contents:
   packages:
-    - wolfi-base
     - alpine-keys
     - apko
+    - wolfi-keys
 
 paths:
   - path: /work

--- a/images/melange/configs/latest.apko.yaml
+++ b/images/melange/configs/latest.apko.yaml
@@ -1,10 +1,9 @@
 contents:
   packages:
     - alpine-keys
-    - wolfi-base
-    - alpine-keys
     - bubblewrap
     - melange
+    - wolfi-keys
 
 paths:
   - path: /work


### PR DESCRIPTION
Both `apko` and `melange` no longer shell out to `apk`.

Needs https://github.com/wolfi-dev/os/pull/4479