### PR TITLE
fix: add mount package to aws-ebs-csi-driver

### DIFF
--- a/images/aws-ebs-csi-driver/config/main.tf
+++ b/images/aws-ebs-csi-driver/config/main.tf
@@ -9,7 +9,7 @@ module "accts" { source = "../../../tflib/accts" }
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(var.extra_packages, ["umount"])
+      packages = concat(var.extra_packages, ["umount", "mount"])
     }
     accounts = module.accts.block
     entrypoint = {


### PR DESCRIPTION
follow-up to #1527 