### PR TITLE
Refactor `kubernetes-csi-node-driver-registrar`

### DIFF
--- a/images/kubernetes-csi-node-driver-registrar/config/main.tf
+++ b/images/kubernetes-csi-node-driver-registrar/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. kubernetes-csi-node-driver-registrar, kubernetes-csi-node-driver-registrar-2.8)."
+  default     = ["kubernetes-csi-node-driver-registrar", "kubernetes-csi-node-driver-registrar-compat"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/kubernetes-csi-node-driver-registrar/config/template.apko.yaml
+++ b/images/kubernetes-csi-node-driver-registrar/config/template.apko.yaml
@@ -1,7 +1,7 @@
 contents:
-  packages:
-    - kubernetes-csi-node-driver-registrar
-    - kubernetes-csi-node-driver-registrar-compat
+  packages: [
+    # CSI Node Driver comes from var.extra_packages
+  ]
 
 accounts:
   groups:

--- a/images/kubernetes-csi-node-driver-registrar/main.tf
+++ b/images/kubernetes-csi-node-driver-registrar/main.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
     apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
   }
 }
 
@@ -8,19 +9,15 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
+module "latest-config" { source = "./config" }
+
 module "latest" {
   source = "../../tflib/publisher"
 
   name = basename(path.module)
 
   target_repository = var.target_repository
-  config            = file("${path.module}/configs/latest.apko.yaml")
-}
-
-module "version-tags" {
-  source  = "../../tflib/version-tags"
-  package = "kubernetes-csi-node-driver-registrar"
-  config  = module.latest.config
+  config            = module.latest-config.config
 }
 
 module "test-latest" {
@@ -28,12 +25,8 @@ module "test-latest" {
   digest = module.latest.image_ref
 }
 
-module "tagger" {
-  source = "../../tflib/tagger"
-
+resource "oci_tag" "latest" {
   depends_on = [module.test-latest]
-
-  tags = merge(
-    { for t in toset(concat(["latest"], module.version-tags.tag_list)) : t => module.latest.image_ref },
-  )
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
 }


### PR DESCRIPTION
This adopts the "virtual package" pattern ahead of version streaming this package.