### PR TITLE
istio-pilot image for Istio controller containers

### DIFF
--- a/images/istio/README.md
+++ b/images/istio/README.md
@@ -15,8 +15,11 @@
 
 # Istio images:
 
-## Proxy 
+## proxy
 This is the data plane part of Istio, consisting of:
 - A custom-built Envoy that contains Istio plugins (Wasm, telemetry)
 - iptables to route inbound/outbound traffic through the Envoy proxy when acting as a sidecar
 - pilot-agent to bootstrap the Envoy with some Istio-specific configurations
+
+## pilot 
+Istio Pilot provides mesh-wide traffic management, security and policy capabilities in the Istio Service Mesh.

--- a/images/istio/configs/pilot/main.tf
+++ b/images/istio/configs/pilot/main.tf
@@ -1,0 +1,23 @@
+
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. istio-pilot-discovery, istio-pilot-discovery-1.18.2-compat)."
+  default = [
+    "istio-pilot-discovery",
+    "istio-pilot-discovery-compat",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/istio/configs/pilot/template.apko.yaml
+++ b/images/istio/configs/pilot/template.apko.yaml
@@ -1,0 +1,22 @@
+contents:
+  packages: [
+    # istio-pilot-discovery comes from extra_packages
+  ]
+
+paths:
+- path: /run
+  type: directory
+  permissions: 0o755
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nobody
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/local/bin/pilot-discovery

--- a/images/istio/main.tf
+++ b/images/istio/main.tf
@@ -15,6 +15,7 @@ module "test-latest" {
   source = "./tests"
   digests = {
     proxy = module.proxy.image_ref
+    pilot = module.proxy.image_ref
   }
 }
 
@@ -22,6 +23,7 @@ resource "oci_tag" "latest" {
   depends_on = [module.test-latest]
   for_each = {
     "proxy" : module.proxy.image_ref,
+    "pilot" : module.pilot.image_ref,
   }
   digest_ref = each.value
   tag        = "latest"
@@ -31,6 +33,7 @@ resource "oci_tag" "latest-dev" {
   depends_on = [module.test-latest]
   for_each = {
     "proxy" : module.proxy-dev.image_ref,
+    "pilot" : module.pilot-dev.image_ref,
   }
   digest_ref = each.value
   tag        = "latest-dev"

--- a/images/istio/pilot.tf
+++ b/images/istio/pilot.tf
@@ -1,0 +1,22 @@
+module "pilot-config" { source = "./configs/pilot" }
+
+module "pilot" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-pilot"
+  config            = module.pilot-config.config
+}
+
+module "pilot-dev" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-pilot"
+  # Make the dev variant an explicit extension of the
+  # locked original.
+  config         = jsonencode(module.pilot.config)
+  extra_packages = module.dev.extra_packages
+}

--- a/images/istio/tests/main.tf
+++ b/images/istio/tests/main.tf
@@ -8,10 +8,16 @@ variable "digests" {
   description = "The image digest to run tests over."
   type = object({
     proxy = string
+    pilot = string
   })
 }
 
-data "oci_exec_test" "version" {
+data "oci_exec_test" "proxy-version" {
   digest = var.digests.proxy
+  script = "docker run --rm $IMAGE_NAME --version"
+}
+
+data "oci_exec_test" "pilot-version" {
+  digest = var.digests.pilot
   script = "docker run --rm $IMAGE_NAME --version"
 }


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes: CVE-2019-3826 is a false positive because Prometheus versioning (0.44 = 2.44 > bad version 1.17) confusing the scanners.

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
