### PR TITLE
Add istio operator image.

### DIFF
--- a/images/istio/configs/operator/main.tf
+++ b/images/istio/configs/operator/main.tf
@@ -1,0 +1,22 @@
+
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. istio-operator."
+  default = [
+    "istio-operator",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/istio/configs/operator/template.apko.yaml
+++ b/images/istio/configs/operator/template.apko.yaml
@@ -1,0 +1,17 @@
+contents:
+  packages: [
+    # istio-operator comes from extra_packages
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nobody
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/operator

--- a/images/istio/main.tf
+++ b/images/istio/main.tf
@@ -14,8 +14,9 @@ module "dev" { source = "../../tflib/dev-subvariant" }
 module "test-latest" {
   source = "./tests"
   digests = {
-    proxy = module.proxy.image_ref
-    pilot = module.proxy.image_ref
+    proxy    = module.proxy.image_ref
+    pilot    = module.pilot.image_ref
+    operator = module.operator.image_ref
   }
 }
 
@@ -24,6 +25,7 @@ resource "oci_tag" "latest" {
   for_each = {
     "proxy" : module.proxy.image_ref,
     "pilot" : module.pilot.image_ref,
+    "operator" : module.operator.image_ref,
   }
   digest_ref = each.value
   tag        = "latest"
@@ -34,6 +36,7 @@ resource "oci_tag" "latest-dev" {
   for_each = {
     "proxy" : module.proxy-dev.image_ref,
     "pilot" : module.pilot-dev.image_ref,
+    "operator" : module.operator-dev.image_ref,
   }
   digest_ref = each.value
   tag        = "latest-dev"

--- a/images/istio/operator.tf
+++ b/images/istio/operator.tf
@@ -1,0 +1,22 @@
+module "operator-config" { source = "./configs/operator" }
+
+module "operator" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-operator"
+  config            = module.operator-config.config
+}
+
+module "operator-dev" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-operator"
+  # Make the dev variant an explicit extension of the
+  # locked original.
+  config         = jsonencode(module.operator.config)
+  extra_packages = module.dev.extra_packages
+}

--- a/images/istio/tests/main.tf
+++ b/images/istio/tests/main.tf
@@ -1,14 +1,16 @@
 terraform {
   required_providers {
-    oci = { source = "chainguard-dev/oci" }
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
   }
 }
 
 variable "digests" {
   description = "The image digest to run tests over."
   type = object({
-    proxy = string
-    pilot = string
+    proxy    = string
+    pilot    = string
+    operator = string
   })
 }
 
@@ -20,4 +22,26 @@ data "oci_exec_test" "proxy-version" {
 data "oci_exec_test" "pilot-version" {
   digest = var.digests.pilot
   script = "docker run --rm $IMAGE_NAME --version"
+}
+
+data "oci_exec_test" "operator-version" {
+  digest = var.digests.operator
+  script = "docker run --rm $IMAGE_NAME version"
+}
+
+data "oci_string" "ref" { input = var.digests.operator }
+
+resource "helm_release" "operator" {
+  name = "operator"
+
+  # There's no official helm chart for the istio operator
+  repository = "https://stevehipwell.github.io/helm-charts/"
+  chart      = "istio-operator"
+
+  values = [jsonencode({
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = data.oci_string.ref.pseudo_tag
+    }
+  })]
 }


### PR DESCRIPTION
## Chainguard Images Pull Request Template


### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [X] The Image is smaller in size than its common public counterpart.

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For utilities/tooling bring up help e.g. `–help`

### Environment Variables

- [X] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
