### PR TITLE
Revert "external-dns test: use traefik instead of nginx"

### DIFF
--- a/images/external-dns/tests/e2e.sh
+++ b/images/external-dns/tests/e2e.sh
@@ -165,7 +165,7 @@ kind: Ingress
 metadata:
   name: dummy
 spec:
-  ingressClassName: traefik # NOTE: This assumes k3s
+  ingressClassName: nginx # NOTE: This assumes kind
   rules:
   - host: ${domain}
     http:


### PR DESCRIPTION
Reverts chainguard-images/images#1483

Didn't seems to address build issue.