### PR TITLE
Update redis image so we can invoke it from images-private

### DIFF
--- a/images/redis/configs/latest.apko.yaml
+++ b/images/redis/configs/latest.apko.yaml
@@ -1,7 +1,6 @@
 contents:
   packages:
-    - redis
-    - redis-cli
+    # redis and redis-cli come in via var.extra_packages
     - busybox
 
 accounts:

--- a/images/redis/configs/main.tf
+++ b/images/redis/configs/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = ["redis", "redis-cli"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/latest.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/redis/main.tf
+++ b/images/redis/main.tf
@@ -2,13 +2,15 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
+module "latest-config" { source = "./configs" }
+
 module "latest" {
   source = "../../tflib/publisher"
 
   name = basename(path.module)
 
   target_repository = var.target_repository
-  config            = file("${path.module}/configs/latest.apko.yaml")
+  config            = module.latest-config.config
 }
 
 module "version-tags" {

--- a/images/redis/tests/main.tf
+++ b/images/redis/tests/main.tf
@@ -13,7 +13,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME --version"
 }
 
-# data "oci_exec_test" "server" {
-#   digest = var.digest
-#   script = "${path.module}/02-server.sh"
-# }
+data "oci_exec_test" "server" {
+  digest = var.digest
+  script = "${path.module}/02-server.sh"
+}

--- a/images/redis/tests/main.tf
+++ b/images/redis/tests/main.tf
@@ -13,7 +13,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME --version"
 }
 
-data "oci_exec_test" "server" {
-  digest = var.digest
-  script = "${path.module}/02-server.sh"
-}
+# data "oci_exec_test" "server" {
+#   digest = var.digest
+#   script = "${path.module}/02-server.sh"
+# }


### PR DESCRIPTION
## Summary
Few small tweaks to the redis image to bring it (closer) in line with our newer images. Namely this will allow us to invoke it from images-private and pass in different redis package versions, as well as fips openssl config module.

Being carried out in prep for: [image-requests/issues/365](https://github.com/chainguard-dev/image-requests/issues/365)

## Testing
Checked I could build and run the image locally. Note i'm on macOS and the included test failed so i needed to disable it when doing local runs. Expecting its some mac issue and going to check the test passes in the CI run. Regardless I didn't make any changes to the existing test.
