### PR TITLE
use chainguard-dev/cosign:0.0.14 as it fixes duplicate attestation

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cosign = {
       source  = "chainguard-dev/cosign"
-      version = "0.0.13"
+      version = "0.0.14"
     }
     apko = {
       source  = "chainguard-dev/apko"


### PR DESCRIPTION
- Related commits here https://github.com/chainguard-dev/terraform-provider-cosign/pull/83
- https://github.com/chainguard-dev/terraform-provider-cosign/pull/82