### PR TITLE
Add prometheus mongodb exporter.

### DIFF
--- a/images/prometheus/configs/latest.mongodb-exporter.apko.yaml
+++ b/images/prometheus/configs/latest.mongodb-exporter.apko.yaml
@@ -1,0 +1,17 @@
+contents:
+  packages:
+    - prometheus-mongodb-exporter
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+  recursive: true
+
+entrypoint:
+  command: /usr/bin/mongodb_exporter

--- a/images/prometheus/main.tf
+++ b/images/prometheus/main.tf
@@ -11,6 +11,7 @@ locals {
     "config-reloader",
     "core",
     "elasticsearch-exporter",
+    "mongodb-exporter",
     "mysqld-exporter",
     "node-exporter",
     "operator",

--- a/images/prometheus/tests/main.tf
+++ b/images/prometheus/tests/main.tf
@@ -13,6 +13,7 @@ variable "digests" {
     core                   = string
     config-reloader        = string
     elasticsearch-exporter = string
+    mongodb-exporter       = string
     mysqld-exporter        = string
     node-exporter          = string
     operator               = string
@@ -190,5 +191,23 @@ resource "helm_release" "pushgateway" {
   set {
     name  = "image.tag"
     value = data.oci_string.ref["pushgateway"].pseudo_tag
+  }
+}
+
+resource "helm_release" "mongodb" {
+  name       = "mongodb"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus-mongodb-exporter"
+
+  namespace        = "prometheus-mongodb-exporter"
+  create_namespace = true
+
+  set {
+    name  = "image.repository"
+    value = data.oci_string.ref["mongodb-exporter"].registry_repo
+  }
+  set {
+    name  = "image.tag"
+    value = data.oci_string.ref["mongodb-exporter"].pseudo_tag
   }
 }


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size

- [X] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)

### Environment Variables

- [ ] Environment variables added.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
