### PR TITLE
This corrects the suffix placement for several images.

### DIFF
--- a/images/ctlog/config/main.tf
+++ b/images/ctlog/config/main.tf
@@ -18,7 +18,7 @@ module "accts" { source = "../../../tflib/accts" }
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["certificate-transparency-${var.name}${var.suffix}"], var.extra_packages)
+      packages = concat(["certificate-transparency${var.suffix}-${var.name}"], var.extra_packages)
     }
     accounts = module.accts.block
     entrypoint = {

--- a/images/rekor/config/main.tf
+++ b/images/rekor/config/main.tf
@@ -18,11 +18,11 @@ module "accts" { source = "../../../tflib/accts" }
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["${var.name}${var.suffix}"], var.extra_packages)
+      packages = concat(["rekor${var.suffix}-${var.name}"], var.extra_packages)
     }
     accounts = module.accts.block
     entrypoint = {
-      command = "/usr/bin/${var.name}"
+      command = "/usr/bin/rekor-${var.name}"
     }
   })
 }

--- a/images/rekor/main.tf
+++ b/images/rekor/main.tf
@@ -15,7 +15,7 @@ locals {
 module "config" {
   for_each = local.components
   source   = "./config"
-  name     = "rekor-${each.key}"
+  name     = each.key
 }
 
 module "latest" {

--- a/images/sigstore-scaffolding/config/main.tf
+++ b/images/sigstore-scaffolding/config/main.tf
@@ -18,7 +18,7 @@ module "accts" { source = "../../../tflib/accts" }
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["sigstore-scaffolding-${var.name}${var.suffix}"], var.extra_packages)
+      packages = concat(["sigstore-scaffolding${var.suffix}-${var.name}"], var.extra_packages)
     }
     accounts = module.accts.block
     entrypoint = {

--- a/images/trillian/config/main.tf
+++ b/images/trillian/config/main.tf
@@ -24,7 +24,7 @@ locals {
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["trillian-${var.name}"], var.extra_packages)
+      packages = concat(["trillian${var.suffix}-${var.name}"], var.extra_packages)
     }
     accounts = module.accts.block
     entrypoint = {


### PR DESCRIPTION
We use the pattern `${{package.name}}-foo` so the suffix comes after the parent package name, but prior to the subcomponent.
