### PR TITLE
dex: add v prefix to version tags

### DIFF
--- a/images/dex/main.tf
+++ b/images/dex/main.tf
@@ -34,5 +34,5 @@ module "tagger" {
     # TODO(jason): Do this for all images, not just dex, and potentially only for `:v1.2.3` and `:v1.2.3-r4` (not `:v1` or `:v1.2`).
     { for t in module.version-tags.tag_list : "v${t}" => module.latest.image_ref },
     { for t in module.version-tags.tag_list : "v${t}-dev" => module.latest.dev_ref },
-  }
+  )
 }

--- a/images/dex/main.tf
+++ b/images/dex/main.tf
@@ -29,5 +29,10 @@ module "tagger" {
   tags = merge(
     { for t in toset(concat(["latest"], module.version-tags.tag_list)) : t => module.latest.image_ref },
     { for t in toset(concat(["latest"], module.version-tags.tag_list)) : "${t}-dev" => module.latest.dev_ref },
-  )
+
+    # This will also tag the image with :v1, :v1.2, :v1.2.3, :v1.2.3-r4, for compatibility with upstream kustomize instructions.
+    # TODO(jason): Do this for all images, not just dex, and potentially only for `:v1.2.3` and `:v1.2.3-r4` (not `:v1` or `:v1.2`).
+    { for t in module.version-tags.tag_list : "v${t}" => module.latest.image_ref },
+    { for t in module.version-tags.tag_list : "v${t}-dev" => module.latest.dev_ref },
+  }
 }


### PR DESCRIPTION
Previously, https://github.com/chainguard-images/images/pull/1430

The customer installs dex in a similar way to argocd, which expects to have images tagged with versions beginning with `v`.