### PR TITLE
prometheus-node-exporter test: correct settings in #1525 

### DIFF
--- a/images/prometheus-node-exporter/tests/main.tf
+++ b/images/prometheus-node-exporter/tests/main.tf
@@ -35,11 +35,12 @@ resource "helm_release" "kube-prometheus-stack" {
 
   values = [
     jsonencode({
-      service = {
-        port       = random_integer.port.result
-        targetPort = random_integer.port.result
-      }
       prometheus-node-exporter = {
+        service = {
+          port       = random_integer.port.result
+          nodePort   = random_integer.port.result
+          targetPort = random_integer.port.result
+        }
         image = {
           registry   = data.oci_string.ref.registry
           repository = data.oci_string.ref.repo
@@ -55,6 +56,10 @@ data "oci_exec_test" "node-runs" {
   digest      = var.digest
   script      = "./node-runs.sh ${random_id.hex.hex}"
   working_dir = path.module
+  env = [{
+    name  = "PROM_PORT"
+    value = random_integer.port.result
+  }]
 }
 
 module "helm_cleanup" {

--- a/images/prometheus-node-exporter/tests/node-runs.sh
+++ b/images/prometheus-node-exporter/tests/node-runs.sh
@@ -6,7 +6,7 @@ RAND_HEX=${1:-abcdef}
 
 kubectl wait --for=condition=Ready pods -n prometheus-${RAND_HEX} -l app.kubernetes.io/instance=prometheus-${RAND_HEX} --timeout=120s
 
-kubectl port-forward -n prometheus-${RAND_HEX} service/prometheus-${RAND_HEX}-prometheus-node-exporter ${FREE_PORT}:9100 &
+kubectl port-forward -n prometheus-${RAND_HEX} service/prometheus-${RAND_HEX}-prometheus-node-exporter ${FREE_PORT}:$PROM_PORT &
 pid=$!
 trap "kill $pid" EXIT
 sleep 5


### PR DESCRIPTION
Correct settings in #1525, also update the script to use the random port.

Confirmed locally 
```
❯ k get daemonsets.apps -n prometheus-3dbf92fd prometheus-3dbf92fd-prometheus-node-exporter -o yaml | grep -i port             
    app.kubernetes.io/name: prometheus-node-exporter
    app.kubernetes.io/part-of: prometheus-node-exporter
    helm.sh/chart: prometheus-node-exporter-4.23.1
    jobLabel: node-exporter
  name: prometheus-3dbf92fd-prometheus-node-exporter
      app.kubernetes.io/name: prometheus-node-exporter
        app.kubernetes.io/name: prometheus-node-exporter
        app.kubernetes.io/part-of: prometheus-node-exporter
        helm.sh/chart: prometheus-node-exporter-4.23.1
        jobLabel: node-exporter
        image: ttl.sh/tcnghia/images/prometheus-node-exporter:v1.6.1@sha256:65ddf4fc9b3b6466e928b429879b2a6b94d3a8efe37f5fd036adca954794c6ad
            port: 58542
        name: node-exporter
        ports:
        - containerPort: 58542
          hostPort: 58542
            port: 58542
      serviceAccount: prometheus-3dbf92fd-prometheus-node-exporter
      serviceAccountName: prometheus-3dbf92fd-prometheus-node-exporter
```