### PR TITLE
Remove usr/local from entrypoint path.

### DIFF
--- a/images/crossplane-aws/config/template.apko.yaml
+++ b/images/crossplane-aws/config/template.apko.yaml
@@ -13,7 +13,7 @@ accounts:
   run-as: 65532
 
 entrypoint:
-  command: /usr/local/bin/provider
+  command: /usr/bin/provider
 
 environment:
   TERRAFORM_NATIVE_PROVIDER_PATH: /usr/bin/terraform-provider-aws

--- a/images/crossplane-azure/config/template.apko.yaml
+++ b/images/crossplane-azure/config/template.apko.yaml
@@ -13,7 +13,7 @@ accounts:
   run-as: 65532
 
 entrypoint:
-  command: /usr/local/bin/provider
+  command: /usr/bin/provider
 
 environment:
   TERRAFORM_NATIVE_PROVIDER_PATH: /usr/bin/terraform-provider-azurerm


### PR DESCRIPTION
This was flagging our linters. The upstream images *do* place the binaries in usr/local, but the entrypoint doesn't contain that path: https://github.com/crossplane-contrib/provider-aws/blob/master/cluster/images/provider-aws/Dockerfile

## Chainguard Images Pull Request Template
