### PR TITLE
Add the remaining AWS crossplane components as images.

### DIFF
--- a/images/crossplane-aws/main.tf
+++ b/images/crossplane-aws/main.tf
@@ -11,9 +11,19 @@ variable "target_repository" {
 locals {
   components = toset([
     "family",
+    "cloudfront",
+    "cloudwatchlogs",
+    "dynamodb",
+    "ec2",
+    "eks",
+    "firehose",
     "iam",
+    "kms",
+    "lambda",
     "rds",
     "s3",
+    "sns",
+    "sqs",
   ])
 
   // Normally the repository is named like "crossplane-provider-aws-{component}"
@@ -42,8 +52,7 @@ module "latest" {
 }
 
 module "test-latest" {
-  source = "./tests"
-
+  source  = "./tests"
   digests = { for k, v in module.latest : k => v.image_ref }
 }
 

--- a/images/crossplane-aws/tests/install.sh
+++ b/images/crossplane-aws/tests/install.sh
@@ -27,9 +27,97 @@ cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
+  name: provider-aws-cloudfront
+spec:
+  package: ${CLOUDFRONT_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-cloudwatchlogs
+spec:
+  package: ${CLOUDWATCHLOGS_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-dynamodb
+spec:
+  package: ${DYNAMODB_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-ec2
+spec:
+  package: ${EC2_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-eks
+spec:
+  package: ${EKS_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-firehose
+spec:
+  package: ${FIREHOSE_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
   name: provider-aws-iam
 spec:
   package: ${IAM_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-kms
+spec:
+  package: ${KMS_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-lambda
+spec:
+  package: ${LAMBDA_DIGEST}
   packagePullSecrets:
   - name: regcred
 EOF
@@ -56,7 +144,29 @@ spec:
   - name: regcred
 EOF
 
-for provider in iam rds s3; do
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-sns
+spec:
+  package: ${SNS_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-sqs
+spec:
+  package: ${SQS_DIGEST}
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+for provider in cloudfront cloudwatchlogs dynamodb ec2 eks firehose iam kms lambda rds s3 sns sqs ; do
   kubectl wait --for=condition=Installed "provider/provider-aws-${provider}" --timeout=3m
   kubectl wait --for=condition=Healthy   "provider/provider-aws-${provider}" --timeout=5m
 done

--- a/images/crossplane-aws/tests/main.tf
+++ b/images/crossplane-aws/tests/main.tf
@@ -8,10 +8,20 @@ terraform {
 variable "digests" {
   description = "The image digests to run tests over."
   type = object({
-    family = string
-    iam    = string
-    rds    = string
-    s3     = string
+    family         = string
+    cloudfront     = string
+    cloudwatchlogs = string
+    dynamodb       = string
+    ec2            = string
+    eks            = string
+    firehose       = string
+    iam            = string
+    kms            = string
+    lambda         = string
+    rds            = string
+    s3             = string
+    sns            = string
+    sqs            = string
   })
 }
 
@@ -44,21 +54,15 @@ data "oci_exec_test" "install" {
   script = "${path.module}/install.sh"
   digest = var.digests.family // Unused but required by the data source
 
-  env {
-    name  = "AWS_DIGEST"
-    value = var.digests.family
-  }
-  env {
-    name  = "IAM_DIGEST"
-    value = var.digests.iam
-  }
-  env {
-    name  = "RDS_DIGEST"
-    value = var.digests.rds
-  }
-  env {
-    name  = "S3_DIGEST"
-    value = var.digests.s3
+  // We are waiting for a lot of stuff to become ready!
+  timeout_seconds = 600
+
+  dynamic "env" {
+    for_each = var.digests
+    content {
+      name  = env.key == "family" ? "AWS_DIGEST" : "${upper(env.key)}_DIGEST"
+      value = env.value
+    }
   }
 }
 


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
