### PR TITLE
Add a test of Envoy serving static rules

### DIFF
--- a/images/envoy/tests/main.tf
+++ b/images/envoy/tests/main.tf
@@ -12,3 +12,15 @@ data "oci_exec_test" "version" {
   digest = var.digest
   script = "docker run --rm $IMAGE_NAME envoy --version | grep '^envoy  version:'"
 }
+
+resource "random_pet" "suffix" {}
+
+data "oci_exec_test" "serving-static-rules" {
+  digest = var.digest
+  script = "${path.module}/static.sh"
+
+  env {
+    name  = "NAMESPACE"
+    value = "envoy-static-${random_pet.suffix.id}"
+  }
+}

--- a/images/envoy/tests/static.sh
+++ b/images/envoy/tests/static.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Create namespace and deployment.
+: "${NAMESPACE:=default}"
+kubectl create ns $NAMESPACE || true
+sed "s|IMAGE_NAME|$IMAGE_NAME|g" $SCRIPT_DIR/static.yaml \
+    | kubectl apply -n $NAMESPACE -f-
+
+# The readiness check actually verifies Envoy serving
+# the static config, we only need to wait for deployment
+# to be ready.
+kubectl rollout status deployment -n $NAMESPACE envoy

--- a/images/envoy/tests/static.yaml
+++ b/images/envoy/tests/static.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config
+data:
+  static.yaml: |
+    static_resources:
+      listeners:
+      - name: listener_0
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8080
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: edge
+              http_filters:
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              route_config:
+                virtual_hosts:
+                - name: direct_response_service
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: "/test-envoy-static"
+                    direct_response:
+                      status: 200
+                      body:
+                        inline_string: |
+                          Yes it's working
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy
+spec:
+  selector:
+    matchLabels:
+      app: envoy
+  template:
+    metadata:
+      labels:
+        app: envoy
+    spec:
+      containers:
+      - name: envoy
+        image: IMAGE_NAME
+        args:
+          - "--config-path"
+          - "/etc/envoy-config/static.yaml"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            port: 8080
+            path: /test-envoy-static
+        volumeMounts:
+        - name: envoy-config
+          mountPath: /etc/envoy-config
+      volumes:
+      - name: envoy-config
+        configMap:
+          name: envoy-config


### PR DESCRIPTION
This test confirms that Envoy can serve a simple static `direct_response` route from a config file.