### PR TITLE
fluentd-latest-dev image

### DIFF
--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -41,6 +41,7 @@ module "tagger" {
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : t => module.latest.image_ref },
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-dev" => module.latest-dev.image_ref },
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk" => module.latest-splunk.image_ref }
+    { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk-dev" => module.latest-splunk.image_ref }
   )
 }
 

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -18,12 +18,6 @@ locals {
   ]
 }
 
-module "splunk-dev" { source = "../../tflib/splunk-dev-subvariant" }
-
-locals {
-  fluentd_splunk_dev = concat(module.splunk-dev.extra_packages, ["build-base","ruby3.2-bundler","ruby-3.2-dev"])
-}
-
 module "tagger" {
   source = "../../tflib/tagger"
 
@@ -84,7 +78,7 @@ module "latest-splunk-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = local.fluentd_splunk_dev
+  extra_packages = local.fluentd_dev
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -77,7 +77,7 @@ module "latest-splunk-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = local.fluent_dev
+  extra_packages = local.fluentd_dev
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -25,7 +25,6 @@ locals {
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
-    "busybox",
   ]) 
 }
 

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -18,16 +18,13 @@ locals {
   ])
 }
 
-module "dev" { source = "../../tflib/splunk-dev-subvariant" }
+module "splunk-dev" { source = "../../tflib/splunk-dev-subvariant" }
 
 locals {
-  fluentd_splunk_dev = concat(module.dev.extra_packages, [
+  fluentd_splunk_dev = concat(module.splunk-dev.extra_packages, [
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
-    "ruby3.2-fluent-plugin-splunk-hec",
-    "fluent-plugin-out-http",
-    "busybox,
   ]) 
 }
 
@@ -45,7 +42,7 @@ module "tagger" {
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : t => module.latest.image_ref },
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-dev" => module.latest-dev.image_ref },
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk" => module.latest-splunk.image_ref }
-    { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk-dev" => module.latest-splunk.image_ref }
+    { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk-dev" => module.latest-splunk-dev.image_ref }
   )
 }
 

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -77,7 +77,7 @@ module "latest-splunk-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = local.fluentd_dev
+  extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http", "${local.fluentd_dev}"]
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -68,6 +68,18 @@ module "latest-splunk" {
   extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http"]
 }
 
+module "latest-splunk-dev" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = var.target_repository
+  # Make the dev variant an explicit extension of the
+  # locked original.
+  config         = jsonencode(module.latest.config)
+  extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http", local.fluent_dev]
+}
+
 module "version-tags-latest" {
   source  = "../../tflib/version-tags"
   package = "ruby3.2-fluentd"

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -25,6 +25,7 @@ locals {
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
+    "busybox",
   ]) 
 }
 
@@ -41,7 +42,7 @@ module "tagger" {
 
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : t => module.latest.image_ref },
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-dev" => module.latest-dev.image_ref },
-    { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk" => module.latest-splunk.image_ref }
+    { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk" => module.latest-splunk.image_ref },
     { for t in toset(concat(["latest"], module.version-tags-latest.tag_list)) : "${t}-splunk-dev" => module.latest-splunk-dev.image_ref }
   )
 }

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -78,7 +78,7 @@ module "latest-splunk-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = local.fluentd_dev
+  extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http", local.fluentd_dev]
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -87,7 +87,7 @@ module "latest-splunk-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http", local.fluentd_dev]
+  extra_packages = local.fluentd_splunk_dev
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -25,7 +25,6 @@ locals {
     "busybox",
 
   ])
-  
 }
 
 module "tagger" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -15,17 +15,13 @@ locals {
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
-  ])
+  ]
 }
 
 module "splunk-dev" { source = "../../tflib/splunk-dev-subvariant" }
 
 locals {
-  fluentd_splunk_dev = concat(module.splunk-dev.extra_packages, [
-    "build-base",
-    "ruby3.2-bundler",
-    "ruby-3.2-dev",
-  ]) 
+  fluentd_splunk_dev = concat(module.splunk-dev.extra_packages, ["build-base","ruby3.2-bundler","ruby-3.2-dev"])
 }
 
 module "tagger" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -16,7 +16,11 @@ locals {
     "ruby3.2-bundler",
     "ruby-3.2-dev",
   ])
+}
 
+module "dev" { source = "../../tflib/splunk-dev-subvariant" }
+
+locals {
   fluentd_splunk_dev = concat(module.dev.extra_packages, [
     "build-base",
     "ruby3.2-bundler",

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -15,7 +15,15 @@ locals {
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
+  ]),
+
+  fluentd_splunk_dev = concat(module.dev.extra_packages, [
+    "build-base",
+    "ruby3.2-bundler",
+    "ruby-3.2-dev",
+    "busybox",
   ])
+  
 }
 
 module "tagger" {
@@ -66,7 +74,7 @@ module "latest-splunk" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http"]
+  extra_packages = local.fluentd_splunk_dev
 }
 
 module "latest-splunk-dev" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -15,16 +15,12 @@ locals {
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
-
   ])
 
-  fluentd_splunk_dev = concat(module.dev.extra_packages, [
-    "build-base",
-    "ruby3.2-bundler",
-    "ruby-3.2-dev",
-    "busybox",
-
-  ])
+  splunk = [
+    "ruby3.2-fluent-plugin-splunk-hec",
+    "fluent-plugin-out-http",
+  ]
 }
 
 module "tagger" {
@@ -75,7 +71,7 @@ module "latest-splunk" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = local.fluentd_splunk_dev
+  extra_packages = local.splunk
 }
 
 module "latest-splunk-dev" {
@@ -86,8 +82,8 @@ module "latest-splunk-dev" {
   target_repository = var.target_repository
   # Make the dev variant an explicit extension of the
   # locked original.
-  config         = jsonencode(module.latest.config)
-  extra_packages = local.fluentd_splunk_dev
+  config         = jsonencode(module.latest-dev.config)
+  extra_packages = concat(local.fluentd_dev, local.splunk)
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -15,6 +15,7 @@ locals {
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
+
   ]),
 
   fluentd_splunk_dev = concat(module.dev.extra_packages, [
@@ -22,6 +23,7 @@ locals {
     "ruby3.2-bundler",
     "ruby-3.2-dev",
     "busybox",
+
   ])
   
 }

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -15,7 +15,7 @@ locals {
     "build-base",
     "ruby3.2-bundler",
     "ruby-3.2-dev",
-  ]
+  ])
 }
 
 module "tagger" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -16,7 +16,7 @@ locals {
     "ruby3.2-bundler",
     "ruby-3.2-dev",
 
-  ]),
+  ])
 
   fluentd_splunk_dev = concat(module.dev.extra_packages, [
     "build-base",

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -16,6 +16,15 @@ locals {
     "ruby3.2-bundler",
     "ruby-3.2-dev",
   ])
+
+  fluentd_splunk_dev = concat(module.dev.extra_packages, [
+    "build-base",
+    "ruby3.2-bundler",
+    "ruby-3.2-dev",
+    "ruby3.2-fluent-plugin-splunk-hec",
+    "fluent-plugin-out-http",
+    "busybox,
+  ]) 
 }
 
 module "tagger" {
@@ -77,7 +86,7 @@ module "latest-splunk-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http", "${local.fluentd_dev}"]
+  extra_packages = local.fluentd_splunk_dev
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -80,10 +80,10 @@ module "latest-splunk-dev" {
   name = basename(path.module)
 
   target_repository = var.target_repository
-  # Make the dev variant an explicit extension of the
-  # locked original.
+  # Make the splunk-dev variant an explicit extension of the
+  # original dev variant, with splunk packages.
   config         = jsonencode(module.latest-dev.config)
-  extra_packages = concat(local.fluentd_dev, local.splunk)
+  extra_packages = local.splunk
 }
 
 module "version-tags-latest" {

--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -77,7 +77,7 @@ module "latest-splunk-dev" {
   # Make the dev variant an explicit extension of the
   # locked original.
   config         = jsonencode(module.latest.config)
-  extra_packages = ["ruby3.2-fluent-plugin-splunk-hec", "fluent-plugin-out-http", local.fluent_dev]
+  extra_packages = local.fluent_dev
 }
 
 module "version-tags-latest" {


### PR DESCRIPTION
Adding a dev image for the splunk variant to allow shell access and testing plugins

## Chainguard Images Pull Request Template

### Image Size

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:
webrick  1.8.1                gem   CVE-2008-1145  Medium

### Basic Testing - K8s cluster

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [x] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [x] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
