### PR TITLE
Give vault more time to become Running.

### DIFF
--- a/images/vault/tests/acceptance.sh
+++ b/images/vault/tests/acceptance.sh
@@ -4,12 +4,13 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 
 # Wait for the pod to be running before we try to unseal, we can't use `kubectl wait` here
 count=0
-while [[ $(kubectl get pods -l app.kubernetes.io/name=vault -n vault-system -o 'jsonpath={..status.phase}') != "Running" ]] && [[ $count -lt 10 ]]; do
+limit=40
+while [[ $(kubectl get pods -l app.kubernetes.io/name=vault -n vault-system -o 'jsonpath={..status.phase}') != "Running" ]] && [[ $count -lt $limit ]]; do
 	sleep 3
 	count=$(($count + 1))
 done
 
-if [[ $count -eq 10 ]]; then
+if [[ $count -eq $limit ]]; then
 	echo "Pod did not become Running after $count tries"
 	exit 1
 fi


### PR DESCRIPTION
Right now the math works out to 30s, but on busy clusters this can take longer.