### PR TITLE
Add gitness server image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 | [gatekeeper](./images/gatekeeper) | `cgr.dev/chainguard/gatekeeper` |
 | [gcc-glibc](./images/gcc-glibc) | `cgr.dev/chainguard/gcc-glibc` |
 | [git](./images/git) | `cgr.dev/chainguard/git` |
+| [gitness](./images/gitness) | `cgr.dev/chainguard/gitness` |
 | [glibc-dynamic](./images/glibc-dynamic) | `cgr.dev/chainguard/glibc-dynamic` |
 | [go](./images/go) | `cgr.dev/chainguard/go` |
 | [google-cloud-sdk](./images/google-cloud-sdk) | `cgr.dev/chainguard/google-cloud-sdk` |

--- a/images/gitness/README.md
+++ b/images/gitness/README.md
@@ -1,0 +1,50 @@
+<!--monopod:start-->
+# gitness
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/gitness` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/gitness/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimal image with the `gitness` [server application](https://github.com/harness/gitness).
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/gitness:latest
+```
+
+## Usage
+
+To run `gitness`:
+
+```
+$ docker run -d \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/gitness:/data \
+  --name gitness \
+  --restart always \
+  cgr.dev/chainguard/gitness
+
+$ docker logs gitness
+{"level":"info","time":"2023-09-30T16:31:40.085883346Z","message":"No valid profiler so skipping profiling ['']"}
+{"level":"info","time":"2023-09-30T16:31:40.099510346Z","message":"Completed setup of system service 'gitness' (id: 1)."}
+{"level":"info","time":"2023-09-30T16:31:40.100499137Z","message":"Completed setup of pipeline service 'pipeline' (id: 2)."}
+{"level":"info","port":3000,"revision":"","repository":"","version":"0.0.0","time":"2023-09-30T16:31:40.100514721Z","message":"server started"}
+{"level":"info","time":"2023-09-30T16:31:40.100516221Z","message":"gitrpc server started"}
+{"level":"info","time":"2023-09-30T16:31:40.100517471Z","message":"gitrpc cron manager subroutine started"}
+time="2023-09-30T16:31:40Z" level=debug msg="poller: request stage from remote server" thread=2
+time="2023-09-30T16:31:40Z" level=debug msg="poller: request stage from remote server" thread=1
+{"level":"info","time":"2023-09-30T16:31:41.560373846Z","message":"added 0 new entries to plugins"}
+```
+
+The server should then be available at `localhost:3000`.

--- a/images/gitness/config/main.tf
+++ b/images/gitness/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. gitness)."
+  default     = ["gitness"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/gitness/config/template.apko.yaml
+++ b/images/gitness/config/template.apko.yaml
@@ -1,0 +1,36 @@
+contents:
+  packages:
+    - gitness
+    - git
+    - busybox
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+environment:
+  XDG_CACHE_HOME: /data
+  GITRPC_SERVER_GIT_ROOT: /data
+  GITNESS_DATABASE_DRIVER: sqlite3
+  GITNESS_DATABASE_DATASOURCE: /data/database.sqlite
+  GITNESS_METRIC_ENABLED: false
+  GITNESS_METRIC_ENDPOINT: https://stats.drone.ci/api/v1/gitness
+  GITNESS_TOKEN_COOKIE_NAME: token
+
+entrypoint:
+  command: /usr/bin/gitness
+
+cmd: server

--- a/images/gitness/config/template.apko.yaml
+++ b/images/gitness/config/template.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - gitness
     - git
     - busybox
 

--- a/images/gitness/main.tf
+++ b/images/gitness/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "gitness-config" { source = "./config" }
+
+module "gitness" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.gitness-config.config
+  build-dev         = true
+}
+
+module "test-gitness" {
+  source = "./tests"
+  digest = module.gitness.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-gitness]
+  digest_ref = module.gitness.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-gitness]
+  digest_ref = module.gitness.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/gitness/tests/01-test.sh
+++ b/images/gitness/tests/01-test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+uid="gitness-$FREE_PORT"
+
+docker run -d \
+  -p $FREE_PORT:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --name $uid \
+  ${IMAGE_NAME}
+
+# The server takes some time to startup
+sleep 15
+
+docker logs $uid
+
+trap "docker logs $uid; docker kill $uid" EXIT
+
+# The healthcheck endpoint requires auth, so just hit the normal URL.
+curl localhost:$FREE_PORT

--- a/images/gitness/tests/main.tf
+++ b/images/gitness/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "test" {
+  digest = var.digest
+  script = "${path.module}/01-test.sh"
+}

--- a/main.tf
+++ b/main.tf
@@ -326,6 +326,11 @@ module "external-dns" {
   target_repository = "${var.target_repository}/external-dns"
 }
 
+module "gitness" {
+  source            = "./images/gitness"
+  target_repository = "${var.target_repository}/gitness"
+}
+
 module "graalvm-native" {
   source            = "./images/graalvm-native"
   target_repository = "${var.target_repository}/graalvm-native"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size

- [X] The Image is smaller in size than its common public counterpart.

Notes: 99 vs. 137 MB

### Image Vulnerabilities

- [X] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes: Two FPs. The upstream one has ~20 real ones.

### Basic Testing - K8s cluster

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)

### Environment Variables

- [X] Environment variables added.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
