### PR TITLE
Add net-tools to fluentd splunk variant

### DIFF
--- a/images/fluentd/main.tf
+++ b/images/fluentd/main.tf
@@ -13,6 +13,7 @@ locals {
     "ruby3.2-fluent-plugin-splunk-hec",
     "ruby3.2-fluent-plugin-prometheus",
     "ruby3.2-fluent-plugin-rewrite-tag-filter",
+    "net-tools", # hostname command is required by rewrite-tag-filter plugin
   ]
 }
 


### PR DESCRIPTION
The fluent-plugin-rewrite-tag-filter requires the `hostname` command

https://github.com/fluent/fluent-plugin-rewrite-tag-filter/blob/18b9cf7e5d29e5aec5c0834b9211930b9f967307/README.md?plain=1#L230