### PR TITLE
Fix typo in readme

### DIFF
--- a/images/rabbitmq/README.md
+++ b/images/rabbitmq/README.md
@@ -23,7 +23,7 @@ The image is available on `cgr.dev`:
 docker pull cgr.dev/chainguard/rabbitmq
 ```
 
-## Using Redis
+## Using RabbitMQ
 
 The default RabbitMQ port is 5672.
 To run with Docker using default configuration:


### PR DESCRIPTION
It's just about - I guess - a copy/paste mistake