### PR TITLE
Add istio-install-cni images

### DIFF
--- a/images/istio/configs/install-cni/main.tf
+++ b/images/istio/configs/install-cni/main.tf
@@ -5,9 +5,12 @@ terraform {
 }
 
 variable "extra_packages" {
-  description = "The additional packages to install (e.g. istio-operator."
+  description = "The additional packages to install (e.g. istio-install-cni, istio-cni...)"
   default = [
-    "istio-operator",
+    "istio-install-cni",
+    "istio-install-cni-compat",
+    "istio-cni",
+    "istio-cni-compat",
   ]
 }
 

--- a/images/istio/configs/install-cni/template.apko.yaml
+++ b/images/istio/configs/install-cni/template.apko.yaml
@@ -1,0 +1,18 @@
+contents:
+  packages: [
+    # istio-cni and istio-install-cni and compat packages
+    # come from extra_packages
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nobody
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/local/bin/install-cni

--- a/images/istio/install-cni.tf
+++ b/images/istio/install-cni.tf
@@ -1,0 +1,11 @@
+module "install-cni-config" { source = "./configs/install-cni" }
+
+module "install-cni" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-install-cni"
+  config            = module.install-cni-config.config
+  build-dev         = true
+}

--- a/images/istio/main.tf
+++ b/images/istio/main.tf
@@ -13,9 +13,10 @@ resource "random_pet" "suffix" {}
 module "test-latest" {
   source = "./tests"
   digests = {
-    proxy    = module.proxy.image_ref
-    pilot    = module.pilot.image_ref
-    operator = module.operator.image_ref
+    install-cni = module.install-cni.image_ref
+    proxy       = module.proxy.image_ref
+    pilot       = module.pilot.image_ref
+    operator    = module.operator.image_ref
   }
   namespace = "istio-system-${random_pet.suffix.id}"
 }
@@ -23,6 +24,7 @@ module "test-latest" {
 resource "oci_tag" "latest" {
   depends_on = [module.test-latest]
   for_each = {
+    "install-cni" : module.install-cni.image_ref
     "proxy" : module.proxy.image_ref,
     "pilot" : module.pilot.image_ref,
     "operator" : module.operator.image_ref,
@@ -34,6 +36,7 @@ resource "oci_tag" "latest" {
 resource "oci_tag" "latest-dev" {
   depends_on = [module.test-latest]
   for_each = {
+    "install-cni" : module.install-cni.dev_ref
     "proxy" : module.proxy.dev_ref,
     "pilot" : module.pilot.dev_ref,
     "operator" : module.operator.dev_ref,


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [x] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes: 
```
❯ docker images | grep cni
ttl.sh/tcnghia/images/new/istio-install-cni                           latest                                                             930e3539cf17   2 days ago      141MB
gcr.io/istio-release/install-cni                                      1.19.0-distroless                                                  dafe1cd98bcf   3 weeks ago     117MB
```
Looks like this is because of the compiled binaries being larger
```
☸ kind-kind in images on  istio-cni [?] via 🐹 v1.21.0 via 💠 default 
❯ tar tvf cni.upstream.tar | grep cni | grep bin              
drwxr-xr-x  0 0      0           0 Sep  1 08:08 opt/cni/bin/
-rwxr-xr-x  0 0      0    55115776 Sep  1 08:08 opt/cni/bin/istio-cni
-rwxr-xr-x  0 0      0    59572224 Sep  1 08:08 usr/local/bin/install-cni

☸ kind-kind in images on  istio-cni [?] via 🐹 v1.21.0 via 💠 default 
❯ tar tvf ours.tar | grep cni | grep bin              
drwxr-xr-x  0 0      0           0 Dec 31  1969 opt/cni/bin/
lrwxrwxrwx  0 0      0           0 Dec 31  1969 opt/cni/bin/istio-cni -> /usr/bin/istio-cni
-rwxr-xr-x  0 0      0    72222536 Dec 31  1969 usr/bin/install-cni
-rwxr-xr-x  0 0      0    68391704 Dec 31  1969 usr/bin/istio-cni
lrwxrwxrwx  0 0      0           0 Dec 31  1969 usr/local/bin/install-cni -> /usr/bin/install-cni
```

### Image Vulnerabilities

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
