### PR TITLE
feat: bump terraform-oci-provider to v0.0.10

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     oci = {
       source  = "chainguard-dev/oci"
-      version = "0.0.9"
+      version = "0.0.10"
     }
   }
 }


### PR DESCRIPTION
Bump version of `terraform-oci-provider` to `v0.0.10` to pick up latest fixes.