### PR TITLE
aws-efs-csi-driver: Outdent paths

### DIFF
--- a/images/aws-efs-csi-driver/configs/latest.apko.yaml
+++ b/images/aws-efs-csi-driver/configs/latest.apko.yaml
@@ -13,19 +13,19 @@ accounts:
   run-as: 65532
   recursive: true
 
-  paths:
-  - path: /etc/amazon/efs/
-    type: directory
-    uid: 65532
-    gid: 65532
-    permissions: 0o755
-    recursive: true
-  - path: /csi/
-    type: directory
-    uid: 65532
-    gid: 65532
-    permissions: 0o755
-    recursive: true
+paths:
+- path: /etc/amazon/efs/
+  type: directory
+  uid: 65532
+  gid: 65532
+  permissions: 0o755
+  recursive: true
+- path: /csi/
+  type: directory
+  uid: 65532
+  gid: 65532
+  permissions: 0o755
+  recursive: true
 
 entrypoint:
   command: aws-efs-csi-driver


### PR DESCRIPTION
This had incorrect indentation, so paths was ignored!