### PR TITLE
Adding missing GPG package for argoCD

### DIFF
--- a/images/argocd/configs/latest.argocd.apko.yaml
+++ b/images/argocd/configs/latest.argocd.apko.yaml
@@ -3,6 +3,7 @@ contents:
     - busybox
     - argo-cd
     - argo-cd-compat
+    - gpg
 
 accounts:
   groups:

--- a/images/argocd/configs/latest.repo-server.apko.yaml
+++ b/images/argocd/configs/latest.repo-server.apko.yaml
@@ -3,6 +3,7 @@ contents:
     - busybox
     - argo-cd-repo-server
     - argo-cd-compat
+    - gpg
 
 accounts:
   groups:


### PR DESCRIPTION
During running an argoCD image from chainguard there is a problem with running argocd-repo-server successfully.
The following error appears in the logs:
```
time="2023-09-19T10:16:46Z" level=fatal msg="exec: \"gpg\": executable file not found in $PATH"
```
Quick search-through the argo-cd repository, and yeah it uses gpg internally:
```
OUTPUT=$(gpg $ARGS 2>&1)
```
https://github.com/argoproj/argo-cd/blob/df714accc0184fea0f09cfa8a4e1d4ed4a6a7b4b/hack/gpg-wrapper.sh#L4

gpg is not in the packages list in the repo, hence adding it.

