### PR TITLE
drop vestigial appends from presubmit-build

### DIFF
--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -3,10 +3,6 @@ description: "Build an image using terraform-provider-apko"
 inputs:
   imageName:
     description: "name of the terraform module"
-  apkoRepositoryAppend:
-    description: "equivalent to --repository-append"
-  apkoKeyringAppend:
-    description: "equivalent to --keyring-append"
 runs:
   using: composite
   steps:

--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -35,22 +35,11 @@ jobs:
       matrix: ${{ fromJson(needs.presubmit-matrix.outputs.shard-0) }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - id: determine-appends
-        run: |
-          # Do not append out repo/keyring/package to Alpine images.
-          set -x
-          if ! grep 'alpinelinux\.org' "${{ matrix.apkoConfig }}" &>/dev/null; then
-            echo "repository-append=https://packages.wolfi.dev/os" >> $GITHUB_OUTPUT
-            echo "keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub" >> $GITHUB_OUTPUT
-          fi
       - name: Add additional inputs
         id: augmented-inputs
         uses: chainguard-dev/actions/matrix-extra-inputs@main
         with:
           matrix-json: ${{ toJSON(matrix) }}
-        env:
-          EXTRA_INPUT_APKO_REPOSITORY_APPEND: ${{ steps.determine-appends.outputs.repository-append }}
-          EXTRA_INPUT_APKO_KEYRING_APPEND: ${{ steps.determine-appends.outputs.keyring-append }}
 
       - uses: chainguard-dev/actions/setup-k3d@main
         with:


### PR DESCRIPTION
https://github.com/chainguard-images/images/pull/1467 made inputs explicit, and these inputs are stupid and not needed.