### PR TITLE
Fix the error message this test is expecting.

### DIFF
--- a/images/trust-manager/tests/main.tf
+++ b/images/trust-manager/tests/main.tf
@@ -14,7 +14,7 @@ data "oci_exec_test" "version" {
   digest = var.digest
   script = <<EOF
     # We expect the command to fail, but want its output anyway.
-    ( docker run --rm $IMAGE_NAME 2>&1 || true ) | grep "failed to create manager"
+    ( docker run --rm $IMAGE_NAME 2>&1 || true ) | grep "failed to register Bundle controller"
   EOF
 }
 


### PR DESCRIPTION
This is a bandaid to unblock things, but we should consider eliminating this ~useless test in favor of something more comprehensive.
