### PR TITLE
fix: have monopod matrix emit includes correctly

### DIFF
--- a/images/crane/README.md
+++ b/images/crane/README.md
@@ -27,5 +27,5 @@ docker pull cgr.dev/chainguard/crane:latest
 Inspect the crane image manifest using the crane image:
 
 ```
-docker run --rm cgr.dev/chainguard/crane:latest manifest cgr.dev/chainguard/crane:latest
+docker run --rm cgr.dev/chainguard/crane:latest manifest cgr.dev/chainguard/crane:latest --platform=linux/amd64
 ```

--- a/monopod/pkg/commands/matrix.go
+++ b/monopod/pkg/commands/matrix.go
@@ -44,7 +44,7 @@ type matrixImpl struct {
 }
 
 type matrixResponse struct {
-	Include []string `json:"include"`
+	Include []images.Image `json:"include"`
 }
 
 func (i *matrixImpl) Do() error {
@@ -68,9 +68,9 @@ func (i *matrixImpl) Do() error {
 			}
 		}
 		if len(includeImages) > 0 {
-			allImagesNew := []string{}
+			allImagesNew := []images.Image{}
 			for _, image := range allImages {
-				if _, ok := includeImages[image]; ok {
+				if _, ok := includeImages[image.ImageName]; ok {
 					allImagesNew = append(allImagesNew, image)
 				}
 			}
@@ -79,7 +79,7 @@ func (i *matrixImpl) Do() error {
 	}
 
 	if i.ShardingFactor > 1 {
-		shards := make([][]string, i.ShardingFactor)
+		shards := make([][]images.Image, i.ShardingFactor)
 		for idx, img := range allImages {
 			idx = idx % int(i.ShardingFactor)
 			shards[idx] = append(shards[idx], img)

--- a/monopod/pkg/commands/readme.go
+++ b/monopod/pkg/commands/readme.go
@@ -81,7 +81,8 @@ func (i *readmeImpl) check() error {
 	sort.Slice(allImages, func(i, j int) bool {
 		return allImages[i].ImageName < allImages[j].ImageName
 	})
-	for _, img := range allImages {
+	for _, i := range allImages {
+		img := i.ImageName
 		// Generate the section to prepend to beginning of file
 		readmeInsert := fmt.Sprintf("# %s\n| | |\n| - | - |\n", img)
 		readmeInsert += fmt.Sprintf("| **OCI Reference** | `cgr.dev/chainguard/%s` |\n", img)
@@ -92,7 +93,7 @@ func (i *readmeImpl) check() error {
 		readmeInsert += "* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*\n\n"
 		readmeInsert += "---"
 
-		filename := path.Join(constants.ImagesDirName, img.ImageName, "README.md")
+		filename := path.Join(constants.ImagesDirName, img, "README.md")
 		existingContent, err := os.ReadFile(filename)
 		if err != nil {
 			fmt.Printf("Error opening %s: %s", filename, err.Error())

--- a/monopod/pkg/commands/readme.go
+++ b/monopod/pkg/commands/readme.go
@@ -78,7 +78,9 @@ func (i *readmeImpl) check() error {
 		}
 	}
 
-	sort.Strings(allImages)
+	sort.Slice(allImages, func(i, j int) bool {
+		return allImages[i].ImageName < allImages[j].ImageName
+	})
 	for _, img := range allImages {
 		// Generate the section to prepend to beginning of file
 		readmeInsert := fmt.Sprintf("# %s\n| | |\n| - | - |\n", img)
@@ -90,7 +92,7 @@ func (i *readmeImpl) check() error {
 		readmeInsert += "* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*\n\n"
 		readmeInsert += "---"
 
-		filename := path.Join(constants.ImagesDirName, img, "README.md")
+		filename := path.Join(constants.ImagesDirName, img.ImageName, "README.md")
 		existingContent, err := os.ReadFile(filename)
 		if err != nil {
 			fmt.Printf("Error opening %s: %s", filename, err.Error())
@@ -136,8 +138,11 @@ func (i *readmeImpl) fixAllReadmes() error {
 	}
 
 	// Individual image README.md files
-	sort.Strings(allImages)
-	for _, img := range allImages {
+	sort.Slice(allImages, func(i, j int) bool {
+		return allImages[i].ImageName < allImages[j].ImageName
+	})
+	for _, i := range allImages {
+		img := i.ImageName
 		// Generate the section to prepend to beginning of file
 		readmeInsert := fmt.Sprintf("# %s\n| | |\n| - | - |\n", img)
 		readmeInsert += fmt.Sprintf("| **OCI Reference** | `cgr.dev/chainguard/%s` |\n", img)
@@ -194,7 +199,7 @@ func (i *readmeImpl) rootReadmeToStdout() error {
 	return nil
 }
 
-func getRootReadmeContents(allImages []string, defaultRegistry string) ([]byte, error) {
+func getRootReadmeContents(allImages []images.Image, defaultRegistry string) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	buf.WriteString("# Chainguard Images\n")
 	buf.WriteString("\n")
@@ -206,8 +211,11 @@ func getRootReadmeContents(allImages []string, defaultRegistry string) ([]byte, 
 	buf.WriteString("| ----- | ----- |")
 	buf.WriteString("\n")
 
-	sort.Strings(allImages)
-	for _, img := range allImages {
+	sort.Slice(allImages, func(i, j int) bool {
+		return allImages[i].ImageName < allImages[j].ImageName
+	})
+	for _, i := range allImages {
+		img := i.ImageName
 		reference := defaultRegistry + "/" + img
 		buf.WriteString(fmt.Sprintf("| [%s](./%s/%s) | `%s` |", img, constants.ImagesDirName, img, reference))
 		buf.WriteString("\n")

--- a/monopod/pkg/images/images.go
+++ b/monopod/pkg/images/images.go
@@ -6,8 +6,12 @@ import (
 	"github.com/chainguard-images/images/monopod/pkg/constants"
 )
 
-func ListAll() ([]string, error) {
-	allImages := []string{}
+type Image struct {
+	ImageName string `json:"imageName"`
+}
+
+func ListAll() ([]Image, error) {
+	allImages := []Image{}
 	imageDirs, err := os.ReadDir(constants.ImagesDirName)
 	if err != nil {
 		return nil, err
@@ -21,7 +25,7 @@ func ListAll() ([]string, error) {
 			continue
 		}
 		imageName := imageDir.Name()
-		allImages = append(allImages, imageName)
+		allImages = append(allImages, Image{ImageName: imageName})
 	}
 	return allImages, nil
 }


### PR DESCRIPTION
It seems matrix logic expects the output to be a list of objects, and not a list of strings.

We might be able to clean this up later, but for now, let's just try to unbreak things.