### PR TITLE
unpin pulumi from py3.11

### DIFF
--- a/images/pulumi/configs/latest.apko.yaml
+++ b/images/pulumi/configs/latest.apko.yaml
@@ -15,9 +15,9 @@ contents:
     - aspnet-7-targeting-pack
     # for Pulumi Python support
     - pulumi-language-python
-    - python-3.11
-    - py3.11-pip
-    - python-3.11-dev
+    - python3
+    - python3-dev
+    - py3-pip
     # for Pulumi Node.js support
     - pulumi-language-nodejs
     - nodejs


### PR DESCRIPTION
This image references python 3.11 specifically, which is currently python3, but which will this week become 3.12.

This unpins the image to let it be built with 3.12 when it becomes the latest.