### PR TITLE
Drop the extra checkout.

### DIFF
--- a/.github/actions/build-image-terraform/action.yml
+++ b/.github/actions/build-image-terraform/action.yml
@@ -6,15 +6,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - if: inputs.overrideCheckoutRef == '' && inputs.overrideCheckoutRepository == ''
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-    - if: inputs.overrideCheckoutRef != '' || inputs.overrideCheckoutRepository != ''
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-      with:
-        clean: false
-        ref: ${{ inputs.overrideCheckoutRef }}
-        repository: ${{ inputs.overrideCheckoutRepository }}
-
     - name: Setup Terrafrom
       uses: hashicorp/setup-terraform@v2
       with:

--- a/.github/actions/release-image-terraform/action.yml
+++ b/.github/actions/release-image-terraform/action.yml
@@ -23,15 +23,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - if: inputs.overrideCheckoutRef == '' && inputs.overrideCheckoutRepository == ''
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-    - if: inputs.overrideCheckoutRef != '' || inputs.overrideCheckoutRepository != ''
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-      with:
-        clean: false
-        ref: ${{ inputs.overrideCheckoutRef }}
-        repository: ${{ inputs.overrideCheckoutRepository }}
-
     - uses: chainguard-dev/actions/setup-chainctl@main
       with:
         identity: ${{ inputs.chainguardIdentity }}


### PR DESCRIPTION
This action used to be used to build stuff for other repos, and this would check out the code to build things.  Now this action is only used by chainguard-images/images and that already needs to be checked out to load the action definition itself.  So we should be able to safely drop these steps now.
