### PR TITLE
add redis-bitnami

### DIFF
--- a/images/redis-bitnami/README.md
+++ b/images/redis-bitnami/README.md
@@ -1,0 +1,36 @@
+<!--monopod:start-->
+# redis (bitnami)
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/redis-bitnami` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/redis/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Wolfi-based [Redis Bitnami](https://bitnami.com/stack/redis/helm) image. See [here](../redis/README.md) for the Wolfi based official Redis.
+
+These images and variants exist to be a drop in replacement for the Bitnami Redis images, primarily deployed through the helm chart:
+
+```shell
+cat > values.yaml <<EOF
+image:
+  registry: cgr.dev
+  repository: chainguard/redis-bitnami
+  tag: latest
+
+# Enable for HA variant
+sentinel:
+  enabled: true
+  image:
+    registry: cgr.dev
+    repository: chainguard/redis-bitnami-sentinel
+    tag: latest
+EOF
+
+helm install my-release oci://registry-1.docker.io/bitnamicharts/redis -f values.yaml
+```

--- a/images/redis-bitnami/configs/main.tf
+++ b/images/redis-bitnami/configs/main.tf
@@ -1,0 +1,40 @@
+variable "name" {
+  description = "Package name (e.g. redis, redis-cluster, redis-sentinel)"
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  type        = list(string)
+  default     = []
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  # Match upstream bitnami uid/gid
+  uid    = 1001
+  gid    = 1001
+  run-as = 1001
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat([
+        "${var.name}-bitnami-compat",
+      ], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/opt/bitnami/scripts/${var.name}/entrypoint.sh /opt/bitnami/scripts/${var.name}/run.sh"
+    }
+    paths = [
+      {
+        path        = "/opt/bitnami"
+        type        = "directory"
+        permissions = 0755
+        uid         = 1001
+        gid         = 1001
+      }
+    ]
+  })
+}

--- a/images/redis-bitnami/main.tf
+++ b/images/redis-bitnami/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  components = {
+    "server" : {
+      package    = "redis"
+      repository = var.target_repository
+    }
+    "cluster" : {
+      package    = "redis"
+      repository = "${var.target_repository}-cluster"
+    }
+    "sentinel" : {
+      package    = "redis"
+      repository = "${var.target_repository}-sentinel"
+    }
+  }
+}
+
+module "config" {
+  for_each = local.components
+  source   = "./configs"
+  name     = each.value.package
+}
+
+module "latest" {
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = each.value.repository
+  config            = module.config[each.key].config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source  = "./tests"
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each = local.components
+  # depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each = local.components
+  # depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+}

--- a/images/redis-bitnami/tests/main.tf
+++ b/images/redis-bitnami/tests/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    server   = string
+    cluster  = string
+    sentinel = string
+  })
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "bitnami" {
+  name             = "redis${random_pet.suffix.id}"
+  namespace        = "redis-system-${random_pet.suffix.id}"
+  chart            = "oci://registry-1.docker.io/bitnamicharts/redis"
+  create_namespace = true
+  timeout          = 600
+
+  values = [
+    jsonencode({
+      image = {
+        registry   = data.oci_string.ref["server"].registry
+        repository = data.oci_string.ref["server"].repo
+        digest     = data.oci_string.ref["server"].digest
+      }
+
+      sentinel = {
+        enabled = true
+        image = {
+          registry   = data.oci_string.ref["sentinel"].registry
+          repository = data.oci_string.ref["sentinel"].repo
+          digest     = data.oci_string.ref["sentinel"].digest
+        }
+      }
+    })
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -837,6 +837,11 @@ module "redis" {
   target_repository = "${var.target_repository}/redis"
 }
 
+module "redis-bitnami" {
+  source            = "./images/redis-bitnami"
+  target_repository = "${var.target_repository}/redis-bitnami"
+}
+
 module "redis-sentinel" {
   source            = "./images/redis-sentinel"
   target_repository = "${var.target_repository}/redis-sentinel"
@@ -1044,4 +1049,3 @@ module "zot" {
   source            = "./images/zot"
   target_repository = "${var.target_repository}/zot"
 }
-


### PR DESCRIPTION
Adds `redis-bitnami`, `redis-bitnami-sentinel`, and `redis-bitnami-cluster`.

Noteworthy:

- `redis-bitnami-cluster` appears unused in the helm chart, but I'm including it for completeness
- our existing `redis-sentinel` remains untouched. I'm chalking this up to "legacy" and leaving it as is to avoid affecting any existing customers using it. moving forward, we want to replace that with these images.
  - `redis-sentinel` is a simple symlink to `redis-server` that the official `redis` distribution doesn't isolate, but bitnami chooses to use different startup scripts for this, hence the additional image

depends on: https://github.com/wolfi-dev/os/pull/6593