### PR TITLE
istio images tests: use more robust splitting logic

### DIFF
--- a/images/istio/tests/main.tf
+++ b/images/istio/tests/main.tf
@@ -100,12 +100,12 @@ resource "helm_release" "istiod" {
       # If the registry_repo is gcr.io/my/repo/istio-proxy, we need to set
       #   hub   = gcr.io/my/repo
       #   image = istio-proxy
-      hub = replace(data.oci_string.proxy-ref.registry_repo, "//[^/]*$/", "")
+      hub = dirname(data.oci_string.proxy-ref.registry_repo)
       proxy = {
-        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
+        image = basename(data.oci_string.proxy-ref.registry_repo)
       }
       proxy-init = {
-        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
+        image = basename(data.oci_string.proxy-ref.registry_repo)
       }
       tag = data.oci_string.proxy-ref.pseudo_tag
     }
@@ -136,12 +136,12 @@ resource "helm_release" "gateway" {
       # If the registry_repo is gcr.io/my/repo/istio-proxy, we need to set
       #   hub   = gcr.io/my/repo
       #   image = istio-proxy
-      hub = replace(data.oci_string.proxy-ref.registry_repo, "//[^/]*$/", "")
+      hub = dirname(data.oci_string.proxy-ref.registry_repo)
       proxy = {
-        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
+        image = basename(data.oci_string.proxy-ref.registry_repo)
       }
       proxy-init = {
-        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
+        image = basename(data.oci_string.proxy-ref.registry_repo)
       }
       tag = data.oci_string.proxy-ref.pseudo_tag
     }
@@ -161,11 +161,11 @@ resource "helm_release" "install-cni" {
       # If the registry_repo is gcr.io/my/repo/istio-install-cni, we need to set
       #   hub   = gcr.io/my/repo
       #   image = istio-install-cni
-      hub = replace(data.oci_string.install-cni-ref.registry_repo, "//[^/]*$/", "")
+      hub = dirname(data.oci_string.install-cni-ref.registry_repo)
       tag = data.oci_string.install-cni-ref.pseudo_tag
     }
     cni = {
-      image = replace(data.oci_string.install-cni-ref.registry_repo, "/^.*//", "")
+      image = basename(data.oci_string.install-cni-ref.registry_repo)
 
       # These two settings are highly dependent on the K8s cluster setup.
       cniBinDir  = "/var/lib/rancher/k3s/data/current/bin" # Special thanks to Wolf

--- a/images/istio/tests/main.tf
+++ b/images/istio/tests/main.tf
@@ -37,7 +37,6 @@ data "oci_exec_test" "operator-version" {
 data "oci_string" "operator-ref" { input = var.digests.operator }
 data "oci_string" "proxy-ref" { input = var.digests.proxy }
 data "oci_string" "install-cni-ref" { input = var.digests.install-cni }
-
 resource "helm_release" "operator" {
   name             = "operator"
   namespace        = local.namespace
@@ -96,16 +95,19 @@ resource "helm_release" "istiod" {
     }
     global = {
       istioNamespace = local.namespace
-      # We have to trim the suffix and specify it in `image`, because this
-      # Helm chart does not like slashes in the image name.
-      hub = replace(data.oci_string.proxy-ref.registry_repo, "/istio-proxy", "")
-      tag = data.oci_string.proxy-ref.pseudo_tag
+      # These Helm charts do not like slashes in the image name.
+      #
+      # If the registry_repo is gcr.io/my/repo/istio-proxy, we need to set
+      #   hub   = gcr.io/my/repo
+      #   image = istio-proxy
+      hub = replace(data.oci_string.proxy-ref.registry_repo, "//[^/]*$/", "")
       proxy = {
-        image = "istio-proxy"
+        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
       }
       proxy-init = {
-        image = "istio_proxy"
+        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
       }
+      tag = data.oci_string.proxy-ref.pseudo_tag
     }
   })]
 }
@@ -129,16 +131,19 @@ resource "helm_release" "gateway" {
     }
     global = {
       istioNamespace = local.namespace
-      # We have to trim the suffix and specify it in `image`, because this
-      # Helm chart does not like slashes in the image name.
-      hub = replace(data.oci_string.proxy-ref.registry_repo, "/istio-proxy", "")
-      tag = data.oci_string.proxy-ref.pseudo_tag
+      # These Helm charts do not like slashes in the image param.
+      #
+      # If the registry_repo is gcr.io/my/repo/istio-proxy, we need to set
+      #   hub   = gcr.io/my/repo
+      #   image = istio-proxy
+      hub = replace(data.oci_string.proxy-ref.registry_repo, "//[^/]*$/", "")
       proxy = {
-        image = "istio-proxy"
+        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
       }
       proxy-init = {
-        image = "istio_proxy"
+        image = replace(data.oci_string.proxy-ref.registry_repo, "/^.*//", "")
       }
+      tag = data.oci_string.proxy-ref.pseudo_tag
     }
   })]
 }
@@ -151,13 +156,16 @@ resource "helm_release" "install-cni" {
   chart      = "cni"
   values = [jsonencode({
     global = {
-      # We have to trim the suffix and specify it in `image`, because this
-      # Helm chart does not like slashes in the image name.
-      hub = replace(data.oci_string.install-cni-ref.registry_repo, "/istio-install-cni", "")
+      # These Helm charts do not like slashes in the image param.
+      #
+      # If the registry_repo is gcr.io/my/repo/istio-install-cni, we need to set
+      #   hub   = gcr.io/my/repo
+      #   image = istio-install-cni
+      hub = replace(data.oci_string.install-cni-ref.registry_repo, "//[^/]*$/", "")
       tag = data.oci_string.install-cni-ref.pseudo_tag
     }
     cni = {
-      image = "istio-install-cni"
+      image = replace(data.oci_string.install-cni-ref.registry_repo, "/^.*//", "")
 
       # These two settings are highly dependent on the K8s cluster setup.
       cniBinDir  = "/var/lib/rancher/k3s/data/current/bin" # Special thanks to Wolf


### PR DESCRIPTION
The current splitting logic assumes the last part of the repository is named `istio-proxy` or `istio-install-cni`. This removes such assumption so this test can be reused better.