### PR TITLE
nginx: refactor to use extra_packages

### DIFF
--- a/images/nginx/config/main.tf
+++ b/images/nginx/config/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. nginx-mainline)."
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/nginx/config/template.apko.yaml
+++ b/images/nginx/config/template.apko.yaml
@@ -1,7 +1,7 @@
 contents:
-  packages:
-    - nginx-mainline
-    - nginx-package-config
+  packages: [
+    # Python comes via var.extra_packages
+  ]
 
 accounts:
   groups:

--- a/images/nginx/main.tf
+++ b/images/nginx/main.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
   }
 }
 
 variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" {
+  source = "./config"
+
+  extra_packages = ["nginx-mainline", "nginx-package-config"]
 }
 
 module "latest" {
@@ -14,7 +21,7 @@ module "latest" {
   name = basename(path.module)
 
   target_repository = var.target_repository
-  config            = file("${path.module}/configs/latest.apko.yaml")
+  config            = module.latest-config.config
 }
 
 module "dev" { source = "../../tflib/dev-subvariant" }
@@ -31,24 +38,25 @@ module "latest-dev" {
   extra_packages = module.dev.extra_packages
 }
 
-module "version-tags" {
-  source  = "../../tflib/version-tags"
-  package = "nginx-mainline"
-  config  = module.latest.config
-}
-
 module "test-latest" {
   source = "./tests"
   digest = module.latest.image_ref
 }
 
-module "tagger" {
-  source = "../../tflib/tagger"
+module "test-latest-dev" {
+  source = "./tests"
 
+  digest = module.latest-dev.image_ref
+}
+
+resource "oci_tag" "latest" {
   depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
 
-  tags = merge(
-    { for t in toset(concat(["latest", "next"], module.version-tags.tag_list)) : t => module.latest.image_ref },
-    { for t in toset(concat(["latest"], module.version-tags.tag_list)) : "${t}-dev" => module.latest-dev.image_ref },
-  )
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest-dev]
+  digest_ref = module.latest-dev.image_ref
+  tag        = "latest-dev"
 }


### PR DESCRIPTION
The digest of the image remains the same before and after this change:

From `main`:

```
module.nginx.module.tagger.oci_tag.this["latest-dev"]: Creation complete after 2s [id=ttl.sh/jason/nginx:latest-dev@sha256:2773091cfad02f528e31c1b9a06f08dbcba57b365de38cfa16726491515ed6fe]
```

From this branch:
```
module.nginx.oci_tag.latest-dev: Creation complete after 1s [id=ttl.sh/jason/nginx:latest-dev@sha256:2773091cfad02f528e31c1b9a06f08dbcba57b365de38cfa16726491515ed6fe]
```