### PR TITLE
Build the sigstore scaffolding images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 | [secrets-store-csi-driver](./images/secrets-store-csi-driver) | `cgr.dev/chainguard/secrets-store-csi-driver` |
 | [secrets-store-csi-driver-provider-gcp](./images/secrets-store-csi-driver-provider-gcp) | `cgr.dev/chainguard/secrets-store-csi-driver-provider-gcp` |
 | [semgrep](./images/semgrep) | `cgr.dev/chainguard/semgrep` |
+| [sigstore-scaffolding](./images/sigstore-scaffolding) | `cgr.dev/chainguard/sigstore-scaffolding` |
 | [skaffold](./images/skaffold) | `cgr.dev/chainguard/skaffold` |
 | [slim-toolkit-debug](./images/slim-toolkit-debug) | `cgr.dev/chainguard/slim-toolkit-debug` |
 | [spark-operator](./images/spark-operator) | `cgr.dev/chainguard/spark-operator` |

--- a/images/sigstore-scaffolding/README.md
+++ b/images/sigstore-scaffolding/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# sigstore-scaffolding
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/sigstore-scaffolding` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/sigstore-scaffolding/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/sigstore-scaffolding/config/main.tf
+++ b/images/sigstore-scaffolding/config/main.tf
@@ -1,0 +1,28 @@
+variable "name" {
+  description = "Package name (e.g. sigstore-scaffolding-foo)"
+}
+
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(["sigstore-scaffolding-${var.name}${var.suffix}"], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/${var.name}"
+    }
+  })
+}

--- a/images/sigstore-scaffolding/main.tf
+++ b/images/sigstore-scaffolding/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  components = toset([
+    "cloudsqlproxy",
+    "ctlog-createctconfig",
+    "ctlog-managectroots",
+    "ctlog-verifyfulcio",
+    "fulcio-createcerts",
+    "getoidctoken",
+    "rekor-createsecret",
+    "trillian-createdb",
+    "trillian-createtree",
+    "trillian-updatetree",
+    "tsa-createcertchain",
+    "tuf-createsecret",
+  ])
+}
+
+module "config" {
+  for_each = local.components
+  source   = "./config"
+  name     = each.key
+}
+
+module "latest" {
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = "${var.target_repository}-${each.key}"
+  config            = module.config[each.key].config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source  = "./tests"
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+}

--- a/images/sigstore-scaffolding/tests/main.tf
+++ b/images/sigstore-scaffolding/tests/main.tf
@@ -1,0 +1,19 @@
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    cloudsqlproxy        = string
+    ctlog-createctconfig = string
+    ctlog-managectroots  = string
+    ctlog-verifyfulcio   = string
+    fulcio-createcerts   = string
+    getoidctoken         = string
+    rekor-createsecret   = string
+    trillian-createdb    = string
+    trillian-createtree  = string
+    trillian-updatetree  = string
+    tsa-createcertchain  = string
+    tuf-createsecret     = string
+  })
+}
+
+# TODO: Add testing for these once we are able to stand up all of sigstore.

--- a/main.tf
+++ b/main.tf
@@ -818,6 +818,11 @@ module "semgrep" {
   target_repository = "${var.target_repository}/semgrep"
 }
 
+module "sigstore-scaffolding" {
+  source            = "./images/sigstore-scaffolding"
+  target_repository = "${var.target_repository}/sigstore-scaffolding"
+}
+
 module "skaffold" {
   source            = "./images/skaffold"
   target_repository = "${var.target_repository}/skaffold"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

These are supporting images for standing up Sigstore components, there isn't really a Helm chart that can be used for these in a meaningful way, but once these land we will use these to test the other main application images and replace our reliance on the upstream images 🤞 

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
