### PR TITLE
Bump tf-cosign to v0.0.14

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cosign = {
       source  = "chainguard-dev/cosign"
-      version = "0.0.13"
+      version = "0.0.14"
     }
     apko = {
       source  = "chainguard-dev/apko"


### PR DESCRIPTION
This picks up a performance fix in cosign_attest and a bug fix for duplicate attestations.