### PR TITLE
Remove `tflib/dev-subvariant` module.

### DIFF
--- a/tflib/dev-subvariant/main.tf
+++ b/tflib/dev-subvariant/main.tf
@@ -1,8 +1,0 @@
-output "extra_packages" {
-  value = [
-    "apk-tools",
-    "bash",
-    "busybox",
-    "git",
-  ]
-}

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -64,8 +64,6 @@ module "this" {
   extra_packages    = var.extra_packages
 }
 
-module "dev" { source = "../dev-subvariant" }
-
 module "this-dev" {
   count   = local.build-dev ? 1 : 0
   source  = "chainguard-dev/apko/publisher"
@@ -75,8 +73,13 @@ module "this-dev" {
 
   # Make the dev variant an explicit extension of the
   # locked original.
-  config         = jsonencode(module.this.config)
-  extra_packages = concat(module.dev.extra_packages, var.extra_dev_packages)
+  config = jsonencode(module.this.config)
+  extra_packages = concat([
+    "apk-tools",
+    "bash",
+    "busybox",
+    "git",
+  ], var.extra_dev_packages)
 }
 
 data "oci_exec_test" "check-reproducibility" {


### PR DESCRIPTION
Now that we have consolidated production of dev variants via the publisher module, this removes the `dev-subvariant` module we used to define the constant because it is used in a single place.
