### PR TITLE
Add a `node-lts` repository.

### DIFF
--- a/images/node-lts/README.md
+++ b/images/node-lts/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# node-lts
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/node-lts` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/node-lts/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/node-lts/main.tf
+++ b/images/node-lts/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" {
+  source         = "../node/config"
+  extra_packages = ["nodejs-lts"]
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  extra_dev_packages = [
+    "yarn",
+    "build-base",
+    "python-3.11",
+  ]
+}
+
+module "test-latest" {
+  source = "../node/tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/main.tf
+++ b/main.tf
@@ -677,6 +677,11 @@ module "node" {
   target_repository = "${var.target_repository}/node"
 }
 
+module "node-lts" {
+  source            = "./images/node-lts"
+  target_repository = "${var.target_repository}/node-lts"
+}
+
 module "nodetaint" {
   source            = "./images/nodetaint"
   target_repository = "${var.target_repository}/nodetaint"


### PR DESCRIPTION
This tracks what was done previously for JRE/JDK