### PR TITLE
aws-efs-csi-driver: Fix /csi permissions

### DIFF
--- a/images/aws-efs-csi-driver/configs/latest.apko.yaml
+++ b/images/aws-efs-csi-driver/configs/latest.apko.yaml
@@ -20,6 +20,12 @@ accounts:
     gid: 65532
     permissions: 0o755
     recursive: true
+  - path: /csi/
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
 
 entrypoint:
   command: aws-efs-csi-driver


### PR DESCRIPTION
When this boots up, it attempts to delete `/csi/csi.sock` and then listen on it, but does not have permissions to do so.
