### PR TITLE
kubernetes-csi-external-attacher: fix template 

### DIFF
--- a/images/kubernetes-csi-external-attacher/config/template.apko.yaml
+++ b/images/kubernetes-csi-external-attacher/config/template.apko.yaml
@@ -1,6 +1,7 @@
 contents:
-  packages:
-    - kubernetes-csi-external-attacher
+  packages: [
+    # Package comes from extra-packages
+  ]
 
 accounts:
   groups:


### PR DESCRIPTION
`kubernetes-csi-external-attacher` is duplicated in template and `extra_packages`.

See https://github.com/chainguard-images/images/blob/main/images/kubernetes-csi-external-attacher/config/template.apko.yaml