### PR TITLE
fix dask-gateway repo names

### DIFF
--- a/images/dask-gateway/main.tf
+++ b/images/dask-gateway/main.tf
@@ -4,13 +4,20 @@ variable "target_repository" {
 
 locals {
   components = toset(["dask-gateway", "dask-gateway-server"])
+
+  // target_repository is going to be something like `cgr.dev/chainguard/dask-gateway`,
+  // so append this suffix to get the full repo name.
+  repositories = {
+    "dask-gateway" : var.target_repository,
+    "dask-gateway-server" : "${var.target_repository}-server",
+  }
 }
 
 module "latest" {
   for_each          = local.components
   source            = "../../tflib/publisher"
   name              = basename(path.module)
-  target_repository = "${var.target_repository}-${each.key}"
+  target_repository = local.repositories[each.key]
   config            = file("${path.module}/configs/latest.${each.key}.apko.yaml")
   build-dev         = true
 }


### PR DESCRIPTION
This has been publishing to `cgr.dev/chainguard/dask-gateway-dask-gateway` and `cgr.dev/chainguard/dask-gateway-dask-gateway-server`, because the `target_repository` input is usually `cgr.dev/chainguard/dask-gateway`.

This accounts for the existing `dask-gateway` and appends either `""` or `"-server"`, so we'll get repo names like `cgr.dev/chainguard/dask-gateway` and `cgr.dev/chainguard/dask-gateway-server`.

After this we can withdraw the existing repos.

Request logs indicate the vast majority of traffic to these repos has been our own image building/moving infrastructure, and that no authenticated users have pulled it. There have been a total of 270 unauthenticated pulls from the two repos combined in the last 90 days.