### PR TITLE
nginx: fix build using nginx-mainline

### DIFF
--- a/images/nginx/configs/latest.apko.yaml
+++ b/images/nginx/configs/latest.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-    - nginx
+    - nginx-mainline
     - nginx-package-config
 
 accounts:

--- a/images/nginx/main.tf
+++ b/images/nginx/main.tf
@@ -33,7 +33,7 @@ module "latest-dev" {
 
 module "version-tags" {
   source  = "../../tflib/version-tags"
-  package = "nginx"
+  package = "nginx-mainline"
   config  = module.latest.config
 }
 


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/4896 renamed the `nginx` package to `nginx-mainline`, which confuses our version-tag module which expects the actual package name, not its provided name.

This updates the YAML config to specify the real package name to avoid confusion, and updates the version-tag module invocation to look for that same package name.