### PR TITLE
Avoid a race to create pods to wait on.

### DIFF
--- a/images/keda/tests/smoke-test.sh
+++ b/images/keda/tests/smoke-test.sh
@@ -15,6 +15,9 @@ kubectl apply -f $SCRIPT_DIR/test-deployment.yaml -n default
 
 sleep 5
 
+# Wait for the replicaset to be ready and old pods to terminated
+kubectl rollout status deployment/test-deployment --timeout=120s -n default
+
 kubectl wait --for=condition=ready pod --selector app=test --timeout=120s -n default
 
 # Use the keda autoscaler to scale the test deployment


### PR DESCRIPTION
This is copied from another instance just below in the file, but we missed this one.