### PR TITLE
Run aws-efs-csi-driver as root

### DIFF
--- a/images/aws-efs-csi-driver/configs/latest.apko.yaml
+++ b/images/aws-efs-csi-driver/configs/latest.apko.yaml
@@ -10,21 +10,9 @@ accounts:
     - username: nonroot
       uid: 65532
       gid: 65532
-  run-as: 65532
-
-paths:
-  - path: /etc/amazon/efs/
-    type: directory
-    uid: 65532
-    gid: 65532
-    permissions: 0o755
-    recursive: true
-  - path: /csi/
-    type: directory
-    uid: 65532
-    gid: 65532
-    permissions: 0o755
-    recursive: true
+  # This package expects to run as root, context:
+  # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/1121#issuecomment-1714003621
+  run-as: 0
 
 entrypoint:
   command: aws-efs-csi-driver


### PR DESCRIPTION
These packages expect to run as root and cannot start up as is.

Currently, it fails with:

> remove /csi/csi.sock: permission denied