### PR TITLE
Fix tags in READMEs

### DIFF
--- a/images/argocd/README.md
+++ b/images/argocd/README.md
@@ -60,11 +60,11 @@ Optionally, you can use Chainguard Images to replace the other ArgoCD dependenci
 redis:
   image:
     repository: cgr.dev/chainguard/redis
-    tag: 7.0
+    tag: latest
 
 dex:
   image:
-    repository: cgr.dev/chainguard/dev
+    repository: cgr.dev/chainguard/dex
     tag: latest
 ```
 

--- a/images/aspnet-runtime/README.md
+++ b/images/aspnet-runtime/README.md
@@ -19,4 +19,4 @@ Container image with the latest ASP.NET runtime.
 
 The image is available on `cgr.dev`:
 
-    docker pull cgr.dev/chainguard/aspnet-runtime:7.0
+    docker pull cgr.dev/chainguard/aspnet-runtime:latest

--- a/images/dotnet-runtime/README.md
+++ b/images/dotnet-runtime/README.md
@@ -19,4 +19,4 @@ Container image with the latest .NET runtime.
 
 The image is available on `cgr.dev`:
 
-    docker pull cgr.dev/chainguard/dotnet-runtime:7.0
+    docker pull cgr.dev/chainguard/dotnet-runtime:latest

--- a/images/dotnet-sdk/README.md
+++ b/images/dotnet-sdk/README.md
@@ -19,4 +19,4 @@ Container image containing a Wolfi-flavored .NET SDK.
 
 The image is available on `cgr.dev`:
 
-    docker pull cgr.dev/chainguard/dotnet-sdk:7.0
+    docker pull cgr.dev/chainguard/dotnet-sdk:latest


### PR DESCRIPTION
This PR cleans up some removed tags from image READMEs.

The Java READMEs still need to be cleaned up in another PR and will take a bit more work.