### PR TITLE
prometheus-statsd-exporter: allow non conflicting helm release resources

### DIFF
--- a/images/prometheus-statsd-exporter/tests/main.tf
+++ b/images/prometheus-statsd-exporter/tests/main.tf
@@ -17,8 +17,10 @@ data "oci_string" "ref" {
   input = var.digest
 }
 
+resource "random_pet" "suffix" {}
+
 resource "helm_release" "test" {
-  name       = "prometheus"
+  name       = "prometheus-statsd-exporter-${random_pet.suffix.id}"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "prometheus-statsd-exporter"
 


### PR DESCRIPTION
This is needed so that we can invoke the test module multiple times without them conflicting.