### PR TITLE
Add the prometheus plugin to the splunk variant of fluentd

### DIFF
--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -11,7 +11,7 @@ locals {
 
   splunk = [
     "ruby3.2-fluent-plugin-splunk-hec",
-    "fluent-plugin-out-http",
+    "ruby3.2-fluent-plugin-prometheus",
   ]
 }
 


### PR DESCRIPTION
Adding the prometheus plugin to the splunk variant of the fluentd image to make it work with upstream charts.