### PR TITLE
Refactor the remaining dev variants.

### DIFF
--- a/images/git/alpine.tf
+++ b/images/git/alpine.tf
@@ -2,51 +2,32 @@ module "latest-alpine" {
   providers = {
     apko = apko.alpine
   }
-  for_each = local.accounts
-  source   = "../../tflib/publisher"
-
-  name = basename(path.module)
-
+  for_each          = local.accounts
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.alpine.${each.key}.apko.yaml")
   # Override the module's default wolfi packages that conflict with alpine
   extra_packages = []
-}
-
-module "latest-alpine-dev" {
-  providers = {
-    apko = apko.alpine
-  }
-  for_each = local.accounts
-  source   = "../../tflib/publisher"
-
-  name = basename(path.module)
-
-  target_repository = var.target_repository
-  config            = file("${path.module}/configs/latest.alpine.${each.key}.apko.yaml")
-  # Override the module's default wolfi packages that conflict with alpine
-  extra_packages = module.dev.extra_packages
+  build-dev      = true
 }
 
 module "version-tags-alpine" {
   for_each = local.accounts
   source   = "../../tflib/version-tags"
-
-  package = "git"
-  config  = module.latest-alpine[each.key].config
+  package  = "git"
+  config   = module.latest-alpine[each.key].config
 }
 
 module "test-latest-alpine" {
   for_each = local.accounts
   source   = "./tests"
-
-  digest = module.latest-alpine[each.key].image_ref
+  digest   = module.latest-alpine[each.key].image_ref
 }
 
 module "test-latest-alpine-dev" {
-  for_each = local.accounts
-  source   = "./tests"
-
-  digest    = module.latest-alpine-dev[each.key].image_ref
+  for_each  = local.accounts
+  source    = "./tests"
+  digest    = module.latest-alpine[each.key].dev_ref
   check-dev = true
 }

--- a/images/git/main.tf
+++ b/images/git/main.tf
@@ -15,8 +15,6 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-module "dev" { source = "../../tflib/dev-subvariant" }
-
 module "tagger" {
   source = "../../tflib/tagger"
 
@@ -39,15 +37,15 @@ module "tagger" {
     # - root-$v-dev
     # Nonroot alpine variant
     { for t in toset(module.version-tags-alpine["nonroot"].tag_list) : t => module.latest-alpine["nonroot"].image_ref },
-    { for t in toset(module.version-tags-alpine["nonroot"].tag_list) : "${t}-dev" => module.latest-alpine-dev["nonroot"].image_ref },
+    { for t in toset(module.version-tags-alpine["nonroot"].tag_list) : "${t}-dev" => module.latest-alpine["nonroot"].dev_ref },
     { "latest" = module.latest-alpine["nonroot"].image_ref },
-    { "latest-dev" = module.latest-alpine-dev["nonroot"].image_ref },
+    { "latest-dev" = module.latest-alpine["nonroot"].dev_ref },
 
     # Root alpine variant
     { for t in toset(module.version-tags-alpine["root"].tag_list) : "root-${t}" => module.latest-alpine["root"].image_ref },
-    { for t in toset(module.version-tags-alpine["root"].tag_list) : "root-${t}-dev" => module.latest-alpine-dev["root"].image_ref },
+    { for t in toset(module.version-tags-alpine["root"].tag_list) : "root-${t}-dev" => module.latest-alpine["root"].dev_ref },
     { "latest-root" = module.latest-alpine["root"].image_ref },
-    { "latest-root-dev" = module.latest-alpine-dev["root"].image_ref },
+    { "latest-root-dev" = module.latest-alpine["root"].dev_ref },
 
     # Tagging format for wolfi/glibc variant:
     # - latest-glibc
@@ -59,14 +57,14 @@ module "tagger" {
     # - glibc-root-$v-dev
     # Nonroot wolfi variant
     { for t in toset(module.version-tags-wolfi["nonroot"].tag_list) : "glibc-${t}" => module.latest-wolfi["nonroot"].image_ref },
-    { for t in toset(module.version-tags-wolfi["nonroot"].tag_list) : "glibc-${t}-dev" => module.latest-wolfi-dev["nonroot"].image_ref },
+    { for t in toset(module.version-tags-wolfi["nonroot"].tag_list) : "glibc-${t}-dev" => module.latest-wolfi["nonroot"].dev_ref },
     { "latest-glibc" = module.latest-wolfi["nonroot"].image_ref },
-    { "latest-glibc-dev" = module.latest-wolfi-dev["nonroot"].image_ref },
+    { "latest-glibc-dev" = module.latest-wolfi["nonroot"].dev_ref },
 
     # Root wolfi variant
     { for t in toset(module.version-tags-wolfi["root"].tag_list) : "glibc-root-${t}" => module.latest-wolfi["root"].image_ref },
-    { for t in toset(module.version-tags-wolfi["root"].tag_list) : "glibc-root-${t}-dev" => module.latest-wolfi-dev["root"].image_ref },
+    { for t in toset(module.version-tags-wolfi["root"].tag_list) : "glibc-root-${t}-dev" => module.latest-wolfi["root"].dev_ref },
     { "latest-glibc-root" = module.latest-wolfi["root"].image_ref },
-    { "latest-glibc-root-dev" = module.latest-wolfi-dev["root"].image_ref },
+    { "latest-glibc-root-dev" = module.latest-wolfi["root"].dev_ref },
   )
 }

--- a/images/git/wolfi.tf
+++ b/images/git/wolfi.tf
@@ -1,43 +1,28 @@
 module "latest-wolfi" {
-  for_each = local.accounts
-  source   = "../../tflib/publisher"
-
-  name = basename(path.module)
-
+  for_each          = local.accounts
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.wolfi.${each.key}.apko.yaml")
-}
-
-module "latest-wolfi-dev" {
-  for_each = local.accounts
-  source   = "../../tflib/publisher"
-
-  name = basename(path.module)
-
-  target_repository = var.target_repository
-  config            = file("${path.module}/configs/latest.wolfi.${each.key}.apko.yaml")
-  extra_packages    = module.dev.extra_packages
+  build-dev         = true
 }
 
 module "version-tags-wolfi" {
   for_each = local.accounts
   source   = "../../tflib/version-tags"
-
-  package = "git"
-  config  = module.latest-wolfi[each.key].config
+  package  = "git"
+  config   = module.latest-wolfi[each.key].config
 }
 
 module "test-latest-wolfi" {
   for_each = local.accounts
   source   = "./tests"
-
-  digest = module.latest-wolfi[each.key].image_ref
+  digest   = module.latest-wolfi[each.key].image_ref
 }
 
 module "test-latest-wolfi-dev" {
-  for_each = local.accounts
-  source   = "./tests"
-
-  digest    = module.latest-wolfi-dev[each.key].image_ref
+  for_each  = local.accounts
+  source    = "./tests"
+  digest    = module.latest-wolfi[each.key].dev_ref
   check-dev = true
 }

--- a/images/maven/11.tf
+++ b/images/maven/11.tf
@@ -1,22 +1,9 @@
 module "eleven" {
-  source = "../../tflib/publisher"
-
-  name = basename(path.module)
-
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
   target_repository = var.target_repository
   config            = file("${path.module}/configs/openjdk-11.apko.yaml")
-}
-
-module "eleven-dev" {
-  source = "../../tflib/publisher"
-
-  name = basename(path.module)
-
-  target_repository = var.target_repository
-  # Make the dev variant an explicit extension of the
-  # locked original.
-  config         = jsonencode(module.eleven.config)
-  extra_packages = module.dev.extra_packages
+  build-dev         = true
 }
 
 module "version-tags-11" {

--- a/images/maven/17.tf
+++ b/images/maven/17.tf
@@ -1,22 +1,9 @@
 module "seventeen" {
-  source = "../../tflib/publisher"
-
-  name = basename(path.module)
-
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
   target_repository = var.target_repository
   config            = file("${path.module}/configs/openjdk-17.apko.yaml")
-}
-
-module "seventeen-dev" {
-  source = "../../tflib/publisher"
-
-  name = basename(path.module)
-
-  target_repository = var.target_repository
-  # Make the dev variant an explicit extension of the
-  # locked original.
-  config         = jsonencode(module.seventeen.config)
-  extra_packages = module.dev.extra_packages
+  build-dev         = true
 }
 
 module "version-tags-17" {

--- a/images/maven/main.tf
+++ b/images/maven/main.tf
@@ -2,8 +2,6 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-module "dev" { source = "../../tflib/dev-subvariant" }
-
 module "tagger" {
   source = "../../tflib/tagger"
 
@@ -14,11 +12,11 @@ module "tagger" {
 
   tags = merge(
     { for t in toset(module.version-tags-11.tag_list) : "openjdk-11-${t}" => module.eleven.image_ref },
-    { for t in toset(module.version-tags-11.tag_list) : "openjdk-11-${t}-dev" => module.eleven-dev.image_ref },
-    { "openjdk-11" : module.eleven.image_ref, "openjdk-11-dev" : module.eleven-dev.image_ref },
+    { for t in toset(module.version-tags-11.tag_list) : "openjdk-11-${t}-dev" => module.eleven.dev_ref },
+    { "openjdk-11" : module.eleven.image_ref, "openjdk-11-dev" : module.eleven.dev_ref },
     { for t in toset(module.version-tags-17.tag_list) : "openjdk-17-${t}" => module.seventeen.image_ref },
-    { for t in toset(module.version-tags-17.tag_list) : "openjdk-17-${t}-dev" => module.seventeen-dev.image_ref },
-    { "openjdk-17" : module.seventeen.image_ref, "openjdk-17-dev" : module.seventeen-dev.image_ref },
-    { "latest" : module.seventeen.image_ref, "latest-dev" : module.seventeen-dev.image_ref },
+    { for t in toset(module.version-tags-17.tag_list) : "openjdk-17-${t}-dev" => module.seventeen.dev_ref },
+    { "openjdk-17" : module.seventeen.image_ref, "openjdk-17-dev" : module.seventeen.dev_ref },
+    { "latest" : module.seventeen.image_ref, "latest-dev" : module.seventeen.dev_ref },
   )
 }

--- a/images/tekton/main.tf
+++ b/images/tekton/main.tf
@@ -38,26 +38,12 @@ module "config" {
 }
 
 module "latest" {
-  for_each = local.components
-  source   = "../../tflib/publisher"
-
+  for_each          = local.components
+  source            = "../../tflib/publisher"
   name              = basename(path.module)
   target_repository = "${var.target_repository}-${each.key}"
   config            = module.config[each.key].config
-}
-
-module "dev" { source = "../../tflib/dev-subvariant" }
-
-module "latest-dev" {
-  for_each = local.components
-  source   = "../../tflib/publisher"
-
-  name              = basename(path.module)
-  target_repository = "${var.target_repository}-${each.key}"
-  # Make the dev variant an explicit extension of the
-  # locked original.
-  config         = jsonencode(module.latest[each.key].config)
-  extra_packages = module.dev.extra_packages
+  build-dev         = true
 }
 
 module "test-latest" {
@@ -75,6 +61,6 @@ resource "oci_tag" "latest" {
 resource "oci_tag" "latest-dev" {
   for_each   = local.components
   depends_on = [module.test-latest]
-  digest_ref = module.latest-dev[each.key].image_ref
+  digest_ref = module.latest[each.key].dev_ref
   tag        = "latest-dev"
 }


### PR DESCRIPTION
Now the only reference to the `dev` module is from the publisher :tada: