### PR TITLE
fix: update guacamole test script to use regex

### DIFF
--- a/images/guacamole-server/tests/01-runs.sh
+++ b/images/guacamole-server/tests/01-runs.sh
@@ -8,7 +8,7 @@ trap "docker rm -f ${container_name}" EXIT
 
 # Poll the logs for the startup string
 for i in {1..5}; do
-  if docker logs "${container_name}" 2>&1  | grep "Guacamole proxy daemon (guacd) version 1.5.2 started"; then
+  if docker logs "${container_name}" 2>&1  | grep -e "Guacamole proxy daemon (guacd) version .* started"; then
     exit 0
   fi
   sleep 1


### PR DESCRIPTION
Use a regex instead of comparing exact versions to prevent test failures when version bumps occur.
