### PR TITLE
Add prometheus pushgateway image.

### DIFF
--- a/images/prometheus/configs/latest.pushgateway.apko.yaml
+++ b/images/prometheus/configs/latest.pushgateway.apko.yaml
@@ -1,0 +1,23 @@
+contents:
+  packages:
+    - prometheus-pushgateway
+
+entrypoint:
+  command: /usr/bin/pushgateway
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65534
+  users:
+    - username: nonroot
+      uid: 65534
+      gid: 65534
+  run-as: 65534
+
+paths:
+  - path: /pushgateway
+    type: directory
+    permissions: 0o755
+
+work-dir: /pushgateway

--- a/images/prometheus/main.tf
+++ b/images/prometheus/main.tf
@@ -15,6 +15,7 @@ locals {
     "node-exporter",
     "operator",
     "postgres-exporter",
+    "pushgateway",
     "redis-exporter",
   ])
 

--- a/images/prometheus/tests/main.tf
+++ b/images/prometheus/tests/main.tf
@@ -17,6 +17,7 @@ variable "digests" {
     node-exporter          = string
     operator               = string
     postgres-exporter      = string
+    pushgateway            = string
     redis-exporter         = string
   })
 }
@@ -171,5 +172,23 @@ resource "helm_release" "cloudwatch-exporter" {
   set {
     name  = "image.tag"
     value = format("latest@%s", data.oci_string.ref["cloudwatch-exporter"].digest)
+  }
+}
+
+resource "helm_release" "pushgateway" {
+  name       = "pushgateway"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus-pushgateway"
+
+  namespace        = "prometheus-pushgateway"
+  create_namespace = true
+
+  set {
+    name  = "image.repository"
+    value = data.oci_string.ref["pushgateway"].registry_repo
+  }
+  set {
+    name  = "image.tag"
+    value = data.oci_string.ref["pushgateway"].pseudo_tag
   }
 }


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [X] The Image is smaller in size than its common public counterpart.

Notes: 12MB vs 21MB

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes: We don't have these for any of the prometheus images.

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)

### Environment Variables

- [X] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
