### PR TITLE
use tigera-operator installation for calico tests

### DIFF
--- a/images/calico/configs/latest.pod2daemon.apko.yaml
+++ b/images/calico/configs/latest.pod2daemon.apko.yaml
@@ -1,6 +1,7 @@
 contents:
   packages:
     - calico-pod2daemon
+    - calico-pod2daemon-flexvol-compat
     - busybox
 
 accounts:


### PR DESCRIPTION
use the `tigera-operator` method for installing and testing `calico`, which buys us a few things:

- its seemingly the upstream supported way of installing and managing calico
- it allows for "easier" replacement of images at install time
- it properly doesn't default to use bpf mounting with `mount-bpff` container, which means it doesn't need the same docker in docker hacks that the bpf method requires.