### PR TITLE
calico: use calico-pod2daemon-compat

### DIFF
--- a/images/calico/configs/latest.pod2daemon.apko.yaml
+++ b/images/calico/configs/latest.pod2daemon.apko.yaml
@@ -1,6 +1,7 @@
 contents:
   packages:
     - calico-pod2daemon
+    - calico-pod2daemon-compat
     - busybox
 
 accounts:

--- a/images/calico/configs/latest.pod2daemon.apko.yaml
+++ b/images/calico/configs/latest.pod2daemon.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
     - calico-pod2daemon
-    - calico-pod2daemon-compat
+    - calico-pod2daemon-flexvol-compat
     - busybox
 
 accounts:


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/4933

Calico operators expect the entrypoint to be in `/usr/local/bin`