### PR TITLE
bump CI kind to 1.25

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: chainguard-dev/actions/setup-kind@main
         with:
-          k8s-version: v1.24.x
+          k8s-version: v1.25.x
           registry-authority: registry.local:5000
 
       # Disable version tags for ko.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - uses: chainguard-dev/actions/setup-kind@main
         with:
-          k8s-version: v1.24.x
+          k8s-version: v1.25.x
           registry-authority: registry.local:5000
 
       # Disable creating new version tags.


### PR DESCRIPTION
`1.24` is EOL, bump us to `1.25` to stay within support.

This fixes a flake in flux, but I'm sure will introduce a few more that will be squashed when this lands.