### PR TITLE
add Caddy image

### DIFF
--- a/images/caddy/README.md
+++ b/images/caddy/README.md
@@ -1,0 +1,75 @@
+<!--monopod:start-->
+# caddy
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/caddy` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/caddy/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+A minimal caddy base image rebuilt every night from source.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/caddy:latest
+```
+
+## Usage
+
+To try out the image, run:
+
+```
+docker run -p 80:80 -p 443:443 cgr.dev/chainguard/caddy
+```
+
+If you navigate to `localhost`, you should see the caddy welcome page.
+
+To run an example Hello World app, navigate to the root of this repo and run:
+
+```
+docker run -v $(pwd)/examples/hello-world/site-content:/usr/share/caddy/html -p 80:80 -p 443:443 cgr.dev/chainguard/caddy
+```
+
+If you navigate to `localhost`, you should see `Hello World from Caddy!`.
+
+To use a custom `caddy.conf` you can mount the file into the container, being sure to edit the published port(s) to match your configuration, if necessary:
+
+```
+docker run -v $(pwd)/$CUSTOM_CADDY_CONF_DIRECTORY/Caddyfile:/etc/caddy/Caddyfile -p 80:80 -p 443:443 cgr.dev/chainguard/caddy
+```
+
+## Run in a read-only File System
+
+If you want to run with read-only filesystem, you will need to mount the `/var/run` and
+`/var/lib/caddy/tmp` directories. The easiest way to do this is with `--tmpfs` e.g:
+
+```
+docker run \
+  --read-only \
+  --tmpfs /var/lib/caddy/tmp/ --tmpfs /var/run/ \
+  --cap-drop=ALL \
+  --cap-add NET_BIND_SERVICE \
+  -p 80:80
+  -p 443:443 \
+  cgr.dev/chainguard/caddy
+```
+
+## Differences to [Docker Official Image](https://hub.docker.com/_/caddy)
+
+Where possible, the image tries to stay close to Docker official image configuration. However our
+image strives for minimalism and the default image does not include a shell or package manager,
+meaning it isn't possible to achieve an identical configuration. In this section we outline the
+major differences.
+
+### Default port
+
+To support the change to an unprivileged user, the default port was moved to 8080, contrasting with
+port 80 used by the official image.

--- a/images/caddy/config/main.tf
+++ b/images/caddy/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = ["caddy", "ca-certificates", "libcap", "mailcap"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/caddy/config/template.apko.yaml
+++ b/images/caddy/config/template.apko.yaml
@@ -1,0 +1,50 @@
+contents:
+  packages:
+  
+
+accounts:
+  groups:
+    - groupname: caddy
+      gid: 65532
+  users:
+    - username: caddy
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  XDG_CONFIG_HOME: /config
+  XDG_DATA_HOME: /data
+
+paths:
+  - path: /usr/share/caddy
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /config
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /config
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+entrypoint:
+  command: /usr/bin/caddy
+
+cmd: run --config /etc/caddy/Caddyfile
+
+stop-signal: SIGQINT

--- a/images/caddy/examples/hello-world/index.html
+++ b/images/caddy/examples/hello-world/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Caddy</title>
+</head>
+<body>
+  <h2>Hello World from Caddy!</h2>
+</body>
+</html>

--- a/images/caddy/main.tf
+++ b/images/caddy/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" {
+  source         = "./config"
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/caddy/tests/02-welcome-page.sh
+++ b/images/caddy/tests/02-welcome-page.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+CONTAINER_NAME=${CONTAINER_NAME:-"caddy-smoketest-${FREE_PORT}"}
+
+docker run -p "${FREE_PORT}:443" -d --name $CONTAINER_NAME $IMAGE_NAME
+trap "docker logs $CONTAINER_NAME && docker rm -f $CONTAINER_NAME" EXIT
+sleep 5
+
+curl -v --insecure --max-time 10 https://localhost:${FREE_PORT}/ | grep '<title>Welcome to Caddy!</title>' || \
+    curl -v --max-time 10 http://localhost/ | grep '<title>Welcome to Caddy!</title>'

--- a/images/caddy/tests/03-shutdown.sh
+++ b/images/caddy/tests/03-shutdown.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# We want nginx to shutdown gracefully. It should get the SIGQUIT signal.
+LOGFILE=$(mktemp)
+ID=$(docker run --rm -d $IMAGE_NAME)
+docker attach $ID 2> $LOGFILE &
+sleep 5
+docker stop $ID
+grep "SIGQUIT" $LOGFILE
+grep "gracefully shutting down" $LOGFILE

--- a/images/caddy/tests/main.tf
+++ b/images/caddy/tests/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm --entrypoint /usr/bin/caddy $IMAGE_NAME version"
+}
+
+data "oci_exec_test" "welcome-page" {
+  digest = var.digest
+  script = "${path.module}/02-welcome-page.sh"
+}
+
+data "oci_exec_test" "shutdown" {
+  digest = var.digest
+  script = "${path.module}/03-shutdown.sh"
+}

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,11 @@ module "busybox" {
   }
 }
 
+module "caddy" {
+  source            = "./images/caddy"
+  target_repository = "${var.target_repository}/caddy"
+}
+
 module "cadvisor" {
   source            = "./images/cadvisor"
   target_repository = "${var.target_repository}/cadvisor"


### PR DESCRIPTION
This is the basis for a Caddy image. There are still some pieces to iron out. I'm still learning how to navigate the ecosystem of chainguard images (e.g. apko, melange, etc.).

One thing I'd like your help on is the k8s-related tests. I'm not familiar with k8s (besides its name and its function), so I'm not sure how to execute its validations. 

## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/caddy)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
