### PR TITLE
Have `cgr.dev/chainguard/{jre,jdk}` track latest non-LTS

### DIFF
--- a/images/jdk/config/main.tf
+++ b/images/jdk/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. openjdk-17)."
-  default     = ["default-jdk-lts"]
+  default     = ["default-jdk"]
 }
 
 data "apko_config" "this" {

--- a/images/jre/config/main.tf
+++ b/images/jre/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. openjdk-17-default-jvm)."
-  default     = ["default-jvm-lts"]
+  default     = ["default-jvm"]
 }
 
 data "apko_config" "this" {


### PR DESCRIPTION
This happens to match the latest LTS once: wolfi-dev/os#6557 lands, which makes the transition easier.
