### PR TITLE
Templatize node-problem-detector configs

### DIFF
--- a/images/node-problem-detector/configs/main.tf
+++ b/images/node-problem-detector/configs/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. node-problem-detector, node-problem-detector-0.8, etc)."
+  default = [
+    "node-problem-detector",
+    "node-problem-detector-compat",
+    "health-checker",
+    "log-counter",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/node-problem-detector/configs/template.apko.yaml
+++ b/images/node-problem-detector/configs/template.apko.yaml
@@ -1,9 +1,6 @@
 contents:
-  packages:
-    - node-problem-detector
-    - node-problem-detector-compat
-    - health-checker
-    - log-counter
+  # All packages come from extra_packages
+  packages: []
 
 accounts:
   groups:

--- a/images/node-problem-detector/image.yaml
+++ b/images/node-problem-detector/image.yaml
@@ -1,3 +1,3 @@
 versions:
   - apko:
-      config: configs/latest.apko.yaml
+      config: configs/0.8.apko.yaml

--- a/images/node-problem-detector/image.yaml
+++ b/images/node-problem-detector/image.yaml
@@ -1,3 +1,3 @@
 versions:
   - apko:
-      config: configs/0.8.apko.yaml
+      config: configs/latest.apko.yaml

--- a/images/node-problem-detector/main.tf
+++ b/images/node-problem-detector/main.tf
@@ -9,12 +9,15 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
+module "latest-config" { source = "./configs" }
+
 module "latest" {
   source = "../../tflib/publisher"
 
-  name              = basename(path.module)
+  name = basename(path.module)
+
   target_repository = var.target_repository
-  config            = file("${path.module}/configs/latest.apko.yaml")
+  config            = module.latest-config.config
 }
 
 module "dev" { source = "../../tflib/dev-subvariant" }
@@ -26,12 +29,7 @@ module "latest-dev" {
 
   target_repository = var.target_repository
   config            = jsonencode(module.latest.config)
-}
-
-module "version-tags" {
-  source  = "../../tflib/version-tags"
-  package = "node-problem-detector-0.8"
-  config  = module.latest.config
+  extra_packages    = module.dev.extra_packages
 }
 
 module "test-latest" {
@@ -39,13 +37,14 @@ module "test-latest" {
   digest = module.latest.image_ref
 }
 
-module "tagger" {
-  source = "../../tflib/tagger"
-
+resource "oci_tag" "latest" {
   depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
 
-  tags = merge(
-    { for t in toset(concat(["latest"], module.version-tags.tag_list)) : t => module.latest.image_ref },
-    { for t in toset(concat(["latest"], module.version-tags.tag_list)) : "${t}-dev" => module.latest-dev.image_ref },
-  )
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest-dev.image_ref
+  tag        = "latest-dev"
 }


### PR DESCRIPTION
Similar https://github.com/chainguard-images/images/pull/1172 to enable sharing the same template across versions.
