### PR TITLE
don't trigger releases on withdrawn images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
+      - withdrawn-images.txt
+      - withdrawn-repos.txt
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
It's needlessly wasteful to trigger a (no-op) release of every image when we change README.md or withdraw images or repos.