### PR TITLE
zig: chmod -R APPDIR in test

### DIFF
--- a/images/zig/tests/02-use.sh
+++ b/images/zig/tests/02-use.sh
@@ -17,3 +17,6 @@ chmod 777 $APPDIR
 # Setup a zig sample app and run it!
 docker run --rm -v ${APPDIR}:/work --workdir /work "${IMAGE_NAME}" init-exe
 docker run --rm -v ${APPDIR}:/work --workdir /work "${IMAGE_NAME}" build run 2>&1 | grep "All your codebase are belong to us" 
+
+# Give us permission to delete anything in here.
+chmod -R 777 $APPDIR


### PR DESCRIPTION
We saw some Permission denied failures that caused the test to fail.

https://github.com/chainguard-images/images-private/actions/runs/6006384024/job/16290861097#step:46:2827

