### PR TITLE
Fix tekton smoke test by pinning to v0.52.0

### DIFF
--- a/images/tekton/tests/test.sh
+++ b/images/tekton/tests/test.sh
@@ -11,7 +11,8 @@ SIDECARLOGRESULTS_IMAGE=${SIDECARLOGRESULTS_IMAGE:-gcr.io/tekton-releases/github
 WEBHOOK_IMAGE=${WEBHOOK_IMAGE:-gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.49.0}
 WORKINGDIRINIT_IMAGE=${WORKINGDIRINIT_IMAGE:-gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/workingdirinit:v0.49.0}
 
-curl -sL https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml | \
+# TODO(jason): Use latest when it's kept up to date with releases.
+curl -sL https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.52.0/release.yaml | \
     sed "s|gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller[a-z0-9:@.]\{1,\}|${CONTROLLER_IMAGE}|g" | \
     sed "s|gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint[a-z0-9:@.]\{1,\}|${ENTRYPOINT_IMAGE}|g" | \
     sed "s|gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/events[a-z0-9:@.]\{1,\}|${EVENTS_IMAGE}|g" | \


### PR DESCRIPTION
Tekton's releases aren't updating the `latest` release.yaml, and our latest image depends on configuration in the latest release (`config-tracing`, specifically, possibly others).

This updates the test to pin to the latest release v0.52.0 until such a time as the `latest` release.yaml is updated with new releases.