### PR TITLE
Add `{jre,jdk}-lts` repos.

### DIFF
--- a/images/jdk-lts/README.md
+++ b/images/jdk-lts/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# jdk-lts
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/jdk-lts` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/jdk-lts/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/jdk-lts/main.tf
+++ b/images/jdk-lts/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" {
+  source         = "../jdk/config"
+  extra_packages = ["default-jdk-lts"]
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "../jdk/tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/jre-lts/README.md
+++ b/images/jre-lts/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# jre-lts
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/jre-lts` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/jre-lts/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/jre-lts/main.tf
+++ b/images/jre-lts/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" {
+  source         = "../jre/config"
+  extra_packages = ["default-jvm-lts"]
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "../jre/tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/main.tf
+++ b/main.tf
@@ -401,6 +401,11 @@ module "jdk" {
   target_repository = "${var.target_repository}/jdk"
 }
 
+module "jdk-lts" {
+  source            = "./images/jdk-lts"
+  target_repository = "${var.target_repository}/jdk-lts"
+}
+
 module "jenkins" {
   source            = "./images/jenkins"
   target_repository = "${var.target_repository}/jenkins"
@@ -409,6 +414,11 @@ module "jenkins" {
 module "jre" {
   source            = "./images/jre"
   target_repository = "${var.target_repository}/jre"
+}
+
+module "jre-lts" {
+  source            = "./images/jre-lts"
+  target_repository = "${var.target_repository}/jre-lts"
 }
 
 module "k3s" {


### PR DESCRIPTION
This is a precursor to switching `{jre,ldk}:latest` to track non-LTS after Java 21 (which is both!).
