### PR TITLE
DNM: Checkpoint.

### DIFF
--- a/images/dreamfactory/config/template.apko.yaml
+++ b/images/dreamfactory/config/template.apko.yaml
@@ -1,33 +1,37 @@
 contents:
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  #keyring:
+  #  - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   repositories:
+    - /work/packages
     - https://packages.wolfi.dev/os
   packages:
+    - busybox
     - ca-certificates-bundle
     - wolfi-base
     - ca-certificates-bundle
     # php packages
     - php-8.1
-    - php-xml
-    - php-curl
-    - php-mysqlnd
-    - php-curl
-    - php-soap
-    - php-mbstring
-    - php-zip
-    - php-bcmath
-    - php-dev
-    - php-ldap
-    - php-pgsql
-    - php-gd
-    - php-fpm
+    - php-8.1-xml
+    - php-8.1-curl
+    - php-8.1-mysqlnd
+    - php-8.1-curl
+    - php-8.1-soap
+    - php-8.1-mbstring
+    - php-8.1-zip
+    - php-8.1-bcmath
+    - php-8.1-dev
+    - php-8.1-ldap
+    - php-8.1-pgsql
+    - php-8.1-gd
+    - php-8.1-fpm
+    - php-igbinary
     # python packages
     - python3
     - py3-pip
     - py3-setuptools
     # Base packages:
     - gpg-agent
+    - libmcrypt-dev
     - curl
     - zip
     - wget
@@ -35,6 +39,19 @@ contents:
     - unixodbc-dev
     - gcc
     - cmake
+    - libpq-15
+    - nodejs
+    - npm
+    - readline-dev
+    # PECL packages
+    - php-8.1-pecl-mcrypt
+    - php-8.1-pecl-mongodb
+    - php-8.1-pecl-raphf
+    - php-8.1-pecl-sqlsrv
+    # Disable for now, it fails currently when initializing with:
+    # PHP Warning:  PHP Startup: Unable to load dynamic library 'pdo_sqlsrv' (tried: /usr/lib/php/modules/pdo_sqlsrv (/usr/lib/php/modules/pdo_sqlsrv: cannot open shared object file: No such file or directory), /usr/lib/php/modules/pdo_sqlsrv.so (/usr/lib/php/modules/pdo_sqlsrv.so: undefined symbol: php_pdo_unregister_driver)) in Unknown on line 0
+    #- php-8.1-pecl-pdosqlsrv
+
     # Missing ones so far for php
     # - php-cli
     # - php-sqllite
@@ -42,27 +59,14 @@ contents:
     # - php-sybase
     # - php-odbc
     # - php-http
-    # - php-raphf
     # Missing base packages:
     # - software-properties-common
-    # - cron
-    # - unzip # Though perhaps it's installed by zip above?
-    # - lsof
+    # - cron  # This is installed by busybox
+    # - unzip # This is installed by busybox
+    # - lsof  # This is installed by busybox
     # - mcrypt
-    # - libmcrypt-dev
-    # - libreadline-dev
     # - sudo
     # - build-essential
-    # Missing pecl packages:
-    # These are currently installed via RUN in docker file, and we can't do
-    # that so they need to be added to the package list above.
-    # - pecl install mcrypt
-    # - pecl install mongodb
-    # - pecl install igbinary
-    # - pecl install sqlsrv
-    # - pecl install pdo_sqlsrv
-
-
 
 accounts:
   groups:

--- a/images/dreamfactory/config/template.apko.yaml
+++ b/images/dreamfactory/config/template.apko.yaml
@@ -1,0 +1,80 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - ca-certificates-bundle
+    - wolfi-base
+    - ca-certificates-bundle
+    # php packages
+    - php-8.1
+    - php-xml
+    - php-curl
+    - php-mysqlnd
+    - php-curl
+    - php-soap
+    - php-mbstring
+    - php-zip
+    - php-bcmath
+    - php-dev
+    - php-ldap
+    - php-pgsql
+    - php-gd
+    - php-fpm
+    # python packages
+    - python3
+    - py3-pip
+    - py3-setuptools
+    # Base packages:
+    - gpg-agent
+    - curl
+    - zip
+    - wget
+    - nginx
+    - unixodbc-dev
+    - gcc
+    - cmake
+    # Missing ones so far for php
+    # - php-cli
+    # - php-sqllite
+    # - php-interbase
+    # - php-sybase
+    # - php-odbc
+    # - php-http
+    # - php-raphf
+    # Missing base packages:
+    # - software-properties-common
+    # - cron
+    # - unzip # Though perhaps it's installed by zip above?
+    # - lsof
+    # - mcrypt
+    # - libmcrypt-dev
+    # - libreadline-dev
+    # - sudo
+    # - build-essential
+    # Missing pecl packages:
+    # These are currently installed via RUN in docker file, and we can't do
+    # that so they need to be added to the package list above.
+    # - pecl install mcrypt
+    # - pecl install mongodb
+    # - pecl install igbinary
+    # - pecl install sqlsrv
+    # - pecl install pdo_sqlsrv
+
+
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/php
+cmd: --help
+

--- a/images/dreamfactory/image.yaml
+++ b/images/dreamfactory/image.yaml
@@ -1,0 +1,3 @@
+versions:
+  - apko:
+      config: configs/latest.apko.yaml

--- a/images/dreamfactory/manifest.json
+++ b/images/dreamfactory/manifest.json
@@ -1,0 +1,1 @@
+[{"Config":"sha256:725fa281c682df8f6529f75bd6b5f4c8c06a723ce50fdafe47d3ff4c5eb60661","RepoTags":["index.docker.io/library/dreamfactory:test-arm64"],"Layers":["c3b208aa479c4e19deac5a86c75efc7298d986f4ff4789b87acc13ff5bdc9e4e.tar.gz"]}]


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
