### PR TITLE
Have `cgr.dev/chainguard/node` track latest non-LTS

### DIFF
--- a/images/node/config/main.tf
+++ b/images/node/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. nodejs, nodejs-lts, nodejs-18)."
-  default     = ["nodejs-lts"]
+  default     = ["nodejs"]
 }
 
 data "apko_config" "this" {


### PR DESCRIPTION
This happens to match the latest LTS once: https://github.com/wolfi-dev/os/pull/6556 lands, which makes the transition easier.

