### PR TITLE
YAML lint, remove unused fields

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -15,6 +15,11 @@ jobs:
 
       - run: terraform fmt -check -recursive -diff
       - run: ./lint.sh
+      - name: Enforce YAML formatting
+        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:5ec18252632ae0c91c05503e5876e80c9f566f5e57a5c43d360f7b03f157cae3
+        with:
+          entrypoint: wolfictl
+          args: lint yam images/
 
       - id: files
         uses: tj-actions/changed-files@e1754a427f478b8778d349341b8f1d80f1f47f44 # v36.4.0

--- a/.yam.yaml
+++ b/.yam.yaml
@@ -1,0 +1,7 @@
+gap:
+  - '.'
+
+sort:
+  - ".contents.packages"
+
+indent: 2

--- a/images/apko/configs/latest.apko.yaml
+++ b/images/apko/configs/latest.apko.yaml
@@ -13,5 +13,5 @@ work-dir: /work
 
 entrypoint:
   command: /usr/bin/apko
-cmd: --help
 
+cmd: --help

--- a/images/argocd/configs/latest.argocd.apko.yaml
+++ b/images/argocd/configs/latest.argocd.apko.yaml
@@ -28,4 +28,3 @@ paths:
     uid: 999
     gid: 999
     recursive: true
-

--- a/images/argocd/configs/latest.repo-server.apko.yaml
+++ b/images/argocd/configs/latest.repo-server.apko.yaml
@@ -49,4 +49,3 @@ paths:
     uid: 999
     gid: 999
     recursive: true
-

--- a/images/aspnet-runtime/configs/latest.apko.yaml
+++ b/images/aspnet-runtime/configs/latest.apko.yaml
@@ -12,9 +12,8 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/dotnet
-cmd: --help
 
+cmd: --help

--- a/images/aws-cli/configs/latest.apko.yaml
+++ b/images/aws-cli/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: aws
-

--- a/images/aws-ebs-csi-driver/configs/latest.apko.yaml
+++ b/images/aws-ebs-csi-driver/configs/latest.apko.yaml
@@ -13,13 +13,5 @@ accounts:
       gid: 65532
   run-as: 65532
 
-paths:
-  - path: /etc/
-    type: directory
-    uid: 65532
-    gid: 65532
-    permissions: 0o755
-    recursive: true
-
 entrypoint:
   command: aws-ebs-csi-driver

--- a/images/aws-ebs-csi-driver/configs/latest.apko.yaml
+++ b/images/aws-ebs-csi-driver/configs/latest.apko.yaml
@@ -13,7 +13,7 @@ accounts:
       gid: 65532
   run-as: 65532
 
-  paths:
+paths:
   - path: /etc/
     type: directory
     uid: 65532
@@ -23,4 +23,3 @@ accounts:
 
 entrypoint:
   command: aws-ebs-csi-driver
-

--- a/images/aws-efs-csi-driver/configs/latest.apko.yaml
+++ b/images/aws-efs-csi-driver/configs/latest.apko.yaml
@@ -11,22 +11,20 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-  recursive: true
 
 paths:
-- path: /etc/amazon/efs/
-  type: directory
-  uid: 65532
-  gid: 65532
-  permissions: 0o755
-  recursive: true
-- path: /csi/
-  type: directory
-  uid: 65532
-  gid: 65532
-  permissions: 0o755
-  recursive: true
+  - path: /etc/amazon/efs/
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /csi/
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
 
 entrypoint:
   command: aws-efs-csi-driver
-

--- a/images/aws-for-fluent-bit/configs/latest.apko.yaml
+++ b/images/aws-for-fluent-bit/configs/latest.apko.yaml
@@ -22,5 +22,5 @@ paths:
 
 entrypoint:
   command: /fluent-bit/bin/fluent-bit
-cmd: -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf
 
+cmd: -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf

--- a/images/aws-load-balancer-controller/config/template.apko.yaml
+++ b/images/aws-load-balancer-controller/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # aws-load-balancer-controller comes via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -14,4 +12,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/controller
-

--- a/images/bank-vaults/config/template.apko.yaml
+++ b/images/bank-vaults/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Package comes from extra-packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -14,4 +12,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/bank-vaults
-

--- a/images/bash/configs/latest.apko.yaml
+++ b/images/bash/configs/latest.apko.yaml
@@ -6,4 +6,3 @@ contents:
 
 entrypoint:
   command: /bin/bash -c
-

--- a/images/bazel/configs/latest.apko.yaml
+++ b/images/bazel/configs/latest.apko.yaml
@@ -31,4 +31,3 @@ environment:
   JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 work-dir: /home/bazel
-

--- a/images/boring-registry/config/template.apko.yaml
+++ b/images/boring-registry/config/template.apko.yaml
@@ -15,4 +15,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/boring-registry
+
 cmd: server

--- a/images/busybox/configs/1.36.wolfi.apko.yaml
+++ b/images/busybox/configs/1.36.wolfi.apko.yaml
@@ -11,4 +11,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/busybox/configs/latest.alpine.apko.yaml
+++ b/images/busybox/configs/latest.alpine.apko.yaml
@@ -2,7 +2,6 @@ contents:
   packages:
     # busybox gives us a shell we can use, when we need one.
     - busybox
-
     # ssl_client allows the busybox wget applet to use https.
     - ssl_client
 
@@ -15,4 +14,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/busybox/configs/latest.wolfi.apko.yaml
+++ b/images/busybox/configs/latest.wolfi.apko.yaml
@@ -11,4 +11,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/cadvisor/config/template.apko.yaml
+++ b/images/cadvisor/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - cadvisor
+    - cadvisor
 
 accounts:
   groups:
@@ -50,4 +50,5 @@ environment:
 
 entrypoint:
   command: /usr/bin/cadvisor
+
 cmd: -logtostderr

--- a/images/calico/configs/latest.calicoctl.apko.yaml
+++ b/images/calico/configs/latest.calicoctl.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/calicoctl
-

--- a/images/calico/configs/latest.cni.apko.yaml
+++ b/images/calico/configs/latest.cni.apko.yaml
@@ -18,5 +18,3 @@ entrypoint:
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin
-
-

--- a/images/calico/configs/latest.csi.apko.yaml
+++ b/images/calico/configs/latest.csi.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/calico-pod2daemon-csidriver
-

--- a/images/calico/configs/latest.kube-controllers.apko.yaml
+++ b/images/calico/configs/latest.kube-controllers.apko.yaml
@@ -19,4 +19,3 @@ paths:
 
 entrypoint:
   command: /usr/bin/calico-kube-controllers
-

--- a/images/calico/configs/latest.node.apko.yaml
+++ b/images/calico/configs/latest.node.apko.yaml
@@ -32,5 +32,3 @@ paths:
 
 entrypoint:
   command: /usr/sbin/start_runit
-
-

--- a/images/calico/configs/latest.typha.apko.yaml
+++ b/images/calico/configs/latest.typha.apko.yaml
@@ -15,6 +15,5 @@ accounts:
 
 entrypoint:
   command: /sbin/tini --
+
 cmd: /usr/bin/calico-typha
-
-

--- a/images/cassandra/configs/latest.apko.yaml
+++ b/images/cassandra/configs/latest.apko.yaml
@@ -5,6 +5,7 @@ contents:
     - busybox
     - cassandra-compat
     - bash
+
 accounts:
   groups:
     - groupname: cassandra
@@ -18,7 +19,8 @@ work-dir: /
 
 entrypoint:
   command: cassandra -f
-environment: 
+
+environment:
   LANG: en_US.UTF-8
   CASSANDRA_HOME: /opt/cassandra
   PATH: /usr/sbin:/sbin:/usr/bin:/bin:/opt/cassandra/bin/
@@ -47,4 +49,3 @@ paths:
     uid: 999
     gid: 999
     recursive: true
-

--- a/images/cc-dynamic/configs/latest.apko.yaml
+++ b/images/cc-dynamic/configs/latest.apko.yaml
@@ -12,4 +12,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/cedar/config/template.apko.yaml
+++ b/images/cedar/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - cedar
+    - cedar
 
 accounts:
   groups:
@@ -14,5 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/cedar
-cmd: help
 
+cmd: help

--- a/images/clang/config/template.apko.yaml
+++ b/images/clang/config/template.apko.yaml
@@ -23,5 +23,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/clang
-cmd: --help
 
+cmd: --help

--- a/images/cluster-autoscaler/config/template.apko.yaml
+++ b/images/cluster-autoscaler/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # cluster-autoscaler comes in via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:

--- a/images/cluster-proportional-autoscaler/configs/latest.apko.yaml
+++ b/images/cluster-proportional-autoscaler/configs/latest.apko.yaml
@@ -1,6 +1,6 @@
 contents:
-    packages:
-      - cluster-proportional-autoscaler
+  packages:
+    - cluster-proportional-autoscaler
 
 accounts:
   groups:
@@ -13,4 +13,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/cluster-proportional-autoscaler
-

--- a/images/conda/config/template.apko.yaml
+++ b/images/conda/config/template.apko.yaml
@@ -15,4 +15,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/conda
+
 cmd: --help

--- a/images/configmap-reload/config/template.apko.yaml
+++ b/images/configmap-reload/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - configmap-reload
+    - configmap-reload
 
 accounts:
   groups:
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/configmap-reload
-

--- a/images/consul/config/template.apko.yaml
+++ b/images/consul/config/template.apko.yaml
@@ -14,13 +14,13 @@ accounts:
   users:
     - username: consul
       uid: 65532
-  recursive: true
   # NOTE: we don't run as consul here. The consul entrypoint expects to run as root
   # and drops permissions to the consul user itself using su-exec
   run-as: 0
 
 entrypoint:
   command: /usr/bin/docker-entrypoint.sh
+
 cmd: agent -dev -client 0.0.0.0
 
 paths:

--- a/images/coredns/configs/latest.apko.yaml
+++ b/images/coredns/configs/latest.apko.yaml
@@ -10,8 +10,6 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/coredns -dns.port=53
-

--- a/images/cosign/configs/latest.apko.yaml
+++ b/images/cosign/configs/latest.apko.yaml
@@ -19,4 +19,3 @@ entrypoint:
   command: /usr/bin/cosign
 
 cmd: help
-

--- a/images/crane/config/template.apko.yaml
+++ b/images/crane/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - crane
+    - crane
 
 accounts:
   groups:

--- a/images/curl/configs/latest.apko.yaml
+++ b/images/curl/configs/latest.apko.yaml
@@ -15,4 +15,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/dask-gateway/configs/latest.dask-gateway-server.apko.yaml
+++ b/images/dask-gateway/configs/latest.dask-gateway-server.apko.yaml
@@ -5,6 +5,7 @@ contents:
 
 entrypoint:
   command: /sbin/tini -g --
+
 cmd: /usr/bin/dask-gateway-server --config /etc/dask-gateway/dask_gateway_config.py
 
 accounts:

--- a/images/deno/configs/latest.apko.yaml
+++ b/images/deno/configs/latest.apko.yaml
@@ -18,6 +18,7 @@ environment:
 
 entrypoint:
   command: /usr/bin/deno
+
 cmd: --help
 
 accounts:
@@ -28,4 +29,3 @@ accounts:
     - username: deno
       uid: 65532
   run-as: 65532
-

--- a/images/dex/configs/latest.apko.yaml
+++ b/images/dex/configs/latest.apko.yaml
@@ -35,5 +35,5 @@ paths:
 
 entrypoint:
   command: /usr/bin/docker-entrypoint
-cmd: dex serve /etc/dex/config.docker.yaml
 
+cmd: dex serve /etc/dex/config.docker.yaml

--- a/images/dive/config/template.apko.yaml
+++ b/images/dive/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - dive
+    - dive
 
 accounts:
   groups:

--- a/images/dotnet/configs/runtime/template.apko.yaml
+++ b/images/dotnet/configs/runtime/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # dotnet comes via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -11,8 +9,8 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/dotnet
+
 cmd: --help

--- a/images/dotnet/configs/sdk/template.apko.yaml
+++ b/images/dotnet/configs/sdk/template.apko.yaml
@@ -11,7 +11,5 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 65532
-  recursive: true
 
 cmd: /bin/sh -l
-

--- a/images/envoy-ratelimit/configs/latest.apko.yaml
+++ b/images/envoy-ratelimit/configs/latest.apko.yaml
@@ -15,4 +15,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/ratelimit
-

--- a/images/envoy/configs/latest.apko.yaml
+++ b/images/envoy/configs/latest.apko.yaml
@@ -13,7 +13,6 @@ accounts:
     - username: envoy
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /var/lib/envoy/init/envoy-entrypoint.sh
@@ -24,4 +23,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-

--- a/images/etcd/configs/latest.apko.yaml
+++ b/images/etcd/configs/latest.apko.yaml
@@ -23,4 +23,3 @@ environment:
 
 entrypoint:
   command: /usr/bin/etcd
-

--- a/images/external-dns/config/template.apko.yaml
+++ b/images/external-dns/config/template.apko.yaml
@@ -1,2 +1,14 @@
-contents
-# external-dns comes via var.extra_packages:: packages
+accounts:
+  groups:
+    - groupname: external-dns
+      gid: 65532
+  users:
+    - username: external-dns
+      uid: 65532
+  run-as: 65532
+  recursive: true
+
+entrypoint:
+  command: /usr/bin/external-dns
+
+cmd: --help

--- a/images/external-dns/config/template.apko.yaml
+++ b/images/external-dns/config/template.apko.yaml
@@ -1,19 +1,2 @@
-contents:
-  packages: [
-    # external-dns comes via var.extra_packages.
-  ]
-
-accounts:
-  groups:
-    - groupname: external-dns
-      gid: 65532
-  users:
-    - username: external-dns
-      uid: 65532
-  run-as: 65532
-  recursive: true
-
-entrypoint:
-  command: /usr/bin/external-dns
-cmd: --help
-
+contents
+# external-dns comes via var.extra_packages:: packages

--- a/images/external-secrets/configs/latest.apko.yaml
+++ b/images/external-secrets/configs/latest.apko.yaml
@@ -1,6 +1,6 @@
 contents:
-    packages:
-      - external-secrets-operator
+  packages:
+    - external-secrets-operator
 
 accounts:
   groups:
@@ -13,4 +13,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/external-secrets
-

--- a/images/falcoctl/config/latest.apko.yaml
+++ b/images/falcoctl/config/latest.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # falcoctl comes in via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:

--- a/images/ffmpeg/config/template.apko.yaml
+++ b/images/ffmpeg/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - ffmpeg
+    - ffmpeg
 
 accounts:
   groups:
@@ -14,4 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/ffmpeg
+
 cmd: --help

--- a/images/fluent-bit/configs/latest.apko.yaml
+++ b/images/fluent-bit/configs/latest.apko.yaml
@@ -21,5 +21,5 @@ paths:
 
 entrypoint:
   command: /usr/bin/fluent-bit
-cmd: -c /fluent-bit/etc/fluent-bit.conf
 
+cmd: -c /fluent-bit/etc/fluent-bit.conf

--- a/images/fluentd/configs/latest.apko.yaml
+++ b/images/fluentd/configs/latest.apko.yaml
@@ -28,24 +28,20 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-
   - path: /fluentd/etc
     type: directory
     uid: 65532
     gid: 65532
     permissions: 0o755
-
   - path: /fluentd/plugins
     type: directory
     uid: 65532
     gid: 65532
     permissions: 0o755
-
-    # Set the fluent.conf to an empty file so the image doesn't fail when
-    # no options are supplied
+  # Set the fluent.conf to an empty file so the image doesn't fail when
+  # no options are supplied
   - path: /etc/fluent/fluent.conf
     type: empty-file
     uid: 65532
     gid: 65532
     permissions: 0o644
-

--- a/images/flux/configs/latest.cli.apko.yaml
+++ b/images/flux/configs/latest.cli.apko.yaml
@@ -18,4 +18,3 @@ entrypoint:
   command: /usr/bin/flux
 
 cmd: help
-

--- a/images/flux/configs/latest.helm-controller.apko.yaml
+++ b/images/flux/configs/latest.helm-controller.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/helm-controller
-

--- a/images/flux/configs/latest.image-automation-controller.apko.yaml
+++ b/images/flux/configs/latest.image-automation-controller.apko.yaml
@@ -22,4 +22,3 @@ paths:
     uid: 65532
     gid: 65532
     recursive: true
-

--- a/images/flux/configs/latest.image-reflector-controller.apko.yaml
+++ b/images/flux/configs/latest.image-reflector-controller.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/image-reflector-controller
-

--- a/images/flux/configs/latest.kustomize-controller.apko.yaml
+++ b/images/flux/configs/latest.kustomize-controller.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/kustomize-controller
-

--- a/images/flux/configs/latest.notification-controller.apko.yaml
+++ b/images/flux/configs/latest.notification-controller.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/notification-controller
-

--- a/images/flux/configs/latest.source-controller.apko.yaml
+++ b/images/flux/configs/latest.source-controller.apko.yaml
@@ -24,4 +24,3 @@ paths:
     uid: 1337
     gid: 1337
     recursive: true
-

--- a/images/gatekeeper/config/template.apko.yaml
+++ b/images/gatekeeper/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # gatekeeper is added via var.extra_packages.
-  ]
+  packages:
 
 accounts:
   groups:

--- a/images/gcc-glibc/configs/latest.apko.yaml
+++ b/images/gcc-glibc/configs/latest.apko.yaml
@@ -12,5 +12,5 @@ work-dir: /work
 
 entrypoint:
   command: /usr/bin/gcc
-cmd: --help
 
+cmd: --help

--- a/images/git/configs/latest.alpine.nonroot.apko.yaml
+++ b/images/git/configs/latest.alpine.nonroot.apko.yaml
@@ -21,4 +21,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/git/configs/latest.alpine.root.apko.yaml
+++ b/images/git/configs/latest.alpine.root.apko.yaml
@@ -20,4 +20,3 @@ accounts:
     - username: git
       uid: 65532
       gid: 65532
-

--- a/images/git/configs/latest.wolfi.nonroot.apko.yaml
+++ b/images/git/configs/latest.wolfi.nonroot.apko.yaml
@@ -18,4 +18,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/git/configs/latest.wolfi.root.apko.yaml
+++ b/images/git/configs/latest.wolfi.root.apko.yaml
@@ -17,4 +17,3 @@ accounts:
     - username: git
       uid: 65532
       gid: 65532
-

--- a/images/glibc-dynamic/configs/latest.apko.yaml
+++ b/images/glibc-dynamic/configs/latest.apko.yaml
@@ -13,4 +13,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/go/config/template.apko.yaml
+++ b/images/go/config/template.apko.yaml
@@ -25,4 +25,3 @@ entrypoint:
   command: /usr/bin/go
 
 cmd: help
-

--- a/images/google-cloud-sdk/config/template.apko.yaml
+++ b/images/google-cloud-sdk/config/template.apko.yaml
@@ -13,7 +13,5 @@ accounts:
     - username: gcloud
       uid: 65532
   run-as: 65532
-  recursive: true
 
 cmd: /usr/bin/gcloud
-

--- a/images/graalvm-native/configs/latest.apko.yaml
+++ b/images/graalvm-native/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/gradle/configs/latest.apko.yaml
+++ b/images/gradle/configs/latest.apko.yaml
@@ -14,7 +14,6 @@ accounts:
     - username: gradle
       uid: 65532
   run-as: 65532
-  recursive: true
 
 work-dir: /home/build
 
@@ -31,4 +30,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-

--- a/images/guacamole-server/configs/latest.apko.yaml
+++ b/images/guacamole-server/configs/latest.apko.yaml
@@ -25,5 +25,3 @@ accounts:
     - username: guacd
       uid: 1000
   run-as: 65532
-  recursive: true
-

--- a/images/haproxy-ingress/configs/latest.apko.yaml
+++ b/images/haproxy-ingress/configs/latest.apko.yaml
@@ -23,26 +23,22 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-
   - path: /haproxy-ingress
     type: directory
     uid: 65532
     gid: 65532
     permissions: 0o755
     recursive: true
-
   - path: /etc/haproxy
     type: directory
     uid: 65532
     gid: 65532
     permissions: 0o755
-
   - path: /var/lib/haproxy
     type: directory
     uid: 65532
     gid: 65532
     permissions: 0o755
-
   - path: /var/run/haproxy
     type: directory
     uid: 65532
@@ -51,4 +47,3 @@ paths:
 
 entrypoint:
   command: /usr/bin/dumb-init -- /usr/bin/start.sh
-

--- a/images/haproxy/configs/latest.apko.yaml
+++ b/images/haproxy/configs/latest.apko.yaml
@@ -28,4 +28,3 @@ paths:
 
 entrypoint:
   command: /usr/local/bin/docker-entrypoint.sh
-

--- a/images/helm-chartmuseum/config/template.apko.yaml
+++ b/images/helm-chartmuseum/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - chartmuseum
+    - chartmuseum
 
 accounts:
   groups:
@@ -29,4 +29,3 @@ environment:
 
 entrypoint:
   command: /usr/bin/chartmuseum
-

--- a/images/http-echo/configs/latest.apko.yaml
+++ b/images/http-echo/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /http-echo
-

--- a/images/hugo/config/template.apko.yaml
+++ b/images/hugo/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - hugo
+    - hugo
 
 entrypoint:
   command: /usr/bin/hugo
@@ -23,4 +23,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/influxdb/configs/latest.apko.yaml
+++ b/images/influxdb/configs/latest.apko.yaml
@@ -12,7 +12,6 @@ accounts:
     - username: influxdb
       uid: 1000
   run-as: 1000
-  recursive: true
 
 entrypoint:
   command: /usr/bin/entrypoint.sh
@@ -33,4 +32,3 @@ paths:
     uid: 1000
     gid: 1000
     permissions: 0o755
-

--- a/images/ingress-nginx-controller/config/latest.apko.yaml
+++ b/images/ingress-nginx-controller/config/latest.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Package comes from extra-packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -17,11 +15,12 @@ environment:
   LUA_PATH: "/usr/share/lua/5.1/?.lua;/usr/lib/lua/?.lua;/usr/lib/lua/?.lua;/usr/share/lua/?.lua"
   LUA_CPATH: "/usr/lib/lua/5.1/?.so;/usr/lib/lua/?/?.so;/usr/lib/lua/?.so;/usr/lib/lua/?.lua;"
 
-work-dir:  /etc/nginx
+work-dir: /etc/nginx
+
+cmd: "/usr/bin/dumb-init ---"
 
 entrypoint:
-  cmd: /nginx-ingress-controller
-cmd: "/usr/bin/dumb-init ---"
+  command: /nginx-ingress-controller
 
 paths:
   - path: /etc/ingress-controller

--- a/images/istio/configs/operator/template.apko.yaml
+++ b/images/istio/configs/operator/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # istio-operator comes from extra_packages
-  ]
+  packages:
 
 accounts:
   groups:

--- a/images/istio/configs/pilot/template.apko.yaml
+++ b/images/istio/configs/pilot/template.apko.yaml
@@ -1,12 +1,10 @@
 contents:
-  packages: [
-    # istio-pilot-discovery comes from extra_packages
-  ]
+  packages:
 
 paths:
-- path: /run
-  type: directory
-  permissions: 0o755
+  - path: /run
+    type: directory
+    permissions: 0o755
 
 accounts:
   groups:

--- a/images/istio/configs/proxy/template.apko.yaml
+++ b/images/istio/configs/proxy/template.apko.yaml
@@ -8,9 +8,9 @@ contents:
     - libmnl
 
 paths:
-- path: /run
-  type: directory
-  permissions: 0o755
+  - path: /run
+    type: directory
+    permissions: 0o755
 
 accounts:
   groups:

--- a/images/jdk/config/template.apko.yaml
+++ b/images/jdk/config/template.apko.yaml
@@ -13,7 +13,6 @@ accounts:
     - username: java
       uid: 65532
   run-as: 65532
-  recursive: true
 
 work-dir: /home/build
 
@@ -27,4 +26,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-

--- a/images/jenkins/configs/latest.apko.yaml
+++ b/images/jenkins/configs/latest.apko.yaml
@@ -17,7 +17,6 @@ accounts:
     - username: jenkins
       uid: 65532
   run-as: 65532
-  recursive: true
 
 work-dir: /app
 
@@ -35,4 +34,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-

--- a/images/jre/config/template.apko.yaml
+++ b/images/jre/config/template.apko.yaml
@@ -21,4 +21,3 @@ entrypoint:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/default-jvm
-

--- a/images/k3s/configs/latest.aio.apko.yaml
+++ b/images/k3s/configs/latest.aio.apko.yaml
@@ -35,4 +35,5 @@ volumes:
 
 entrypoint:
   command: /bin/k3s
+
 cmd: agent

--- a/images/k3s/configs/latest.apko.yaml
+++ b/images/k3s/configs/latest.apko.yaml
@@ -33,6 +33,5 @@ volumes:
 
 entrypoint:
   command: /bin/k3s
+
 cmd: agent
-
-

--- a/images/k8s-sidecar/config/template.apko.yaml
+++ b/images/k8s-sidecar/config/template.apko.yaml
@@ -17,5 +17,3 @@ accounts:
     - username: k8s-sidecar
       uid: 65532
   run-as: 65532
-  recursive: true
-

--- a/images/k8sgpt-operator/config/template.apko.yaml
+++ b/images/k8sgpt-operator/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - k8sgpt-operator
+    - k8sgpt-operator
 
 accounts:
   groups:
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: manager
-

--- a/images/k8sgpt/config/template.apko.yaml
+++ b/images/k8sgpt/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - k8sgpt
+    - k8sgpt
 
 accounts:
   groups:
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: k8sgpt
-

--- a/images/kafka/config/template.apko.yaml
+++ b/images/kafka/config/template.apko.yaml
@@ -15,7 +15,6 @@ accounts:
     - username: kafka
       uid: 65532
   run-as: 65532
-  recursive: true
 
 # While logging to disk isn't a best practice for containers, Kafka handles it's own rotation by default.
 # Most other kafka images use this same configuration, so this is the principle of least-surprise.
@@ -26,7 +25,7 @@ paths:
     permissions: 0o755
     uid: 65532
     gid: 65532
-  - path: /opt/binami
+  - path: /opt/bitnami
     type: directory
     permissions: 0o755
     uid: 65532

--- a/images/karpenter/configs/latest.apko.yaml
+++ b/images/karpenter/configs/latest.apko.yaml
@@ -10,8 +10,6 @@ accounts:
     - username: karpenter
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/controller
-

--- a/images/keda/configs/latest.adapter.apko.yaml
+++ b/images/keda/configs/latest.adapter.apko.yaml
@@ -16,4 +16,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/keda-adapter --secure-port=6443 --logtostderr=true --v=0
-

--- a/images/keda/configs/latest.controller.apko.yaml
+++ b/images/keda/configs/latest.controller.apko.yaml
@@ -16,4 +16,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/keda --zap-log-level=info --zap-encoder=console
-

--- a/images/keda/configs/latest.webhooks.apko.yaml
+++ b/images/keda/configs/latest.webhooks.apko.yaml
@@ -16,4 +16,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/keda-admission-webhooks --zap-log-level=info --zap-encoder=console
-

--- a/images/ko/configs/latest.apko.yaml
+++ b/images/ko/configs/latest.apko.yaml
@@ -17,4 +17,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/ko
-

--- a/images/kube-bench/configs/latest.apko.yaml
+++ b/images/kube-bench/configs/latest.apko.yaml
@@ -23,4 +23,3 @@ entrypoint:
   command: /usr/bin/kube-bench
 
 cmd: help
-

--- a/images/kube-downscaler/config/template.apko.yaml
+++ b/images/kube-downscaler/config/template.apko.yaml
@@ -15,4 +15,3 @@ accounts:
 
 entrypoint:
   command: python3 -m kube_downscaler
-

--- a/images/kube-fluentd-operator/configs/latest.apko.yaml
+++ b/images/kube-fluentd-operator/configs/latest.apko.yaml
@@ -24,4 +24,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 0 # need to write to /var/log and hostPath volumes are mounted as root
-

--- a/images/kube-state-metrics/config/template.apko.yaml
+++ b/images/kube-state-metrics/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # kube-state-metrics comes from var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -14,4 +12,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/kube-state-metrics
-

--- a/images/kubectl/config/template.apko.yaml
+++ b/images/kubectl/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # kubectl comes via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -15,4 +13,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/kubectl
+
 cmd: help

--- a/images/kubernetes-csi-external-attacher/config/template.apko.yaml
+++ b/images/kubernetes-csi-external-attacher/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Package comes from extra-packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -11,8 +9,6 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 0
-  recursive: true
 
 entrypoint:
-  command: csi-attacher
-
+  command: /usr/bin/csi-attacher

--- a/images/kubernetes-csi-external-provisioner/config/template.apko.yaml
+++ b/images/kubernetes-csi-external-provisioner/config/template.apko.yaml
@@ -11,8 +11,6 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 0 # image doesn't work with nonroot user
-  recursive: true
 
 entrypoint:
   command: /usr/bin/csi-provisioner
-

--- a/images/kubernetes-csi-external-resizer/config/template.apko.yaml
+++ b/images/kubernetes-csi-external-resizer/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Package comes from extra-packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -11,7 +9,6 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
-  command: csi-resizer
+  command: /usr/bin/csi-resizer

--- a/images/kubernetes-csi-external-snapshot-controller/configs/latest.apko.yaml
+++ b/images/kubernetes-csi-external-snapshot-controller/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: snapshot-controller
-

--- a/images/kubernetes-csi-external-snapshot-validation-webhook/configs/latest.apko.yaml
+++ b/images/kubernetes-csi-external-snapshot-validation-webhook/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: snapshot-validation-webhook
-

--- a/images/kubernetes-csi-external-snapshotter/config/template.apko.yaml
+++ b/images/kubernetes-csi-external-snapshotter/config/template.apko.yaml
@@ -13,5 +13,4 @@ accounts:
   run-as: 65532
 
 entrypoint:
-  command:  csi-snapshotter
-
+  command: csi-snapshotter

--- a/images/kubernetes-csi-livenessprobe/configs/latest.apko.yaml
+++ b/images/kubernetes-csi-livenessprobe/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/livenessprobe
-

--- a/images/kubernetes-csi-node-driver-registrar/config/template.apko.yaml
+++ b/images/kubernetes-csi-node-driver-registrar/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # CSI Node Driver comes from var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -15,4 +13,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/csi-node-driver-registrar
-

--- a/images/kubernetes-dashboard/configs/latest.dashboard.apko.yaml
+++ b/images/kubernetes-dashboard/configs/latest.dashboard.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/share/kubernetes-dashboard/dashboard --insecure-bind-address=0.0.0.0 --bind-address=0.0.0.0
-

--- a/images/kubernetes-dashboard/configs/latest.metrics-scraper.apko.yaml
+++ b/images/kubernetes-dashboard/configs/latest.metrics-scraper.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/metrics-sidecar
-

--- a/images/kubernetes-ingress-defaultbackend/configs/latest.apko.yaml
+++ b/images/kubernetes-ingress-defaultbackend/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/defaultbackend
-

--- a/images/kubewatch/config/template.apko.yaml
+++ b/images/kubewatch/config/template.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
 
 environment:
   KW_CONFIG: /opt/bitnami/kubewatch
-

--- a/images/kyverno/configs/latest.admission.apko.yaml
+++ b/images/kyverno/configs/latest.admission.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/kyverno
 
 cmd: help
-

--- a/images/kyverno/configs/latest.background.apko.yaml
+++ b/images/kyverno/configs/latest.background.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/background-controller
 
 cmd: help
-

--- a/images/kyverno/configs/latest.cleanup.apko.yaml
+++ b/images/kyverno/configs/latest.cleanup.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/cleanup-controller
 
 cmd: help
-

--- a/images/kyverno/configs/latest.cli.apko.yaml
+++ b/images/kyverno/configs/latest.cli.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/kubectl-kyverno
 
 cmd: help
-

--- a/images/kyverno/configs/latest.init.apko.yaml
+++ b/images/kyverno/configs/latest.init.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/kyvernopre
 
 cmd: help
-

--- a/images/kyverno/configs/latest.reports.apko.yaml
+++ b/images/kyverno/configs/latest.reports.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/reports-controller
 
 cmd: help
-

--- a/images/loki/config/template.apko.yaml
+++ b/images/loki/config/template.apko.yaml
@@ -14,6 +14,7 @@ accounts:
 
 entrypoint:
   command: /usr/bin/loki
+
 cmd: -config.file=/etc/loki/local-config.yaml
 
 paths:

--- a/images/mariadb/configs/latest.apko.yaml
+++ b/images/mariadb/configs/latest.apko.yaml
@@ -37,4 +37,3 @@ paths:
     permissions: 0o777
     uid: 65532
     gid: 65532
-

--- a/images/maven/configs/openjdk-11.apko.yaml
+++ b/images/maven/configs/openjdk-11.apko.yaml
@@ -14,7 +14,6 @@ accounts:
     - username: maven
       uid: 65532
   run-as: 65532
-  recursive: true
 
 work-dir: /home/build
 
@@ -31,4 +30,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-

--- a/images/maven/configs/openjdk-17.apko.yaml
+++ b/images/maven/configs/openjdk-17.apko.yaml
@@ -14,7 +14,6 @@ accounts:
     - username: maven
       uid: 65532
   run-as: 65532
-  recursive: true
 
 work-dir: /home/build
 
@@ -31,4 +30,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-

--- a/images/mdbook/config/template.apko.yaml
+++ b/images/mdbook/config/template.apko.yaml
@@ -1,6 +1,7 @@
 contents:
   packages:
     - mdbook
+
 accounts:
   groups:
     - groupname: nonroot
@@ -10,6 +11,8 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
+
 entrypoint:
   command: /usr/bin/mdbook
+
 cmd: --help

--- a/images/meilisearch/config/template.apko.yaml
+++ b/images/meilisearch/config/template.apko.yaml
@@ -9,11 +9,11 @@ accounts:
   users:
     - username: meilisearch
       uid: 999
-  recursive: true
   run-as: 999
 
 entrypoint:
   command: /usr/bin/meilisearch
+
 cmd: --help
 
 paths:
@@ -22,4 +22,3 @@ paths:
     uid: 999
     gid: 999
     permissions: 0o755
-

--- a/images/melange/configs/latest.apko.yaml
+++ b/images/melange/configs/latest.apko.yaml
@@ -14,5 +14,5 @@ work-dir: /work
 
 entrypoint:
   command: /usr/bin/melange
-cmd: --help
 
+cmd: --help

--- a/images/memcached-exporter/config/template.apko.yaml
+++ b/images/memcached-exporter/config/template.apko.yaml
@@ -13,4 +13,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/memcached_exporter
-

--- a/images/memcached/configs/latest.apko.yaml
+++ b/images/memcached/configs/latest.apko.yaml
@@ -13,4 +13,3 @@ accounts:
 
 entrypoint:
   command: memcached
-

--- a/images/metacontroller/config/template.apko.yaml
+++ b/images/metacontroller/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
-    packages:
-      - metacontroller
+  packages:
+    - metacontroller
 
 accounts:
   groups:
@@ -13,4 +13,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/metacontroller
-

--- a/images/metrics-server/config/template.apko.yaml
+++ b/images/metrics-server/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # metrics-server comes from var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -23,4 +21,3 @@ paths:
 
 entrypoint:
   command: metrics-server --cert-dir=/tmp
-

--- a/images/minio/configs/latest.minio-client.apko.yaml
+++ b/images/minio/configs/latest.minio-client.apko.yaml
@@ -11,8 +11,6 @@ accounts:
     - username: minio
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/mc
-

--- a/images/minio/configs/latest.minio.apko.yaml
+++ b/images/minio/configs/latest.minio.apko.yaml
@@ -10,8 +10,6 @@ accounts:
     - username: minio
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/minio
-

--- a/images/nats/configs/latest.apko.yaml
+++ b/images/nats/configs/latest.apko.yaml
@@ -10,9 +10,8 @@ accounts:
     - username: nats
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/nats-server
-cmd: --config=/etc/nats/nats-server.conf
 
+cmd: --config=/etc/nats/nats-server.conf

--- a/images/netcat/config/template.apko.yaml
+++ b/images/netcat/config/template.apko.yaml
@@ -2,6 +2,7 @@ contents:
   packages:
     - busybox
     - netcat-openbsd
+
 accounts:
   groups:
     - groupname: nonroot
@@ -14,6 +15,7 @@ accounts:
 
 entrypoint:
   command: /usr/bin/nc
-cmd: -h
-work-dir: /home/nc
 
+cmd: -h
+
+work-dir: /home/nc

--- a/images/newrelic/configs/latest.fluent-bit-output.apko.yaml
+++ b/images/newrelic/configs/latest.fluent-bit-output.apko.yaml
@@ -24,5 +24,5 @@ paths:
 
 entrypoint:
   command: /usr/bin/fluent-bit
-cmd: -c /fluent-bit/etc/fluent-bit.conf -e /fluent-bit/bin/out_newrelic.so
 
+cmd: -c /fluent-bit/etc/fluent-bit.conf -e /fluent-bit/bin/out_newrelic.so

--- a/images/newrelic/configs/latest.infrastructure-bundle.apko.yaml
+++ b/images/newrelic/configs/latest.infrastructure-bundle.apko.yaml
@@ -15,4 +15,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 0
-

--- a/images/newrelic/configs/latest.k8s-events-forwarder.apko.yaml
+++ b/images/newrelic/configs/latest.k8s-events-forwarder.apko.yaml
@@ -16,6 +16,7 @@ accounts:
 
 entrypoint:
   command: /sbin/tini --
+
 cmd: /usr/bin/newrelic-infra-service
 
 environment:
@@ -23,4 +24,3 @@ environment:
   NRIA_OVERRIDE_HOST_ROOT: ""
   NRIA_IS_SECURE_FORWARD_ONLY: true
   NRIA_HTTP_SERVER_ENABLED: true
-

--- a/images/newrelic/configs/latest.kube-events.apko.yaml
+++ b/images/newrelic/configs/latest.kube-events.apko.yaml
@@ -16,4 +16,3 @@ accounts:
 
 entrypoint:
   command: /sbin/tini -- /usr/bin/nri-kube-events
-

--- a/images/newrelic/configs/latest.kubernetes.apko.yaml
+++ b/images/newrelic/configs/latest.kubernetes.apko.yaml
@@ -21,4 +21,3 @@ entrypoint:
 
 environment:
   METADATA: true
-

--- a/images/newrelic/configs/latest.prometheus-configurator.apko.yaml
+++ b/images/newrelic/configs/latest.prometheus-configurator.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/prometheus-configurator
-

--- a/images/newrelic/configs/latest.prometheus.apko.yaml
+++ b/images/newrelic/configs/latest.prometheus.apko.yaml
@@ -16,4 +16,3 @@ accounts:
 
 entrypoint:
   command: /sbin/tini -- /usr/bin/nri-prometheus
-

--- a/images/nginx/config/template.apko.yaml
+++ b/images/nginx/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Python comes via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -36,9 +34,8 @@ paths:
     recursive: false
 
 entrypoint:
-    command: /usr/sbin/nginx
+  command: /usr/sbin/nginx
 
 cmd: -c /etc/nginx/nginx.conf -e /dev/stderr -g "daemon off;"
 
 stop-signal: SIGQUIT
-

--- a/images/node-problem-detector/configs/latest.apko.yaml
+++ b/images/node-problem-detector/configs/latest.apko.yaml
@@ -43,5 +43,5 @@ paths:
 
 entrypoint:
   command: /usr/bin/node-problem-detector
-cmd: --config.system-log-monitor=/config/kernel-monitor.json
 
+cmd: --config.system-log-monitor=/config/kernel-monitor.json

--- a/images/node/config/template.apko.yaml
+++ b/images/node/config/template.apko.yaml
@@ -24,6 +24,7 @@ environment:
 
 entrypoint:
   command: /usr/bin/node
+
 cmd: --help
 
 # By convention, the official Docker node image defines a `node` user, but
@@ -36,4 +37,3 @@ accounts:
     - username: node
       uid: 65532
   run-as: 65532
-

--- a/images/nodetaint/configs/latest.apko.yaml
+++ b/images/nodetaint/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/nodetaint
-

--- a/images/ntpd-rs/config/template.apko.yaml
+++ b/images/ntpd-rs/config/template.apko.yaml
@@ -9,9 +9,6 @@ accounts:
   users:
     - username: ntpd-rs
       uid: 65532
-  recursive: true
-  # Until apko supports capabilities, we need to run this as root.
 
 entrypoint:
   command: /usr/bin/ntp-daemon
-

--- a/images/nvidia-device-plugin/config/template.apko.yaml
+++ b/images/nvidia-device-plugin/config/template.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/nvidia-device-plugin
-

--- a/images/oauth2-proxy/configs/latest.apko.yaml
+++ b/images/oauth2-proxy/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/oauth2-proxy
-

--- a/images/openai/config/template.apko.yaml
+++ b/images/openai/config/template.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/openai
 
 cmd: --help
-

--- a/images/opensearch/config/template.apko.yaml
+++ b/images/opensearch/config/template.apko.yaml
@@ -12,18 +12,19 @@ accounts:
     - username: opensearch
       uid: 65532
   run-as: 65532
+
 paths:
-- path: /usr/share/opensearch
-  type: directory
-  uid: 65532
-  gid: 65532
-  permissions: 0o755
-  recursive: true
+  - path: /usr/share/opensearch
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
 
 environment:
   JAVA_HOME: /usr/lib/jvm/java-11-openjdk
 
 entrypoint:
   command: /usr/bin/docker-entrypoint.sh
-cmd: opensearchwrapper
 
+cmd: opensearchwrapper

--- a/images/opentofu/config/template.apko.yaml
+++ b/images/opentofu/config/template.apko.yaml
@@ -15,4 +15,3 @@ entrypoint:
   command: /usr/bin/tofu
 
 cmd: --help
-

--- a/images/paranoia/config/template.apko.yaml
+++ b/images/paranoia/config/template.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/paranoia
-

--- a/images/pgbouncer/config/template.apko.yaml
+++ b/images/pgbouncer/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - pgbouncer
+    - pgbouncer
 
 accounts:
   groups:
@@ -14,5 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/pgbouncer
-cmd: --help
 
+cmd: --help

--- a/images/php/config/fpm/template.apko.yaml
+++ b/images/php/config/fpm/template.apko.yaml
@@ -40,4 +40,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/postgres/config/template.apko.yaml
+++ b/images/postgres/config/template.apko.yaml
@@ -5,7 +5,6 @@ contents:
     - su-exec
     # Postgres comes via var.extra_packages
 
-
 accounts:
   groups:
     - groupname: postgres
@@ -31,4 +30,3 @@ paths:
     uid: 70
     gid: 70
     permissions: 0o777
-

--- a/images/powershell/configs/latest-root.apko.yaml
+++ b/images/powershell/configs/latest-root.apko.yaml
@@ -11,8 +11,6 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 0
-  recursive: true
 
 entrypoint:
   command: /usr/bin/pwsh
-

--- a/images/powershell/configs/latest.apko.yaml
+++ b/images/powershell/configs/latest.apko.yaml
@@ -11,8 +11,6 @@ accounts:
     - username: nonroot
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/pwsh
-

--- a/images/prometheus-adapter/config/template.apko.yaml
+++ b/images/prometheus-adapter/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   # prometheus-adapter comes in via var.extra_packages
-  packages: []
+  packages:
 
 accounts:
   groups:

--- a/images/prometheus-cloudwatch-exporter/config/latest.apko.yaml
+++ b/images/prometheus-cloudwatch-exporter/config/latest.apko.yaml
@@ -19,4 +19,3 @@ entrypoint:
   command: /usr/bin/java -jar /usr/share/java/cloudwatch_exporter/cloudwatch_exporter.jar 9106
 
 cmd: /config/config.yml
-

--- a/images/prometheus-node-exporter/config/latest.apko.yaml
+++ b/images/prometheus-node-exporter/config/latest.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # prometheus-node-exporter comes in via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:

--- a/images/prometheus-redis-exporter/config/latest.apko.yaml
+++ b/images/prometheus-redis-exporter/config/latest.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # prometheus-redis-exporter comes in via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -12,7 +10,6 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/redis_exporter

--- a/images/prometheus-statsd-exporter/config/latest.apko.yaml
+++ b/images/prometheus-statsd-exporter/config/latest.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # prometheus-statsd-exporter comes in via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:

--- a/images/prometheus/configs/latest.alertmanager.apko.yaml
+++ b/images/prometheus/configs/latest.alertmanager.apko.yaml
@@ -3,12 +3,14 @@ contents:
     - prometheus-alertmanager
     - wolfi-base
     - busybox
+
 paths:
   - path: /alertmanager
     type: directory
     permissions: 0o777
     uid: 65532
     gid: 65532
+
 accounts:
   groups:
     - groupname: alertmanager
@@ -20,5 +22,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/alertmanager
-cmd: --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager
 
+cmd: --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager

--- a/images/prometheus/configs/latest.config-reloader.apko.yaml
+++ b/images/prometheus/configs/latest.config-reloader.apko.yaml
@@ -1,7 +1,7 @@
 contents:
-    packages:
-      - prometheus-config-reloader
-      - prometheus-config-reloader-oci-entrypoint-compat
+  packages:
+    - prometheus-config-reloader
+    - prometheus-config-reloader-oci-entrypoint-compat
 
 accounts:
   groups:
@@ -15,4 +15,3 @@ accounts:
 
 entrypoint:
   command: /bin/prometheus-config-reloader
-

--- a/images/prometheus/configs/latest.core.apko.yaml
+++ b/images/prometheus/configs/latest.core.apko.yaml
@@ -4,4 +4,3 @@ contents:
 
 entrypoint:
   command: prometheus
-

--- a/images/prometheus/configs/latest.mongodb-exporter.apko.yaml
+++ b/images/prometheus/configs/latest.mongodb-exporter.apko.yaml
@@ -11,7 +11,6 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/mongodb_exporter

--- a/images/prometheus/configs/latest.mysqld-exporter.apko.yaml
+++ b/images/prometheus/configs/latest.mysqld-exporter.apko.yaml
@@ -15,4 +15,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/mysqld_exporter
-

--- a/images/prometheus/configs/latest.node-exporter.apko.yaml
+++ b/images/prometheus/configs/latest.node-exporter.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/node_exporter
-

--- a/images/prometheus/configs/latest.operator.apko.yaml
+++ b/images/prometheus/configs/latest.operator.apko.yaml
@@ -14,4 +14,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/prometheus/configs/latest.postgres-exporter.apko.yaml
+++ b/images/prometheus/configs/latest.postgres-exporter.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/postgres_exporter
-

--- a/images/promtail/config/template.apko.yaml
+++ b/images/promtail/config/template.apko.yaml
@@ -15,4 +15,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/promtail
+
 cmd: -config.file=/etc/promtail/config.yml

--- a/images/proxysql/configs/latest.apko.yaml
+++ b/images/proxysql/configs/latest.apko.yaml
@@ -9,10 +9,10 @@ accounts:
   users:
     - username: proxysql
       uid: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/proxysql
+
 cmd: --initial --idle-threads -f -c /etc/proxysql.cnf
 
 paths:
@@ -21,4 +21,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o755
-

--- a/images/pulumi/configs/latest.apko.yaml
+++ b/images/pulumi/configs/latest.apko.yaml
@@ -3,11 +3,9 @@ contents:
     - pulumi
     - pulumi-watch
     - busybox # Needed for language support
-
     # for Pulumi Go support
     - pulumi-language-go
     - go
-
     # for Pulumi Dotnet support
     - pulumi-language-dotnet
     - dotnet-7
@@ -15,18 +13,15 @@ contents:
     - dotnet-7-sdk
     - aspnet-7-runtime
     - aspnet-7-targeting-pack
-
     # for Pulumi Python support
     - pulumi-language-python
     - python-3.11
     - py3.11-pip
     - python-3.11-dev
-
     # for Pulumi Node.js support
     - pulumi-language-nodejs
     - nodejs
     - nghttp2
-
     # for Pulumi Java support
     - pulumi-language-java
     - glibc-locale-en
@@ -35,10 +30,8 @@ contents:
     - openjdk-17
     - libstdc++
     - maven
-
     # for Pulumi YAML support
     - pulumi-language-yaml
-
     # other miscellaneous
     - git
     - bash
@@ -63,6 +56,7 @@ environment:
 
 entrypoint:
   command: /usr/bin/pulumi
+
 cmd: -h
 
 paths:
@@ -71,4 +65,3 @@ paths:
     uid: 65532
     gid: 65532
     permissions: 0o777
-

--- a/images/python/config/template.apko.yaml
+++ b/images/python/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Python comes via var.extra_packages
-  ]
+  packages:
 
 entrypoint:
   command: /usr/bin/python

--- a/images/r-base/config/template.apko.yaml
+++ b/images/r-base/config/template.apko.yaml
@@ -14,4 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/R
+
 cmd: --help

--- a/images/rabbitmq/configs/latest.apko.yaml
+++ b/images/rabbitmq/configs/latest.apko.yaml
@@ -13,7 +13,7 @@ paths:
     permissions: 0o777
     uid: 999
     gid: 999
-    resursive: true
+    recursive: true
   - path: /app
     type: directory
     permissions: 0o777
@@ -63,4 +63,3 @@ accounts:
     - username: rabbitmq
       uid: 999
   run-as: 999
-

--- a/images/redis-sentinel/configs/6.2.apko.yaml
+++ b/images/redis-sentinel/configs/6.2.apko.yaml
@@ -30,4 +30,5 @@ environment:
 
 entrypoint:
   command: /opt/bitnami/scripts/redis-sentinel/entrypoint.sh
+
 cmd: /opt/bitnami/scripts/redis-sentinel/run.sh

--- a/images/rqlite/config/template.apko.yaml
+++ b/images/rqlite/config/template.apko.yaml
@@ -12,7 +12,6 @@ accounts:
     - username: rqlite
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/docker-entrypoint.sh
@@ -23,4 +22,3 @@ paths:
     permissions: 0o777
     uid: 65532
     gid: 65532
-

--- a/images/ruby/config/template.apko.yaml
+++ b/images/ruby/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Ruby comes via var.extra_packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -22,4 +20,5 @@ work-dir: /work
 
 entrypoint:
   command: /usr/bin/ruby
+
 cmd: --version

--- a/images/rust/configs/latest.apko.yaml
+++ b/images/rust/configs/latest.apko.yaml
@@ -23,5 +23,5 @@ work-dir: /work
 
 entrypoint:
   command: /usr/bin/rustc
-cmd: --help
 
+cmd: --help

--- a/images/secrets-store-csi-driver-provider-gcp/config/template.apko.yaml
+++ b/images/secrets-store-csi-driver-provider-gcp/config/template.apko.yaml
@@ -10,8 +10,6 @@ accounts:
     - username: secrets-store-csi-driver-provider-gcp
       uid: 65532
   run-as: 0 # run as root
-  recursive: true
 
 entrypoint:
   command: /usr/bin/secrets-store-csi-driver-provider-gcp
-

--- a/images/secrets-store-csi-driver/configs/latest.apko.yaml
+++ b/images/secrets-store-csi-driver/configs/latest.apko.yaml
@@ -11,8 +11,6 @@ accounts:
     - username: secrets-store-csi-driver
       uid: 65532
   run-as: 0 # run as root
-  recursive: true
 
 entrypoint:
   command: /usr/bin/secrets-store-csi
-

--- a/images/semgrep/config/template.apko.yaml
+++ b/images/semgrep/config/template.apko.yaml
@@ -14,4 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/semgrep
+
 cmd: --help

--- a/images/skaffold/config/template.apko.yaml
+++ b/images/skaffold/config/template.apko.yaml
@@ -20,6 +20,7 @@ environment:
 
 entrypoint:
   command: /usr/bin/skaffold
+
 cmd: --help
 
 accounts:
@@ -30,4 +31,3 @@ accounts:
     - username: skaffold
       uid: 65532
   run-as: 65532
-

--- a/images/spark-operator/configs/latest.apko.yaml
+++ b/images/spark-operator/configs/latest.apko.yaml
@@ -15,4 +15,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/entrypoint.sh
-

--- a/images/spire/configs/latest.agent.apko.yaml
+++ b/images/spire/configs/latest.agent.apko.yaml
@@ -18,4 +18,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/spire-agent run
-

--- a/images/spire/configs/latest.oidc-discovery-provider.apko.yaml
+++ b/images/spire/configs/latest.oidc-discovery-provider.apko.yaml
@@ -16,4 +16,3 @@ entrypoint:
   command: /usr/bin/oidc-discovery-provider
 
 cmd: --help
-

--- a/images/spire/configs/latest.server.apko.yaml
+++ b/images/spire/configs/latest.server.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/spire-server run
-

--- a/images/stakater-reloader/configs/latest.apko.yaml
+++ b/images/stakater-reloader/configs/latest.apko.yaml
@@ -16,4 +16,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/manager
-

--- a/images/static/configs/alpine.apko.yaml
+++ b/images/static/configs/alpine.apko.yaml
@@ -11,4 +11,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/static/configs/wolfi.apko.yaml
+++ b/images/static/configs/wolfi.apko.yaml
@@ -11,4 +11,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/stunnel/config/template.apko.yaml
+++ b/images/stunnel/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-  - stunnel
+    - stunnel
 
 accounts:
   groups:
@@ -14,5 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/stunnel
-cmd: -help
 
+cmd: -help

--- a/images/telegraf/configs/latest.apko.yaml
+++ b/images/telegraf/configs/latest.apko.yaml
@@ -10,8 +10,6 @@ accounts:
     - username: telegraf
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/telegraf
-

--- a/images/terraform/config/template.apko.yaml
+++ b/images/terraform/config/template.apko.yaml
@@ -15,4 +15,3 @@ entrypoint:
   command: /usr/bin/terraform
 
 cmd: --help
-

--- a/images/thanos-operator/configs/latest.apko.yaml
+++ b/images/thanos-operator/configs/latest.apko.yaml
@@ -15,4 +15,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/manager
-

--- a/images/thanos/configs/latest.apko.yaml
+++ b/images/thanos/configs/latest.apko.yaml
@@ -13,4 +13,3 @@ accounts:
 
 entrypoint:
   command: thanos
-

--- a/images/tigera-operator/config/template.apko.yaml
+++ b/images/tigera-operator/config/template.apko.yaml
@@ -1,7 +1,5 @@
 contents:
-  packages: [
-    # Package comes from extra-packages
-  ]
+  packages:
 
 accounts:
   groups:
@@ -14,4 +12,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/operator
+
 cmd: --help

--- a/images/traefik/configs/latest.apko.yaml
+++ b/images/traefik/configs/latest.apko.yaml
@@ -12,10 +12,9 @@ accounts:
   run-as: 65532
 
 paths:
-- path: /tmp
-  type: directory
-  permissions: 0o777
+  - path: /tmp
+    type: directory
+    permissions: 0o777
 
 entrypoint:
   command: /usr/bin/traefik
-

--- a/images/trust-manager/config/template.apko.yaml
+++ b/images/trust-manager/config/template.apko.yaml
@@ -14,4 +14,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/trust-manager
-

--- a/images/vault/configs/latest.vault-k8s.apko.yaml
+++ b/images/vault/configs/latest.vault-k8s.apko.yaml
@@ -11,8 +11,6 @@ accounts:
     - username: vault
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/bin/vault-k8s
-

--- a/images/vault/configs/latest.vault.apko.yaml
+++ b/images/vault/configs/latest.vault.apko.yaml
@@ -11,10 +11,8 @@ accounts:
     - username: vault
       uid: 65532
   run-as: 0 # Entrypoint script will change user
-  recursive: true
 
 entrypoint:
   command: /usr/bin/docker-entrypoint.sh
 
 cmd: server -dev
-

--- a/images/vela-cli/config/template.apko.yaml
+++ b/images/vela-cli/config/template.apko.yaml
@@ -16,4 +16,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/vela
-

--- a/images/vertical-pod-autoscaler/configs/latest.admission-controller.apko.yaml
+++ b/images/vertical-pod-autoscaler/configs/latest.admission-controller.apko.yaml
@@ -13,7 +13,6 @@ accounts:
   run-as: 65532
 
 entrypoint:
-  command:  /usr/bin/admission-controller
+  command: /usr/bin/admission-controller
 
 cmd: "--v=4 --stderrthreshold=info"
-

--- a/images/vertical-pod-autoscaler/configs/latest.recommender.apko.yaml
+++ b/images/vertical-pod-autoscaler/configs/latest.recommender.apko.yaml
@@ -16,4 +16,3 @@ entrypoint:
   command: /usr/bin/recommender
 
 cmd: "--v=4 --stderrthreshold=info"
-

--- a/images/vertical-pod-autoscaler/configs/latest.updater.apko.yaml
+++ b/images/vertical-pod-autoscaler/configs/latest.updater.apko.yaml
@@ -14,5 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/updater
-cmd: "--v=4 --stderrthreshold=info"
 
+cmd: "--v=4 --stderrthreshold=info"

--- a/images/vt/config/template.apko.yaml
+++ b/images/vt/config/template.apko.yaml
@@ -15,4 +15,3 @@ accounts:
 
 entrypoint:
   command: /usr/bin/vt
-

--- a/images/wait-for-it/configs/latest.apko.yaml
+++ b/images/wait-for-it/configs/latest.apko.yaml
@@ -14,4 +14,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-

--- a/images/wasmer/config/template.apko.yaml
+++ b/images/wasmer/config/template.apko.yaml
@@ -14,5 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/wasmer
-cmd: --help
 
+cmd: --help

--- a/images/wasmtime/config/template.apko.yaml
+++ b/images/wasmtime/config/template.apko.yaml
@@ -14,5 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/wasmtime
-cmd: --help
 
+cmd: --help

--- a/images/wavefront-proxy/configs/latest.apko.yaml
+++ b/images/wavefront-proxy/configs/latest.apko.yaml
@@ -1,13 +1,13 @@
 contents:
-    packages:
-      - openjdk-11-jre
-      - openjdk-11-default-jvm
-      - wavefront-proxy
-      - wavefront-proxy-config
-      - wavefront-proxy-licenses
-      - wavefront-proxy-oci-entrypoint
-      - bash
-      - busybox
+  packages:
+    - openjdk-11-jre
+    - openjdk-11-default-jvm
+    - wavefront-proxy
+    - wavefront-proxy-config
+    - wavefront-proxy-licenses
+    - wavefront-proxy-oci-entrypoint
+    - bash
+    - busybox
 
 accounts:
   groups:
@@ -18,7 +18,6 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-
 
 paths:
   - path: /var/spool/wavefront-proxy
@@ -36,4 +35,3 @@ paths:
 
 entrypoint:
   command: /usr/local/bin/run.sh
-

--- a/images/wazero/config/template.apko.yaml
+++ b/images/wazero/config/template.apko.yaml
@@ -14,5 +14,5 @@ accounts:
 
 entrypoint:
   command: /usr/bin/wazero
-cmd: --help
 
+cmd: --help

--- a/images/weaviate/config/template.apko.yaml
+++ b/images/weaviate/config/template.apko.yaml
@@ -17,6 +17,7 @@ paths:
 
 entrypoint:
   command: /bin/weaviate
+
 cmd: --host 0.0.0.0 --port 8080 --scheme http
 
 accounts:
@@ -27,4 +28,3 @@ accounts:
     - username: weaviate
       uid: 65532
   run-as: 65532
-

--- a/images/zig/config/template.apko.yaml
+++ b/images/zig/config/template.apko.yaml
@@ -17,4 +17,3 @@ entrypoint:
   command: /usr/bin/zig
 
 cmd: help
-

--- a/images/zookeeper/configs/latest.apko.yaml
+++ b/images/zookeeper/configs/latest.apko.yaml
@@ -15,10 +15,10 @@ accounts:
     - username: zookeeper
       uid: 65532
   run-as: 65532
-  recursive: true
 
 entrypoint:
   command: /usr/share/java/zookeeper/bin/zkServer.sh
+
 cmd: start-foreground
 
 paths:
@@ -31,4 +31,3 @@ paths:
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/java-17-openjdk
-

--- a/images/zot/config/template.apko.yaml
+++ b/images/zot/config/template.apko.yaml
@@ -24,4 +24,3 @@ entrypoint:
   command: /usr/bin/zot
 
 cmd: --help
-


### PR DESCRIPTION
https://github.com/chainguard-dev/terraform-provider-apko/pull/174 checks that all fields in the YAML are defined in the type. Perhaps surprisingly (or not), we have a bunch of YAML fields that haven't been used at all.

A lot of these were `.accounts.recursive: true`, which doesn't mean anything. I suspect our old friend copypasta. 🍝 

Another common one was bad indentation, and in those cases I moved the things back to where I think they were supposed to go, but it does beg the question: do we need these at all, if they haven't been used this whole time? 🤔 
- `aws-ebs-csi-driver` had `paths` that were invalid; those were removed

Another one was `command` in the top level, which should be `cmd` (obviously, come on).

This adds `.yam.yaml` which sorts stuff and adds gaps, while we're making mass YAML changes, and enforces yam conformance in presubmit.