### PR TITLE
add rewrite-tag-filter plugin to fluentd splunk variant

### DIFF
--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -12,6 +12,7 @@ locals {
   splunk = [
     "ruby3.2-fluent-plugin-splunk-hec",
     "ruby3.2-fluent-plugin-prometheus",
+    "ruby3.2-fluent-plugin-rewrite-tag-filter",
   ]
 }
 


### PR DESCRIPTION
Adding another plugin to the fluentd splunk variant. Dependent on https://github.com/wolfi-dev/os/pull/5927