### PR TITLE
Fix the `cert-manager` tests to test all images.

### DIFF
--- a/images/cert-manager/tests/main.tf
+++ b/images/cert-manager/tests/main.tf
@@ -44,16 +44,22 @@ resource "helm_release" "cert-manager" {
       tag        = data.oci_string.ref["controller"].pseudo_tag
     }
     acmesolver = {
-      repository = data.oci_string.ref["acmesolver"].registry_repo
-      tag        = data.oci_string.ref["acmesolver"].pseudo_tag
+      image = {
+        repository = data.oci_string.ref["acmesolver"].registry_repo
+        tag        = data.oci_string.ref["acmesolver"].pseudo_tag
+      }
     }
     cainjector = {
-      repository = data.oci_string.ref["cainjector"].registry_repo
-      tag        = data.oci_string.ref["cainjector"].pseudo_tag
+      image = {
+        repository = data.oci_string.ref["cainjector"].registry_repo
+        tag        = data.oci_string.ref["cainjector"].pseudo_tag
+      }
     }
     webhook = {
-      repository = data.oci_string.ref["webhook"].registry_repo
-      tag        = data.oci_string.ref["webhook"].pseudo_tag
+      image = {
+        repository = data.oci_string.ref["webhook"].registry_repo
+        tag        = data.oci_string.ref["webhook"].pseudo_tag
+      }
     }
   })]
 }


### PR DESCRIPTION
Previously the non-controller images weren't being overidden due to a missing layer of `image = {...}`.

cc @wlynch FYI