### PR TITLE
add bitnami helm test

### DIFF
--- a/images/kafka/config/template.apko.yaml
+++ b/images/kafka/config/template.apko.yaml
@@ -31,8 +31,13 @@ paths:
     uid: 65532
     gid: 65532
 
+cmd: /opt/bitnami/scripts/kafka/run.sh
 entrypoint:
-  command: /opt/bitnami/scripts/kafka/entrypoint.sh /opt/bitnami/scripts/kafka/run.sh
+  command: /opt/bitnami/scripts/kafka/entrypoint.sh
 
 environment:
+  PATH: /opt/bitnami/common/bin:/opt/bitnami/java/bin:/opt/bitnami/kafka/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   BITNAMI_APP_NAME: kafka
+  JAVA_HOME: /opt/bitnami/java
+  OS_NAME: linux
+

--- a/images/kafka/tests/docker-compose.sh
+++ b/images/kafka/tests/docker-compose.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # This is based on:
-# https://github.com/bitnami/containers/blob/561da6cf36010ee9ff382cc0dabbfc6d5c4ec681/bitnami/kafka/3.5/debian-11/docker-compose.yaml
-
+# https://github.com/bitnami/containers/blob/561da6cf36010ee9ff382cc0dabbfc6d5c4ec681/bitnami/kafka/3.5/debian-11/docker-compose.yml
 set -euxo pipefail
 
 IMAGE_NAME=${IMAGE_NAME:-"bitnami/kafka:3.5"}
@@ -31,7 +30,6 @@ services:
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
       - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
       - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
-      - ALLOW_PLAINTEXT_LISTENER=yes
 volumes:
   kafka_data:
     driver: local

--- a/images/kafka/tests/main.tf
+++ b/images/kafka/tests/main.tf
@@ -13,3 +13,29 @@ data "oci_exec_test" "docker-compose" {
   script      = "./docker-compose.sh"
   working_dir = path.module
 }
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "bitnami" {
+  name             = "kafka-bitnami-${random_pet.suffix.id}"
+  repository       = "oci://registry-1.docker.io/bitnamicharts"
+  chart            = "kafka"
+  namespace        = "kafka-bitnami-${random_pet.suffix.id}"
+  create_namespace = true
+
+  values = [jsonencode({
+    image = {
+      registry   = data.oci_string.ref.registry
+      repository = data.oci_string.ref.repo
+      digest     = data.oci_string.ref.digest
+    }
+  })]
+}
+
+module "helm-cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.bitnami.id
+  namespace = helm_release.bitnami.namespace
+}


### PR DESCRIPTION
This test currently fails with

```
kafka 16:05:25.%2N ERROR ==> The KAFKA_CFG_LISTENERS environment variable does not configure a secure listener. Set the environment variable ALLOW_PLAINTEXT_LISTENER=yes to allow the container to be started with a plaintext listener. This is only recommended for development.
```