### PR TITLE
Adjust helm test timeouts

### DIFF
--- a/images/cert-manager/tests/main.tf
+++ b/images/cert-manager/tests/main.tf
@@ -26,6 +26,7 @@ resource "helm_release" "cert-manager" {
   repository       = "https://charts.jetstack.io"
   chart            = "cert-manager"
   create_namespace = true
+  timeout          = 600
 
   values = [jsonencode({
     installCRDs = "true"

--- a/images/gatekeeper/tests/main.tf
+++ b/images/gatekeeper/tests/main.tf
@@ -17,6 +17,7 @@ resource "helm_release" "gatekeeper" {
   name             = "gatekeeper"
   namespace        = "gatekeeper-system"
   create_namespace = true
+  timeout          = 600
 
   repository = "https://open-policy-agent.github.io/gatekeeper/charts"
   chart      = "gatekeeper"

--- a/images/keda/tests/main.tf
+++ b/images/keda/tests/main.tf
@@ -30,7 +30,7 @@ resource "helm_release" "keda" {
   repository       = "https://kedacore.github.io/charts"
   chart            = "keda"
   create_namespace = true
-  timeout          = 120
+  timeout          = 600
 
   values = [
     <<EOF


### PR DESCRIPTION
Reusing these test modules downstream from a mega-module we are seeing high contention on the KinD cluster and pods taking longer than the default timeout to get created.  This allows them more time to come up.