### PR TITLE
add redis-bitnami-compat latest images

### DIFF
--- a/images/redis-bitnami/README.md
+++ b/images/redis-bitnami/README.md
@@ -1,0 +1,32 @@
+<!--monopod:start-->
+# redis-bitnami
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/redis-bitnami` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/redis-bitnami/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimalist Wolfi-based [Redis-Bitnami]() image. This is intended to be a drop in replacement for deployments that require Bitnami compatibility. The most common case is the Bitnami Helm chart, which can be deployed as follows:
+
+```bash
+cat <<EOF > values.yaml
+image:
+  registry: cgr.dev
+  repository: chainguard/redis-server-bitnami
+  tag: latest
+# Optinoally enable HA sentinel:
+sentinel:
+  enabled: true
+  image:
+    registry: cgr.dev
+    repository: chainguard/redis-sentinel-bitnami
+    tag: latest
+EOF
+```
+

--- a/images/redis-bitnami/config/main.tf
+++ b/images/redis-bitnami/config/main.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  description = "Package name (e.g. cainjector, acmeresolver, controller, webhook)"
+}
+
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  run-as = 1001
+  uid    = 1001
+  gid    = 1001
+  name   = "redis"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(["${var.name}${var.suffix}-bitnami-compat"], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/opt/bitnami/scripts/${var.name}/entrypoint.sh /opt/bitnami/scripts/${var.name}/run.sh"
+    }
+  })
+}

--- a/images/redis-bitnami/main.tf
+++ b/images/redis-bitnami/main.tf
@@ -1,0 +1,54 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "suffix" {
+  default     = "-7.2"
+  description = "The redis component version suffix."
+}
+
+locals {
+  components = toset(["server", "sentinel", "cluster"])
+}
+
+module "config" {
+  for_each = local.components
+  source   = "./config"
+  name     = each.key == "server" ? "redis" : "redis-${each.key}"
+  suffix   = var.suffix
+}
+
+module "latest" {
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = "${var.target_repository}-${each.key}-bitnami"
+  config            = module.config[each.key].config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source  = "./tests"
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+}

--- a/images/redis-bitnami/tests/main.tf
+++ b/images/redis-bitnami/tests/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    server   = string
+    cluster  = string
+    sentinel = string
+  })
+}
+
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "redis" {
+  name             = "redis-${random_pet.suffix.id}"
+  namespace        = "redis-system-${random_pet.suffix.id}"
+  chart            = "oci://registry-1.docker.io/bitnamicharts/redis"
+  create_namespace = true
+  timeout          = 600
+
+  values = [
+    jsonencode({
+      image = {
+        registry   = data.oci_string.ref["server"].registry
+        repository = data.oci_string.ref["server"].repo
+        digest     = data.oci_string.ref["server"].digest
+      }
+
+      sentinel = {
+        enabled = true
+        image = {
+          registry   = data.oci_string.ref["sentinel"].registry
+          repository = data.oci_string.ref["sentinel"].repo
+          digest     = data.oci_string.ref["sentinel"].digest
+        }
+      }
+    })
+  ]
+}
+
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.redis.id
+  namespace = helm_release.redis.namespace
+}

--- a/main.tf
+++ b/main.tf
@@ -837,6 +837,12 @@ module "redis" {
   target_repository = "${var.target_repository}/redis"
 }
 
+module "redis-bitnami" {
+  source = "./images/redis-bitnami"
+  # -bitnami is added in the module
+  target_repository = "${var.target_repository}/redis"
+}
+
 module "redis-sentinel" {
   source            = "./images/redis-sentinel"
   target_repository = "${var.target_repository}/redis-sentinel"
@@ -1044,4 +1050,3 @@ module "zot" {
   source            = "./images/zot"
   target_repository = "${var.target_repository}/zot"
 }
-


### PR DESCRIPTION
Adds `redis-bitnami`, `redis-bitnami-sentinel`, and `redis-bitnami-cluster`.

Noteworthy:

- `redis-bitnami-cluster` appears unused in the helm chart, but I'm including it for completeness
- our existing `redis-sentinel` remains untouched. I'm chalking this up to "legacy" and leaving it as is to avoid affecting any existing customers using it. moving forward, we want to replace that with these images.
  - `redis-sentinel` is a simple symlink to `redis-server` that the official `redis` distribution doesn't isolate, but bitnami chooses to use different startup scripts for this, hence the additional image

depends on: https://github.com/wolfi-dev/os/pull/6593