### PR TITLE
prometheus-adapter: fix test

### DIFF
--- a/images/prometheus-adapter/tests/cleanup.sh
+++ b/images/prometheus-adapter/tests/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# The helm chart needs to be completely uninstalled between testing different versions
+# This is because the Helm Chart creates cluster-level resources that need to be deleted and recreated (ClusterRole, APIService etc)
+# otherwise Terraform spits out this error: `Unable to continue with install: APIService "v1beta1.custom.metrics.k8s.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata`
+
+helm uninstall prometheus-adapter --wait

--- a/images/prometheus-adapter/tests/main.tf
+++ b/images/prometheus-adapter/tests/main.tf
@@ -12,10 +12,8 @@ data "oci_string" "ref" {
   input = var.digest
 }
 
-resource "random_pet" "suffix" {}
-
 resource "helm_release" "test" {
-  name       = "prometheus-adapter-${random_pet.suffix.id}"
+  name       = "prometheus-adapter"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "prometheus-adapter"
 
@@ -25,4 +23,10 @@ resource "helm_release" "test" {
       tag        = data.oci_string.ref.pseudo_tag
     }
   })]
+}
+
+data "oci_exec_test" "cleanup" {
+  digest     = var.digest
+  script     = "${path.module}/cleanup.sh"
+  depends_on = [helm_release.test]
 }


### PR DESCRIPTION
this helm chart installs cluster level resources. if we're using this module to test different versions, the entire Helm Chart needs to be uninstalled for a new version to be installed.

