### PR TITLE
istio test: shell to curl & fix cleanup order

### DIFF
--- a/images/istio/tests/main.tf
+++ b/images/istio/tests/main.tf
@@ -218,7 +218,7 @@ module "helm_cleanup-gateway" {
 }
 
 module "helm_cleanup-istiod" {
-  depends_on = [data.oci_exec_test.sidecar-injection-works]
+  depends_on = [data.oci_exec_test.sidecar-injection-works, data.oci_exec_test.gateway]
   source     = "../../../tflib/helm-cleanup"
   name       = helm_release.istiod.id
   namespace  = helm_release.istiod.namespace

--- a/images/istio/tests/test-gateway.sh
+++ b/images/istio/tests/test-gateway.sh
@@ -19,4 +19,17 @@ EOF
 
 sed "s/ISTIO_NAMESPACE/$ISTIO_NAMESPACE/g" $SCRIPT_DIR/virtualservice.yaml \
   | kubectl apply -f- -n $NAMESPACE
-kubectl wait --for=condition=complete --timeout=60s -n $NAMESPACE job/curl
+
+kubectl port-forward -n $ISTIO_NAMESPACE svc/$ISTIO_NAMESPACE-gateway "${FREE_PORT}:80" &
+pid=$!
+trap "kill -9 $pid" EXIT
+
+set +o errexit
+for i in {1..10}; do
+    curl --retry 10 localhost:$FREE_PORT -H "Host: ingress.test.foo" && s=0 && break
+    s=$?
+    sleep 15
+done
+if [ $s -ne 0 ]; then
+    exit $s
+fi

--- a/images/istio/tests/virtualservice.yaml
+++ b/images/istio/tests/virtualservice.yaml
@@ -25,26 +25,3 @@ spec:
       status: 200
       body:
         string: "Yes it's working\n"
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: curl
-spec:
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      containers:
-      - name: curl
-        image: cgr.dev/chainguard/curl:latest
-        command:
-        - curl
-        - -v
-        - --fail-with-body
-        - -H
-        - "Host:ingress.test.foo"
-        - ISTIO_NAMESPACE-gateway.ISTIO_NAMESPACE.svc
-      restartPolicy: Never
-  backoffLimit: 20


### PR DESCRIPTION
Using a Job to curl on un under-provisioned test cluster may result in little retries. 

Also avoid cleaning up istiod before the gateway test.