### PR TITLE
Add trillian images

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@
 | [tigera-operator](./images/tigera-operator) | `cgr.dev/chainguard/tigera-operator` |
 | [timoni](./images/timoni) | `cgr.dev/chainguard/timoni` |
 | [traefik](./images/traefik) | `cgr.dev/chainguard/traefik` |
+| [trillian](./images/trillian) | `cgr.dev/chainguard/trillian` |
 | [trust-manager](./images/trust-manager) | `cgr.dev/chainguard/trust-manager` |
 | [vault](./images/vault) | `cgr.dev/chainguard/vault` |
 | [vela-cli](./images/vela-cli) | `cgr.dev/chainguard/vela-cli` |

--- a/images/trillian/README.md
+++ b/images/trillian/README.md
@@ -1,0 +1,24 @@
+<!--monopod:start-->
+# trillian
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/trillian` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/trillian/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+[Trillian](https://github.com/google/trillian) is a Merkle tree implementation that is used as the backing for various functionalities including Certificate Transparency and the Sigstore Rekor transparency log.
+
+## Get It
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/trillian-logserver
+docker pull cgr.dev/chainguard/trillian-logsigner
+```

--- a/images/trillian/config/main.tf
+++ b/images/trillian/config/main.tf
@@ -1,0 +1,34 @@
+variable "name" {
+}
+
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+locals {
+  binaries = {
+    "logserver" = "trillian_log_server"
+    "logsigner" = "trillian_log_signer"
+  }
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(["trillian-${var.name}"], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/${local.binaries["${var.name}"]}"
+    }
+  })
+}

--- a/images/trillian/main.tf
+++ b/images/trillian/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  components = toset(["logserver", "logsigner"])
+}
+
+module "config" {
+  for_each = local.components
+  source   = "./config"
+  name     = each.key
+}
+
+module "latest" {
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = "${var.target_repository}-${each.key}"
+  config            = module.config[each.key].config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source  = "./tests"
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+}

--- a/images/trillian/tests/main.tf
+++ b/images/trillian/tests/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    logserver = string
+    logsigner = string
+  })
+}
+
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+
+data "oci_exec_test" "test" {
+  digest = data.oci_string.ref["logsigner"].id
+  script = "${path.module}/test.sh"
+
+  env {
+    name  = "TRILLIAN_LOG_SIGNER"
+    value = data.oci_string.ref["logsigner"].id
+  }
+
+  env {
+    name  = "TRILLIAN_LOG_SERVER"
+    value = data.oci_string.ref["logserver"].id
+  }
+}

--- a/images/trillian/tests/test.sh
+++ b/images/trillian/tests/test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+
+TMP="$(mktemp -d)"
+pushd "${TMP}"
+
+# Grabbed this from trillian
+# https://github.com/google/trillian/blob/master/examples/deployment/docker-compose.yml
+cat <<EOF > docker-compose.yml
+
+version: '3.4'
+services:
+  mysql:
+    image: gcr.io/trillian-opensource-ci/db_server:v1.5.2
+    environment:
+      - MYSQL_ROOT_PASSWORD=zaphod
+      - MYSQL_DATABASE=test
+      - MYSQL_USER=test
+      - MYSQL_PASSWORD=zaphod
+    restart: always # keep the MySQL server running
+  trillian-log-server:
+    image: $TRILLIAN_LOG_SERVER
+    command: [
+      "--storage_system=mysql",
+      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+      "--rpc_endpoint=0.0.0.0:8090",
+      "--http_endpoint=0.0.0.0:8091",
+      "--alsologtostderr",
+    ]
+    restart: always # retry while mysql is starting up
+    ports:
+      - "8090:8090"
+      - "8091:8091"
+    depends_on:
+      - mysql
+  trillian-log-signer:
+    image: $TRILLIAN_LOG_SIGNER
+    command: [
+      "--storage_system=mysql",
+      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+      "--rpc_endpoint=0.0.0.0:8090",
+      "--http_endpoint=0.0.0.0:8091",
+      "--force_master",
+      "--alsologtostderr",
+    ]
+    restart: always # retry while mysql is starting up
+    ports:
+      - "8092:8091"
+    depends_on:
+      - mysql
+EOF
+
+docker compose up --wait
+curl --retry 10 --retry-all-errors localhost:8091/metrics 
+docker compose down

--- a/main.tf
+++ b/main.tf
@@ -892,6 +892,11 @@ module "traefik" {
   target_repository = "${var.target_repository}/traefik"
 }
 
+module "trillian" {
+  source            = "./images/trillian"
+  target_repository = "${var.target_repository}/trillian"
+}
+
 module "trust-manager" {
   source            = "./images/trust-manager"
   target_repository = "${var.target_repository}/trust-manager"


### PR DESCRIPTION
## Chainguard Images Pull Request Template



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

41MB vs 72MB (gcr.io/trillian-opensource-ci/log_server:v1.5.2)

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

```
NAME                              INSTALLED  FIXED-IN  TYPE       VULNERABILITY  SEVERITY 
github.com/prometheus/prometheus  v0.35.0              go-module  CVE-2019-3826  Medium
```

based on https://github.com/anchore/grype/issues/840, it seems like this is a CVE in the prometheus frontend and shouldn't affect this application.

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
