### PR TITLE
This was applied downstream but not here.

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -39,6 +39,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.presubmit-matrix.outputs.shard-0) }}
     steps:
+      # In some cases, we runs out of disk space during tests, so this hack frees up approx 10G.
+      # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      - name: Free up runner disk space
+        shell: bash
+        run: |
+          set -x
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4 # v3.5.2
       - name: Add additional inputs
         id: augmented-inputs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,14 @@ jobs:
       contents: read
       actions: read
     steps:
+      # In some cases, we runs out of disk space during tests, so this hack frees up approx 10G.
+      # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      - name: Free up runner disk space
+        shell: bash
+        run: |
+          set -x
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4 # v3.5.2
       - id: release-image-inputs
         name: Add additional inputs for release-image action


### PR DESCRIPTION
ref: https://github.com/chainguard-images/images/pull/1570