### PR TITLE
Refactor `cert-manager` to virtual/latest pattern

### DIFF
--- a/images/cert-manager/config/main.tf
+++ b/images/cert-manager/config/main.tf
@@ -18,7 +18,7 @@ module "accts" { source = "../../../tflib/accts" }
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["cert-manager-${var.name}${var.suffix}"], var.extra_packages)
+      packages = concat(["cert-manager${var.suffix}-${var.name}"], var.extra_packages)
     }
     accounts = module.accts.block
     entrypoint = {

--- a/images/cert-manager/main.tf
+++ b/images/cert-manager/main.tf
@@ -1,9 +1,15 @@
-locals {
-  components = toset(["acmesolver", "controller", "cainjector", "webhook"])
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
 }
 
 variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  components = toset(["acmesolver", "controller", "cainjector", "webhook"])
 }
 
 module "config" {
@@ -16,22 +22,18 @@ module "latest" {
   for_each = local.components
   source   = "../../tflib/publisher"
 
-  name = basename(path.module)
-
+  name              = basename(path.module)
   target_repository = "${var.target_repository}-${each.key}"
   config            = module.config[each.key].config
 }
 
-module "dev" {
-  source = "../../tflib/dev-subvariant"
-}
+module "dev" { source = "../../tflib/dev-subvariant" }
 
 module "latest-dev" {
   for_each = local.components
   source   = "../../tflib/publisher"
 
-  name = basename(path.module)
-
+  name              = basename(path.module)
   target_repository = "${var.target_repository}-${each.key}"
   config            = jsonencode(module.latest[each.key].config)
   extra_packages    = concat(module.dev.extra_packages, ["cmctl"])
@@ -40,27 +42,25 @@ module "latest-dev" {
 module "version-tags" {
   for_each = local.components
   source   = "../../tflib/version-tags"
-
-  package = "cert-manager-1.12-${each.key}"
-  config  = module.latest[each.key].config
+  package  = "cert-manager-${each.key}"
+  config   = module.latest[each.key].config
 }
 
 module "test-latest" {
-  source = "./tests"
-
+  source  = "./tests"
   digests = { for k, v in module.latest : k => v.image_ref }
 }
 
-module "tagger" {
-  for_each = local.components
-  source   = "../../tflib/tagger"
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
 
-  depends_on = [
-    module.test-latest,
-  ]
-
-  tags = merge(
-    { for t in toset(concat(["latest"], module.version-tags[each.key].tag_list)) : t => module.latest[each.key].image_ref },
-    { for t in toset(concat(["latest"], module.version-tags[each.key].tag_list)) : "${t}-dev" => module.latest-dev[each.key].image_ref },
-  )
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest-dev[each.key].image_ref
+  tag        = "latest-dev"
 }


### PR DESCRIPTION
We have 1.13, but it looks like it's missing the provides, so we'll need to go back and add that.

https://github.com/wolfi-dev/os/blob/main/cert-manager-1.13.yaml

cc @k4leung4 @wlynch 