### PR TITLE
aws-load-balancer-controller: reduce test flakes

### DIFF
--- a/images/aws-load-balancer-controller/tests/main.tf
+++ b/images/aws-load-balancer-controller/tests/main.tf
@@ -23,6 +23,11 @@ resource "helm_release" "aws-load-balancer-controller" {
   create_namespace = true
 
   values = [jsonencode({
+    webhookNamespaceSelectors = {
+      matchLabels = {
+        "aws-load-balancer-controller-namespace" = "aws-lbc-${random_pet.suffix.id}"
+      }
+    }
     image = {
       tag        = data.oci_string.ref.pseudo_tag
       repository = data.oci_string.ref.registry_repo


### PR DESCRIPTION
Restrict the namespaces being watched by the `aws-load-balancer-controller` webhook so that it doesn't cause other tests to flake when running side by side.