### PR TITLE
use the new kubectl latest for tracking default kubectl

### DIFF
--- a/images/helm/configs/latest.apko.yaml
+++ b/images/helm/configs/latest.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - helm
-    - kubectl
+    - kubectl-latest
 
 accounts:
   groups:

--- a/images/kubectl/configs/latest.apko.yaml
+++ b/images/kubectl/configs/latest.apko.yaml
@@ -1,7 +1,6 @@
 contents:
   packages:
-    - kubectl-1.28
-    - kubernetes-1.28-default
+    - kubectl-latest
 
 accounts:
   groups:

--- a/images/kyverno/configs/latest.admission.apko.yaml
+++ b/images/kyverno/configs/latest.admission.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - kyverno
-    - kubectl
+    - kubectl-latest
 
 accounts:
   groups:

--- a/images/kyverno/configs/latest.background.apko.yaml
+++ b/images/kyverno/configs/latest.background.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - kyverno-background-controller
-    - kubectl
+    - kubectl-latest
 
 accounts:
   groups:

--- a/images/kyverno/configs/latest.cleanup.apko.yaml
+++ b/images/kyverno/configs/latest.cleanup.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - kyverno-cleanup-controller
-    - kubectl
+    - kubectl-latest
 
 accounts:
   groups:

--- a/images/kyverno/configs/latest.cli.apko.yaml
+++ b/images/kyverno/configs/latest.cli.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - kyverno-cli
-    - kubectl
+    - kubectl-latest
 
 accounts:
   groups:

--- a/images/kyverno/configs/latest.init.apko.yaml
+++ b/images/kyverno/configs/latest.init.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - kyverno-init-container
-    - kubectl
+    - kubectl-latest
 
 accounts:
   groups:

--- a/images/kyverno/configs/latest.reports.apko.yaml
+++ b/images/kyverno/configs/latest.reports.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - kyverno-reports-controller
-    - kubectl
+    - kubectl-latest
 
 accounts:
   groups:


### PR DESCRIPTION
[kubectl-latest](https://github.com/wolfi-dev/os/blob/main/kubernetes-latest.yaml) introd a new way of tracking the latest kubectl component _and_ adding it as the default kubectl (`/usr/bin/kubectl`)

this changes all our images that rely on a "latest" `kubectl` to track using this new package.