### PR TITLE
Move prometheus-mongodb-exporter to its own folder

### DIFF
--- a/images/prometheus-mongodb-exporter/README.md
+++ b/images/prometheus-mongodb-exporter/README.md
@@ -1,0 +1,36 @@
+<!--monopod:start-->
+# prometheus-mongodb-exporter
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/prometheus-mongodb-exporter` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-mongodb-exporter/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimalist Wolfi-based Prometheus MongoDB Exporter image for exporting various metrics about MongoDB.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/prometheus-mongodb-exporter:latest
+```
+
+## Usage
+
+The easiest way to install the Prometheus MongoDB Exporter is to use the Helm chart.
+
+```bash
+$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+$ helm repo update
+$ helm install prom-mongodb-exporter prometheus-community/prometheus-mongodb-exporter \
+ --set image.repository=cgr.dev/chainguard/prometheus-mongodb-exporter --set image.tag=latest
+```
+
+For more detail, please refer to the [MongoDB Exporter documentation](https://github.com/percona/mongodb_exporter).

--- a/images/prometheus-mongodb-exporter/config/latest.apko.yaml
+++ b/images/prometheus-mongodb-exporter/config/latest.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - prometheus-mongodb-exporter
 
 accounts:
   groups:

--- a/images/prometheus-mongodb-exporter/config/main.tf
+++ b/images/prometheus-mongodb-exporter/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  default = ["prometheus-mongodb-exporter"]
+  default     = ["prometheus-mongodb-exporter"]
 }
 
 data "apko_config" "this" {

--- a/images/prometheus-mongodb-exporter/config/main.tf
+++ b/images/prometheus-mongodb-exporter/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = ["prometheus-mongodb-exporter"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/latest.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/prometheus-mongodb-exporter/main.tf
+++ b/images/prometheus-mongodb-exporter/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/prometheus-mongodb-exporter/tests/main.tf
+++ b/images/prometheus-mongodb-exporter/tests/main.tf
@@ -31,3 +31,8 @@ resource "helm_release" "test" {
     }
   })]
 }
+
+module "helm_cleanup" {
+  source = "../../../tflib/helm-cleanup"
+  name   = helm_release.test.id
+}

--- a/images/prometheus-mongodb-exporter/tests/main.tf
+++ b/images/prometheus-mongodb-exporter/tests/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME --version"
+}
+
+data "oci_string" "ref" {
+  input = var.digest
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "test" {
+  name       = "prometheus-mongodb-exporter-${random_pet.suffix.id}"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus-mongodb-exporter"
+
+  values = [jsonencode({
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = data.oci_string.ref.pseudo_tag
+    }
+  })]
+}

--- a/images/prometheus/main.tf
+++ b/images/prometheus/main.tf
@@ -3,7 +3,6 @@ locals {
     "alertmanager",
     "config-reloader",
     "core",
-    "mongodb-exporter",
     "mysqld-exporter",
     "operator",
     "postgres-exporter",

--- a/images/prometheus/tests/main.tf
+++ b/images/prometheus/tests/main.tf
@@ -11,7 +11,6 @@ variable "digests" {
     alertmanager      = string
     core              = string
     config-reloader   = string
-    mongodb-exporter  = string
     mysqld-exporter   = string
     operator          = string
     postgres-exporter = string
@@ -136,24 +135,6 @@ resource "helm_release" "pushgateway" {
   set {
     name  = "image.tag"
     value = data.oci_string.ref["pushgateway"].pseudo_tag
-  }
-}
-
-resource "helm_release" "mongodb" {
-  name       = "mongodb-${random_pet.suffix.id}"
-  repository = "https://prometheus-community.github.io/helm-charts"
-  chart      = "prometheus-mongodb-exporter"
-
-  namespace        = "prometheus-mongodb-exporter"
-  create_namespace = true
-
-  set {
-    name  = "image.repository"
-    value = data.oci_string.ref["mongodb-exporter"].registry_repo
-  }
-  set {
-    name  = "image.tag"
-    value = data.oci_string.ref["mongodb-exporter"].pseudo_tag
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -767,6 +767,11 @@ module "prometheus-elasticsearch-exporter" {
   target_repository = "${var.target_repository}/prometheus-elasticsearch-exporter"
 }
 
+module "prometheus-mongodb-exporter" {
+  source            = "./images/prometheus-mongodb-exporter"
+  target_repository = "${var.target_repository}/prometheus-mongodb-exporter"
+}
+
 module "prometheus-node-exporter" {
   source            = "./images/prometheus-node-exporter"
   target_repository = "${var.target_repository}/prometheus-node-exporter"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

Moves `prometheus-mongodb-exporter` from the `prometheus` folder to its own folder, following the pattern in [this PR](https://github.com/chainguard-images/images/pull/1413). Added Helm chart test and README.

## No checklist
This is a refactoring change.