### PR TITLE
chore: rename images folder from configs to config

### DIFF
--- a/monopod/pkg/commands/scaffold.go
+++ b/monopod/pkg/commands/scaffold.go
@@ -18,7 +18,7 @@ const (
 	MainConfigTfTemplate = "main-config.tf.tpl"
 	ApkoTemplate         = "template.apko.yaml.tpl"
 
-	ConfigsFolder   = "configs"
+	ConfigFolder    = "config"
 	TestsFolder     = "tests"
 	GeneratedFolder = "generated"
 )
@@ -112,7 +112,7 @@ func (o scaffoldOptions) runScaffold() error {
 	}
 
 	// this file should be written in the configs directory
-	mainConfigTfOutfile, err := o.createOutputFile(filepath.Join(ConfigsFolder, outputMappings[MainConfigTfTemplate]))
+	mainConfigTfOutfile, err := o.createOutputFile(filepath.Join(ConfigFolder, outputMappings[MainConfigTfTemplate]))
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (o scaffoldOptions) runScaffold() error {
 	}
 
 	// this file should be written in the configs directory
-	apkoOutfile, err := o.createOutputFile(filepath.Join(ConfigsFolder, outputMappings[ApkoTemplate]))
+	apkoOutfile, err := o.createOutputFile(filepath.Join(ConfigFolder, outputMappings[ApkoTemplate]))
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (o scaffoldOptions) createOutputFolderStructure() error {
 		return fmt.Errorf("unable to generate target folder %s: %w", path, err)
 	}
 
-	for _, f := range []string{ConfigsFolder, TestsFolder} {
+	for _, f := range []string{ConfigFolder, TestsFolder} {
 		subPath := filepath.Join(path, f)
 		if err := os.MkdirAll(subPath, os.ModePerm); err != nil {
 			return fmt.Errorf("unable to generate target folder %s: %w", subPath, err)


### PR DESCRIPTION
Following the anatomy of the images detailed [here](https://docs.google.com/document/d/14devrKiCxFs3Eqrl9QH2jBgsCONGnXCOC9CxZUudbr8/edit#heading=h.od18w6wsqlib), we decided to rename the `configs` folder to `config` for all the new images created via scaffold command.