### PR TITLE
dynamic-localpv-provisioner

### DIFF
--- a/images/dynamic-localpv-provisioner/README.md
+++ b/images/dynamic-localpv-provisioner/README.md
@@ -1,0 +1,42 @@
+<!--monopod:start-->
+# dynamic-localpv-provisioner
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/dynamic-localpv-provisioner` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/dynamic-localpv-provisioner/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimal images for dynamic-localpv-provisioner
+
+## Get It
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/dynamic-localpv-provisioner:latest
+```
+
+## Testing
+
+Fortunately, we have a Helm Chart ready-to-use for testing this image. 
+
+You can find it [here](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/deploy/helm/charts/README.md).
+
+Basically, all you need to do is running the commands below to test the application:
+
+```shell
+helm repo add openebs-localpv https://openebs.github.io/dynamic-localpv-provisioner
+helm repo update
+helm install openebs-localpv openebs-localpv/dynamic-localpv-provisioner \
+  --set localpv.image.registry=cgr.dev/ \
+  --set localpv.image.repository=chainguard/dynamic-localpv-provisioner \
+  --set localpv.image.tag=latest
+```
+
+Once you run the commands above, you will end up having the application running on your cluster.

--- a/images/dynamic-localpv-provisioner/config/main.tf
+++ b/images/dynamic-localpv-provisioner/config/main.tf
@@ -1,0 +1,19 @@
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = ["dynamic-localpv-provisioner"]
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/provisioner-localpv"
+    }
+  })
+}

--- a/images/dynamic-localpv-provisioner/main.tf
+++ b/images/dynamic-localpv-provisioner/main.tf
@@ -1,0 +1,37 @@
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "version-tags" {
+  source  = "../../tflib/version-tags"
+  package = "dynamic-localpv-provisioner"
+  config  = module.latest.config
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+module "tagger" {
+  source = "../../tflib/tagger"
+
+  depends_on = [module.test-latest]
+
+  tags = merge(
+    { for t in module.version-tags.tag_list : t => module.latest.image_ref },
+    { for t in module.version-tags.tag_list : "${t}-dev" => module.latest.dev_ref },
+    { "latest" : module.latest.image_ref },
+    { "latest-dev" : module.latest.dev_ref }
+  )
+}

--- a/images/dynamic-localpv-provisioner/tests/main.tf
+++ b/images/dynamic-localpv-provisioner/tests/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "helm_release" "dynamic-localpv-provisioner" {
+  name = "dynamic-localpv-provisioner"
+
+  repository = "https://openebs.github.io/dynamic-localpv-provisioner"
+  chart      = "localpv-provisioner"
+
+  values = [jsonencode({
+    localpv = {
+      image = {
+        registry   = join("", [data.oci_string.ref.registry, "/"])
+        repository = data.oci_string.ref.repo
+        tag        = data.oci_string.ref.pseudo_tag
+      }
+    }
+  })]
+}
+
+module "helm_cleanup" {
+  source = "../../../tflib/helm-cleanup"
+  name   = helm_release.dynamic-localpv-provisioner.id
+}

--- a/main.tf
+++ b/main.tf
@@ -266,6 +266,11 @@ module "dotnet" {
   target_repository = "${var.target_repository}/dotnet"
 }
 
+module "dynamic-localpv-provisioner" {
+  source            = "./images/dynamic-localpv-provisioner"
+  target_repository = "${var.target_repository}/dynamic-localpv-provisioner"
+}
+
 module "envoy" {
   source            = "./images/envoy"
   target_repository = "${var.target_repository}/envoy"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [x] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes: We added bunch of runtime packages this is why the image end up having a little bit bigger size.

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
