### PR TITLE
disable new version tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,11 +92,9 @@ jobs:
           k8s-version: v1.24.x
           registry-authority: registry.local:5000
 
-      # Disable version tags for ko.
+      # Disable creating new version tags.
       - run: |
-          if [[ "${{ matrix.imageName }}" == "ko" ]]; then
-            echo "TF_APKO_DISABLE_VERSION_TAGS=true" >> $GITHUB_ENV
-          fi
+          echo "TF_APKO_DISABLE_VERSION_TAGS=true" >> $GITHUB_ENV
 
       - uses: ./.github/actions/release-image-terraform
         with: ${{ fromJSON(steps.release-image-inputs.outputs.matrix-json) }}


### PR DESCRIPTION
https://github.com/chainguard-images/images/pull/1200 trialed this for `ko`, which was correctly built without version-tagging last night.

This change will disable version tagging for all new image builds.