### PR TITLE
Give nvidia time before wait

### DIFF
--- a/images/nvidia-device-plugin/tests/helm.sh
+++ b/images/nvidia-device-plugin/tests/helm.sh
@@ -12,7 +12,10 @@ helm upgrade --install nvdp nvdp/nvidia-device-plugin \
 # Since it's challenging to satisfy the prerequisites as described in the
 # https://github.com/NVIDIA/k8s-device-plugin#prerequisites, we'll just wait
 # for the Pod to be CrashLoopBackOff and then ensure some of the expected
-# output is present in the logs.
+# output is present in the logs. We cannot kubectl rollout status to wait for
+# pods, so sleep and pray instead.
+
+sleep 20
 
 kubectl wait --for=jsonpath='{.status.containerStatuses[0].state.waiting.reason}'=CrashLoopBackOff pod --selector app.kubernetes.io/name=nvidia-device-plugin -n nvidia-device-plugin
 


### PR DESCRIPTION
I had a test flake with:
```
Test failed for ref registry.local:5000/testing/nvidia-device-plugin@sha256:d50d1bd3d176000f6d8a06786266e1a3f35ce35ba87beb80e8da2b28d02a54c6, got error: exit status 1
+ helm repo add nvdp https://nvidia.github.io/k8s-device-plugin
"nvdp" has been added to your repositories
+ helm upgrade --install nvdp nvdp/nvidia-device-plugin --namespace nvidia-device-plugin --create-namespace --set image.repository=registry.local:5000/testing/nvidia-device-plugin --set image.tag=unused@sha256:d50d1bd3d176000f6d8a06786266e1a3f35ce35ba87beb80e8da2b28d02a54c6
Release "nvdp" does not exist. Installing it now.
NAME: nvdp
LAST DEPLOYED: Fri Sep  8 02:06:12 2023
NAMESPACE: nvidia-device-plugin
STATUS: deployed
REVISION: 1
TEST SUITE: None
+ kubectl wait '--for=jsonpath={.status.containerStatuses[0].state.waiting.reason}=CrashLoopBackOff' pod --selector app.kubernetes.io/name=nvidia-device-plugin -n nvidia-device-plugin
error: no matching resources found
```

This is the telltale sign of creating a bunch of resources and then immediately looking for pods, which may not have even been created yet (by the controller for the higher-level abstraction that was actually applied, here a DaemonSet).
