### PR TITLE
kubernetes-csi-external-attacher: fix cluster-level resource name collision

### DIFF
--- a/images/kubernetes-csi-external-attacher/tests/deploy.sh
+++ b/images/kubernetes-csi-external-attacher/tests/deploy.sh
@@ -11,6 +11,8 @@ curl https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/d
 
 curl https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/rbac.yaml \
     | sed "s|namespace: default|namespace: $NAMESPACE|g" \
+    | sed "s|csi-attacher-role|csi-attacher-role-$NAMESPACE|g" \
+    | sed "s|external-attacher-runner|external-attacher-runner-$NAMESPACE|g" \
     | kubectl apply -n $NAMESPACE -f -
 
 sleep 5


### PR DESCRIPTION
Fix cluster level test resource name collision to allow tests to run side-by-side.