### PR TITLE
Switch the package name to version streamed.

### DIFF
--- a/images/calico/main.tf
+++ b/images/calico/main.tf
@@ -28,7 +28,7 @@ locals {
     "calicoctl" : "calicoctl",
     "csi" : "calico-pod2daemon",
     "typha" : "calico-typhad",
-    "node-driver-registrar" : "kubernetes-csi-node-driver-registrar",
+    "node-driver-registrar" : "kubernetes-csi-node-driver-registrar-2.9",
   })
 
   // Normally the repository is named like "calico-{component}"


### PR DESCRIPTION
This package was version streamed yesterday and I didn't realize we had two image builds of the same package.
