### PR TITLE
fix: add redis-cli as it is required by the tests

### DIFF
--- a/images/redis/configs/latest.apko.yaml
+++ b/images/redis/configs/latest.apko.yaml
@@ -1,6 +1,7 @@
 contents:
   packages:
     - redis
+    - redis-cli
     - busybox
 
 accounts:


### PR DESCRIPTION
- redis moved to sub-packages ,  `redis-cli` is not included in the main package any more 