### PR TITLE
withdraw dask-gateway-dask-gateway(-server)

### DIFF
--- a/withdrawn-repos.txt
+++ b/withdrawn-repos.txt
@@ -1,3 +1,6 @@
 nri-kube-events
 nri-kubernetes
 nri-prometheus
+
+dask-gateway-dask-gateway
+dask-gateway-dask-gateway-server


### PR DESCRIPTION
These images were erroneously pushed to these repos, fixed in https://github.com/chainguard-images/images/pull/1534 to push to `cgr.dev/chainguard/dask-gateway(-server)`.

These images have gotten almost no pulls since being pushed, and all pulls were unauthenticated so we can't notify anybody that it's moved. Given the fairly obvious fact that this repo name is wrong, I suspect nobody relies on this in prod.