### PR TITLE
ensure argocd uses the actual helm chart

### DIFF
--- a/images/argocd/tests/main.tf
+++ b/images/argocd/tests/main.tf
@@ -18,13 +18,13 @@ data "oci_string" "ref" {
   input    = each.value
 }
 
-resource "helm_release" "argocd-repo-server" {
-  name = "argocd-repo-server"
+resource "helm_release" "argocd" {
+  name = "argocd"
 
   repository = "https://argoproj.github.io/argo-helm"
-  chart      = "argo"
+  chart      = "argo-cd"
 
-  namespace        = "argocd-repo-server"
+  namespace        = "argocd"
   create_namespace = true
 
   # The argocd helm chart installs CRDs from the `templates/` directory,


### PR DESCRIPTION
The existing chart (`argo`) is using some extremely outdated, non representative deployment of argocd (`argo-cd`).

This also renames things to deloy `argocd` with its `argocd-repo-server` component.

Ref: https://artifacthub.io/packages/helm/argo/argo-cd