### PR TITLE
Configure gatekeeper check-ignore-label.sh webhook to fail open in tests

### DIFF
--- a/images/gatekeeper/tests/main.tf
+++ b/images/gatekeeper/tests/main.tf
@@ -32,6 +32,8 @@ preInstall:
 image:
   repository: ${data.oci_string.ref.registry_repo}
   release: ${data.oci_string.ref.pseudo_tag}
+
+validatingWebhookCheckIgnoreFailurePolicy: Ignore
 EOF
   ]
 }


### PR DESCRIPTION
The webhook pods may be slow to come up and may be rotated especially when running many tests together. Change the failure policy to fail open. This also matches default behavior with other Gatekeeper [webhook](https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/README.md).

### Basic Testing - K8s cluster
- [x] The container image was successfully loaded into a kind cluster.

Notes:

### Helm
- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.

