### PR TITLE
Drop terraform things from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,3 @@ updates:
     directory: "./"
     schedule:
       interval: "daily"
-  - package-ecosystem: terraform
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: terraform
-    directory: "/tflib/publisher"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
These generally require a bit of hand-holding anyway and trigger rebuilds of the world, so don't automate them.