### PR TITLE
Add a Rekor image.

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -62,6 +62,7 @@ jobs:
         uses: chainguard-dev/actions/k8s-diag@main
         with:
           cluster-type: k3d
+          namespace-resources: pods,svc,deploy,sts,daemonset
           artifact-name: ${{ matrix.imageName }}-diagnostics
 
   presubmit-roundup:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 | [rabbitmq](./images/rabbitmq) | `cgr.dev/chainguard/rabbitmq` |
 | [redis](./images/redis) | `cgr.dev/chainguard/redis` |
 | [redis-sentinel](./images/redis-sentinel) | `cgr.dev/chainguard/redis-sentinel` |
+| [rekor](./images/rekor) | `cgr.dev/chainguard/rekor` |
 | [rqlite](./images/rqlite) | `cgr.dev/chainguard/rqlite` |
 | [ruby](./images/ruby) | `cgr.dev/chainguard/ruby` |
 | [rust](./images/rust) | `cgr.dev/chainguard/rust` |

--- a/images/rekor/README.md
+++ b/images/rekor/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# rekor
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/rekor` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/rekor/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/rekor/config/main.tf
+++ b/images/rekor/config/main.tf
@@ -1,0 +1,28 @@
+variable "name" {
+  description = "Package name (e.g. rekor-server, rekor-cli)"
+}
+
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(["${var.name}${var.suffix}"], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/${var.name}"
+    }
+  })
+}

--- a/images/rekor/main.tf
+++ b/images/rekor/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  components = toset(["server", "cli", "backfill-redis"])
+}
+
+module "config" {
+  for_each = local.components
+  source   = "./config"
+  name     = "rekor-${each.key}"
+}
+
+module "latest" {
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = "${var.target_repository}-${each.key}"
+  config            = module.config[each.key].config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source  = "./tests"
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+}

--- a/images/rekor/tests/main.tf
+++ b/images/rekor/tests/main.tf
@@ -1,0 +1,177 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    server         = string
+    cli            = string
+    backfill-redis = string
+  })
+}
+
+data "oci_ref" "curl" {
+  ref = "cgr.dev/chainguard/curl:latest-dev"
+}
+
+data "oci_ref" "redis" {
+  ref = "cgr.dev/chainguard/redis:latest"
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "rekor" {
+  name       = "rekor-${random_pet.suffix.id}"
+  repository = "https://sigstore.github.io/helm-charts"
+  chart      = "rekor"
+  timeout    = 600
+
+  namespace        = "rekor-${random_pet.suffix.id}"
+  create_namespace = true
+
+  set {
+    name  = "namespace.name"
+    value = "rekor-${random_pet.suffix.id}"
+  }
+
+  // curl
+  set {
+    name  = "initContainerImage.curl.registry"
+    value = "cgr.dev"
+  }
+  set {
+    name  = "initContainerImage.curl.repository"
+    value = "chainguard/curl"
+  }
+  set {
+    name  = "initContainerImage.curl.version"
+    value = data.oci_ref.curl.digest
+  }
+
+  // redis
+  set {
+    name  = "redis.image.registry"
+    value = "cgr.dev"
+  }
+  set {
+    name  = "redis.image.repository"
+    value = "chainguard/redis"
+  }
+  set {
+    name  = "redis.image.version"
+    value = data.oci_ref.redis.digest
+  }
+
+  // rekor-server
+  set {
+    name  = "server.image.registry"
+    value = data.oci_string.ref["server"].registry
+  }
+  set {
+    name  = "server.image.repository"
+    value = data.oci_string.ref["server"].repo
+  }
+  set {
+    name  = "server.image.version"
+    value = data.oci_string.ref["server"].digest
+  }
+
+  // rekor-server
+  set {
+    name  = "backfillredis.image.registry"
+    value = data.oci_string.ref["backfill-redis"].registry
+  }
+  set {
+    name  = "backfillredis.image.repository"
+    value = data.oci_string.ref["backfill-redis"].repo
+  }
+  set {
+    name  = "backfillredis.image.version"
+    value = data.oci_string.ref["backfill-redis"].digest
+  }
+
+  // scaffolding createtree
+  // TODO(mattmoor): Switch to chainguard image
+  set {
+    name  = "createtree.image.registry"
+    value = "ghcr.io"
+  }
+  set {
+    name  = "createtree.image.repository"
+    value = "sigstore/scaffolding/createtree"
+  }
+  set {
+    name  = "createtree.image.version"
+    value = "sha256:8e921d028b46d5ad98994d58f79e2724cf84e99e3270f5799fe0f1a6b518bc4e"
+  }
+}
+
+# Based on https://github.com/sigstore/rekor/blob/main/types.md#hashed-rekord
+resource "kubernetes_job_v1" "check_rekor" {
+  depends_on = [helm_release.rekor]
+
+  metadata {
+    name      = "check-rekor"
+    namespace = "rekor-${random_pet.suffix.id}"
+  }
+
+  spec {
+    template {
+      metadata {}
+      spec {
+        init_container {
+          name        = "sign"
+          image       = "cgr.dev/chainguard/wolfi-base:latest"
+          working_dir = "/workspace"
+          command     = ["/bin/sh", "-c"]
+          args = [<<EOF
+          set -ex
+          apk add openssl
+          openssl ecparam -genkey -name prime256v1 > ec_private.pem
+          openssl ec -in ec_private.pem -pubout > ec_public.pem
+          echo -n ${random_pet.suffix.id} | openssl dgst -sha256 -sign ec_private.pem -out foo.sig
+          EOF
+          ]
+          volume_mount {
+            name       = "workspace"
+            mount_path = "/workspace"
+          }
+        }
+        container {
+          name  = "check-rekor"
+          image = var.digests["cli"]
+          args = [
+            "upload",
+            "--rekor_server=http://rekor-${random_pet.suffix.id}-server.rekor-${random_pet.suffix.id}.svc",
+            "--type=hashedrekord:0.0.1",
+            "--artifact-hash=${sha256(random_pet.suffix.id)}",
+            "--signature=foo.sig",
+            "--pki-format=x509",
+            "--public-key=ec_public.pem",
+          ]
+          working_dir = "/workspace"
+          volume_mount {
+            name       = "workspace"
+            mount_path = "/workspace"
+          }
+        }
+        volume {
+          name = "workspace"
+          empty_dir {}
+        }
+        restart_policy = "Never"
+      }
+    }
+  }
+
+  wait_for_completion = true
+}

--- a/main.tf
+++ b/main.tf
@@ -768,7 +768,6 @@ module "r-base" {
   target_repository = "${var.target_repository}/r-base"
 }
 
-
 module "rabbitmq" {
   source            = "./images/rabbitmq"
   target_repository = "${var.target_repository}/rabbitmq"
@@ -782,6 +781,11 @@ module "redis" {
 module "redis-sentinel" {
   source            = "./images/redis-sentinel"
   target_repository = "${var.target_repository}/redis-sentinel"
+}
+
+module "rekor" {
+  source            = "./images/rekor"
+  target_repository = "${var.target_repository}/rekor"
 }
 
 module "rqlite" {


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
