### PR TITLE
Add a `helm-cleanup` module.

### DIFF
--- a/images/cert-manager/tests/main.tf
+++ b/images/cert-manager/tests/main.tf
@@ -63,3 +63,9 @@ resource "helm_release" "cert-manager" {
     }
   })]
 }
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.cert-manager.id
+  namespace = helm_release.cert-manager.namespace
+}

--- a/images/prometheus-adapter/tests/cleanup.sh
+++ b/images/prometheus-adapter/tests/cleanup.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset -o errtrace -o pipefail -x
-
-# The helm chart needs to be completely uninstalled between testing different versions
-# This is because the Helm Chart creates cluster-level resources that need to be deleted and recreated (ClusterRole, APIService etc)
-# otherwise Terraform spits out this error: `Unable to continue with install: APIService "v1beta1.custom.metrics.k8s.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata`
-
-helm uninstall prometheus-adapter --wait

--- a/images/prometheus-adapter/tests/main.tf
+++ b/images/prometheus-adapter/tests/main.tf
@@ -25,8 +25,7 @@ resource "helm_release" "test" {
   })]
 }
 
-data "oci_exec_test" "cleanup" {
-  digest     = var.digest
-  script     = "${path.module}/cleanup.sh"
-  depends_on = [helm_release.test]
+module "helm_cleanup" {
+  source = "../../../tflib/helm-cleanup"
+  name   = helm_release.test.id
 }

--- a/tflib/helm-cleanup/main.tf
+++ b/tflib/helm-cleanup/main.tf
@@ -1,0 +1,15 @@
+variable "name" {}
+variable "namespace" {
+  default = "default"
+}
+
+resource "null_resource" "cleanup" {
+  provisioner "local-exec" {
+    command = <<EOF
+    set -ex
+    helm list -n ${var.namespace}
+    helm get all -n ${var.namespace} ${var.name}
+    helm uninstall -n ${var.namespace} ${var.name} --wait
+    EOF
+  }
+}


### PR DESCRIPTION
This allows us to clean up resources provisioned via Helm, which will help with resource utilization and avoiding test conflicts across versions.


