### PR TITLE
kubectl: fix image build

### DIFF
--- a/images/kubectl/configs/latest.apko.yaml
+++ b/images/kubectl/configs/latest.apko.yaml
@@ -1,6 +1,7 @@
 contents:
   packages:
-    - kubectl
+    - kubectl-1.28
+    - kubernetes-1.28-default
 
 accounts:
   groups:

--- a/images/kubectl/main.tf
+++ b/images/kubectl/main.tf
@@ -33,7 +33,7 @@ module "latest-dev" {
 
 module "version-tags" {
   source  = "../../tflib/version-tags"
-  package = "kubectl"
+  package = "kubectl-1.28"
   config  = module.latest.config
 }
 


### PR DESCRIPTION
The version tag module we use to extract the version from the given package doesn't seem to understand when that package is `provide`d by a package with a different name.

This makes the config very explicit about what version of kubectl to use, and what package to use when generating the version tag.