### PR TITLE
bump release runner fanout to 4c runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         modified-files: ${{ steps.build-filter.outputs.filter }}
 
   build-0:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     needs: [generate-matrix]
     strategy:
       fail-fast: false


### PR DESCRIPTION
we're seeing:

```
  Warning  Evicted    3m28s  kubelet            The node had condition: [DiskPressure].
```

now on some legs of the build.

this bumps us up (slightly) to 4c runners, which also have _significantly_ larger disks

ref: https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners#machine-sizes-for-larger-runners