### PR TITLE
Revive this dropped tag from Tf migration.

### DIFF
--- a/images/maven/main.tf
+++ b/images/maven/main.tf
@@ -21,8 +21,10 @@ module "tagger" {
   tags = merge(
     { for t in toset(module.version-tags-11.tag_list) : "openjdk-11-${t}" => module.eleven.image_ref },
     { for t in toset(module.version-tags-11.tag_list) : "openjdk-11-${t}-dev" => module.eleven-dev.image_ref },
+    { "openjdk-11" : module.eleven.image_ref, "openjdk-11-dev" : module.eleven-dev.image_ref },
     { for t in toset(module.version-tags-17.tag_list) : "openjdk-17-${t}" => module.seventeen.image_ref },
     { for t in toset(module.version-tags-17.tag_list) : "openjdk-17-${t}-dev" => module.seventeen-dev.image_ref },
+    { "openjdk-17" : module.seventeen.image_ref, "openjdk-17-dev" : module.seventeen-dev.image_ref },
     { "latest" : module.seventeen.image_ref, "latest-dev" : module.seventeen-dev.image_ref },
   )
 }


### PR DESCRIPTION
I believe that when we were migrating to TF we dropped this tag, so this brings it back.

This was caught by some checking I'm adding to our downstream syncer that checks signature timestamps on our tagged images.