### PR TITLE
New image: Keycloak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ plan.out*
 sbom-*.json
 sbom-*.cdx
 *.tar
+
+# macOS
+.DS_Store

--- a/images/keycloak/README.md
+++ b/images/keycloak/README.md
@@ -1,0 +1,95 @@
+<!--monopod:start-->
+# keycloak
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/keycloak` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/keycloak/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimalist Wolfi-based Keycloak image.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/keycloak:latest
+```
+
+## Usage
+
+### Docker
+
+Launch a development instance of Keycloak:
+
+```bash
+docker run --name local-keycloak -p 8080:8080 \
+	-e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=change_me \
+	cgr.dev/chainguard/keycloak:latest \
+	start-dev
+```
+
+The Keycloak UI can be accessed via:
+- [http://localhost:8080/](http://localhost:8080)
+
+To launch a production instance of Keycloak, refer to the examples in the
+[following documentation](https://github.com/keycloak/keycloak/blob/main/docs/guides/server/containers.adoc),
+as this is dependent on environment-specific settings and customizatons.
+
+### Helm
+
+To launch a development instance of keycloak in k8s using the following
+[helm chart](https://github.com/codecentric/helm-charts/blob/master/charts/keycloak/README.md):
+
+```bash
+helm install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
+  --set image.repository=cgr.dev/chainguard/keycloak \
+  --set image.tag=latest \
+  --set "args[0]=start-dev"
+```
+
+Refer to the [keycloak](https://github.com/keycloak/keycloak/blob/main/docs/guides/server/containers.adoc)
+and [helm](https://github.com/codecentric/helm-charts/blob/master/charts/keycloak/README.md)
+documentation for more detail.
+
+### Customizing the image
+
+Keyclock provides a mechanism to configure and customize the image. This process
+is outlined in the [Keycloak image documentation](https://github.com/keycloak/keycloak/blob/main/docs/guides/server/containers.adoc).
+
+There are subtle differences in the executable paths used in the Chainguard
+image. Below is the example copied from the documentation, updated with the
+correct paths:
+
+```bash
+FROM cgr.dev/chainguard/keycloak:latest as builder
+
+# Enable health and metrics support
+ENV KC_HEALTH_ENABLED=true
+ENV KC_METRICS_ENABLED=true
+
+# Configure a database vendor
+ENV KC_DB=postgres
+
+WORKDIR /usr/share/java/keycloak
+# for demonstration purposes only, please make sure to use proper certificates in production instead
+RUN keytool -genkeypair -storepass password -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore conf/server.keystore
+RUN /usr/share/java/keycloak/bin/kc.sh build
+
+FROM cgr.dev/chainguard/keycloak:latest
+COPY --from=builder /usr/share/java/keycloak/ /usr/share/java/keycloak/
+
+# change these values to point to a running postgres instance
+ENV KC_DB=postgres
+ENV KC_DB_URL=<DBURL>
+ENV KC_DB_USERNAME=<DBUSERNAME>
+ENV KC_DB_PASSWORD=<DBPASSWORD>
+ENV KC_HOSTNAME=localhost
+ENTRYPOINT ["/usr/share/java/keycloak/bin/kc.sh"]
+```

--- a/images/keycloak/config/latest.apko.yaml
+++ b/images/keycloak/config/latest.apko.yaml
@@ -2,7 +2,6 @@ contents:
   packages:
     # jdk and keycloak packages passed in via 'extra_packages' in ./main.tf
     - busybox
-    - ca-certificates-bundle
 
 accounts:
   groups:

--- a/images/keycloak/config/latest.apko.yaml
+++ b/images/keycloak/config/latest.apko.yaml
@@ -1,0 +1,26 @@
+contents:
+  packages:
+    # jdk and keycloak packages passed in via 'extra_packages' in ./main.tf
+    - busybox
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+paths:
+  - path: /usr/share/java/keycloak
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
+
+entrypoint:
+  command: /usr/bin/kc.sh

--- a/images/keycloak/config/main.tf
+++ b/images/keycloak/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = ["openjdk-17", "openjdk-17-default-jvm", "keycloak"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/latest.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/keycloak/main.tf
+++ b/images/keycloak/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/keycloak/tests/main.tf
+++ b/images/keycloak/tests/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+# invoking '--help' instead of '--version' due to:
+# - https://github.com/keycloak/keycloak/issues/23783
+data "oci_exec_test" "help" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME --help"
+}
+data "oci_string" "ref" {
+  input = var.digest
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "test" {
+  name       = "keycloak-${random_pet.suffix.id}"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
+  chart      = "keycloak"
+  values = [jsonencode({
+    image = {
+      registry   = ""
+      repository = data.oci_string.ref.registry_repo,
+      digest     = data.oci_string.ref.digest
+    },
+    args = ["start-dev"]
+  })]
+}
+
+module "helm_cleanup" {
+  source = "../../../tflib/helm-cleanup"
+  name   = helm_release.test.id
+}

--- a/images/keycloak/tests/main.tf
+++ b/images/keycloak/tests/main.tf
@@ -30,10 +30,6 @@ resource "helm_release" "test" {
       repository = data.oci_string.ref.registry_repo,
       digest     = data.oci_string.ref.digest
     },
-    // TODO: Temp change to see if it impacts CI
-    diagnosticMode = {
-      enabled = true
-    },
     args = ["start-dev"]
   })]
 }

--- a/images/keycloak/tests/main.tf
+++ b/images/keycloak/tests/main.tf
@@ -30,6 +30,10 @@ resource "helm_release" "test" {
       repository = data.oci_string.ref.registry_repo,
       digest     = data.oci_string.ref.digest
     },
+    // TODO: Temp change to see if it impacts CI
+    diagnosticMode = {
+      enabled = true
+    },
     args = ["start-dev"]
   })]
 }

--- a/main.tf
+++ b/main.tf
@@ -480,6 +480,11 @@ module "keda" {
   target_repository = "${var.target_repository}/keda"
 }
 
+module "keycloak" {
+  source            = "./images/keycloak"
+  target_repository = "${var.target_repository}/keycloak"
+}
+
 module "ko" {
   source            = "./images/ko"
   target_repository = "${var.target_repository}/ko"


### PR DESCRIPTION
Creation of a new image for Keycloak, including some tests.

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [X] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The TRIVY vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:
Trivy scans returning zero vulns. Grype unlike trivy, doesn't currently filter out the false positives from our vuln feed, but once these are filtered out there are zero returned. 

Note, one additional vuln was found when doing package vuln scans (CVE-2023-4586), but wasn't glagged by trivy or grype. We're working to publish an advisory for this. It looks to be an issue in a transitive dependency of Keycloak which doesn't yet have a published fix.

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [X] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [X] Functional tests have been included and the tests are passing.  All tests have been documented in the notes section.

Notes:
Helm test added - spins up container image in a local kind cluster, and will fail the test if the pod does not come up successfully in a ready state, and passing probes. Additional test added to spin up the container via docker and invoke --help options.

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [X] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [X] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
