### PR TITLE
add additional tags for calico's copy of node-driver-registrar

### DIFF
--- a/images/calico/main.tf
+++ b/images/calico/main.tf
@@ -73,6 +73,9 @@ module "tagger" {
   tags = merge(
     { for t in toset(concat(["latest"], module.version-tags[each.key].tag_list)) : t => module.latest[each.key].image_ref },
 
+    # NOTE: Ensure the calico copy of kubernetes-csi-node-driver-registrar is tagged with the same tags as the upstream calico version.
+    { for t in toset(concat(["latest"], module.version-tags["node"].tag_list)) : t => module.latest["node-driver-registrar"].image_ref if each.key == "node-driver-registrar" },
+
     # This will also tag the image with :v1, :v1.2, :v1.2.3, :v1.2.3-r4, for compatibility with Tigera Operator to install Calico.
     # TODO(jason): Do this for all images, not just calico, and potentially only for `:v1.2.3` and `:v1.2.3-r4` (not `:v1` or `:v1.2`).
     { for t in module.version-tags[each.key].tag_list : "v${t}" => module.latest[each.key].image_ref },


### PR DESCRIPTION
In the absence of digests, the default behavior is to reference `calico-node-driver-registrar` by the calico version, not the version we publish based on `kubernetes-csi-node-driver-registrar-2.9`).

This adds additional tags to calico's copy:

```
➜ crane ls k3d-k3d.localhost:5005/cgg/calico-node-driver-registrar
3.26.1-r15
latest
2.9.0-r2
2.9.0
3
3.26
3.26.1
2.9
2
v2
v2.9.0
v2.9.0-r2
v2.9
```

