### PR TITLE
Add namespace to csi-external-attacher tests

### DIFF
--- a/images/kubernetes-csi-external-attacher/tests/deploy.sh
+++ b/images/kubernetes-csi-external-attacher/tests/deploy.sh
@@ -2,11 +2,17 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-curl https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/deployment.yaml | \
-    sed "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:.*|${IMAGE_NAME}|g" | \
-    kubectl apply -f -
-kubectl apply -f  https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/rbac.yaml
+: "${NAMESPACE:=default}"
+kubectl create ns $NAMESPACE || true
+
+curl https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/deployment.yaml \
+    | sed "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:.*|${IMAGE_NAME}|g" \
+    | kubectl apply -n $NAMESPACE -f -
+
+curl https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/rbac.yaml \
+    | sed "s|namespace: default|namespace: $NAMESPACE|g" \
+    | kubectl apply -n $NAMESPACE -f -
 
 sleep 5
 
-kubectl rollout status deployment csi-attacher --timeout=120s
+kubectl rollout status deployment -n $NAMESPACE csi-attacher --timeout=120s

--- a/images/kubernetes-csi-external-attacher/tests/main.tf
+++ b/images/kubernetes-csi-external-attacher/tests/main.tf
@@ -8,7 +8,13 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
+resource "random_pet" "suffix" {}
+
 data "oci_exec_test" "deploy" {
   digest = var.digest
   script = "${path.module}/deploy.sh"
+  env {
+    name  = "NAMESPACE"
+    value = "csi-attacher-${random_pet.suffix.id}"
+  }
 }


### PR DESCRIPTION
This allows running tests of different versions side-by-side.