### PR TITLE
migrate bash image to config module pattern

### DIFF
--- a/images/bash/config/main.tf
+++ b/images/bash/config/main.tf
@@ -1,0 +1,20 @@
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat([
+        "bash",
+        "busybox",
+        "curl",
+      ], var.extra_packages)
+    }
+    entrypoint = {
+      command = "/bin/bash -c"
+    }
+  })
+}

--- a/images/bash/configs/latest.apko.yaml
+++ b/images/bash/configs/latest.apko.yaml
@@ -1,9 +1,0 @@
-contents:
-  packages:
-    - curl
-    - bash
-    - busybox
-
-entrypoint:
-  command: /bin/bash -c
-


### PR DESCRIPTION
The original image config doesn't specify an `accounts` block, which is mildly concerning...