### PR TITLE
Have `telegraf` extract versions from the `telegraf-1.27` package

### DIFF
--- a/images/telegraf/main.tf
+++ b/images/telegraf/main.tf
@@ -33,7 +33,7 @@ module "latest-dev" {
 
 module "version-tags" {
   source  = "../../tflib/version-tags"
-  package = "telegraf"
+  package = "telegraf-1.27"
   config  = module.latest.config
 }
 


### PR DESCRIPTION
This is in preparation for https://github.com/wolfi-dev/os/pull/4625