### PR TITLE
crossplane tests: enable pushing to a private repo

### DIFF
--- a/images/crossplane-aws/tests/install.sh
+++ b/images/crossplane-aws/tests/install.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 
-set -o errexit -o nounset -o errtrace -o pipefail -x
+set -o errexit -o nounset -o errtrace -o pipefail
+
+# If the image is on cgr.dev and we have a cred helper for that available, use
+# it to generate creds we can pass to the Crossplane control plane.
+# This is necessary when pushing to a private repo, since the Crossplane
+# control plane needs to pull the image to get configuration from it.
+tmp=$(mktemp -d)
+echo "{}" > ${tmp}/config.json
+if [ -x "$(command -v docker-credential-cgr)" ]; then
+  token=$(echo "cgr.dev" | docker-credential-cgr get)
+  user=$(echo $token | jq -r '.Username')
+  pass=$(echo $token | jq -r '.Secret')
+
+  DOCKER_CONFIG=${tmp} crane auth login -u ${user} -p ${pass} cgr.dev
+  echo "WROTE ${tmp}/config.json"
+fi
+head -c 100 ${tmp}/config.json
+kubectl delete secret regcred -n crossplane-system || true
+kubectl create secret generic regcred \
+  -n crossplane-system \
+  --from-file=.dockerconfigjson=${tmp}/config.json \
+  --type=kubernetes.io/dockerconfigjson
 
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -9,6 +30,8 @@ metadata:
   name: provider-aws-iam
 spec:
   package: ${IAM_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -18,6 +41,8 @@ metadata:
   name: provider-aws-rds
 spec:
   package: ${RDS_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -27,6 +52,8 @@ metadata:
   name: provider-aws-s3
 spec:
   package: ${S3_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 for provider in iam rds s3; do
@@ -43,6 +70,8 @@ metadata:
   name: upbound-provider-family-aws
 spec:
   package: ${AWS_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 kubectl wait --for=condition=Installed provider/upbound-provider-family-aws --timeout=3m

--- a/images/crossplane-azure/tests/install.sh
+++ b/images/crossplane-azure/tests/install.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 
-set -o errexit -o nounset -o errtrace -o pipefail -x
+set -o errexit -o nounset -o errtrace -o pipefail
+
+# If the image is on cgr.dev and we have a cred helper for that available, use
+# it to generate creds we can pass to the Crossplane control plane.
+# This is necessary when pushing to a private repo, since the Crossplane
+# control plane needs to pull the image to get configuration from it.
+tmp=$(mktemp -d)
+echo "{}" > ${tmp}/config.json
+if [ -x "$(command -v docker-credential-cgr)" ]; then
+  token=$(echo "cgr.dev" | docker-credential-cgr get)
+  user=$(echo $token | jq -r '.Username')
+  pass=$(echo $token | jq -r '.Secret')
+
+  DOCKER_CONFIG=${tmp} crane auth login -u ${user} -p ${pass} cgr.dev
+  echo "WROTE ${tmp}/config.json"
+fi
+head -c 100 ${tmp}/config.json
+kubectl delete secret regcred -n crossplane-system || true
+kubectl create secret generic regcred \
+  -n crossplane-system \
+  --from-file=.dockerconfigjson=${tmp}/config.json \
+  --type=kubernetes.io/dockerconfigjson
 
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -9,6 +30,8 @@ metadata:
   name: provider-azure-authorization
 spec:
   package: ${AUTHORIZATION_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -18,6 +41,8 @@ metadata:
   name: provider-azure-managedidentity
 spec:
   package: ${MANAGEDIDENTITY_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -27,6 +52,8 @@ metadata:
   name: provider-azure-sql
 spec:
   package: ${SQL_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -36,6 +63,8 @@ metadata:
   name: provider-azure-storage
 spec:
   package: ${STORAGE_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 for provider in authorization managedidentity sql storage; do
@@ -52,6 +81,8 @@ metadata:
   name: upbound-provider-family-azure
 spec:
   package: ${AZURE_DIGEST}
+  packagePullSecrets:
+  - name: regcred
 EOF
 
 kubectl wait --for=condition=Installed provider/upbound-provider-family-azure --timeout=3m


### PR DESCRIPTION
These tests pass when pushing to cgr.dev/chainguard, where anybody can pull, but fail when pushed to another non-public repo on cgr.dev (or, I suppose, any private repo anywhere).

The tests fail because the Crossplane control plane running on the cluster doesn't have permission to pull the image, which it needs to do to extract provider metadata from it.

This PR updates the test to check if the cgr cred helper is installed, and if so, populate an ephemeral Docker config, and populate a Kubernetes Secret with those creds, and tell the Crossplane control plane to use the secret to pull.

This passed for me locally with:

```
terraform apply -var=target_repository=cgr.dev/imjasonh.dev -target=module.crossplane-aws -auto-approve
```