### PR TITLE
Bump tf-provider-cosign and tf-publisher-apko

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cosign = {
       source  = "chainguard-dev/cosign"
-      version = "0.0.14"
+      version = "0.0.16"
     }
     apko = {
       source  = "chainguard-dev/apko"
@@ -75,7 +75,7 @@ locals {
 
 module "this" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.8"
+  version = "0.0.9"
 
   target_repository = var.target_repository
   config            = yamlencode(local.updated_config)
@@ -85,7 +85,7 @@ module "this" {
 module "this-dev" {
   count   = local.build-dev ? 1 : 0
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.8"
+  version = "0.0.9"
 
   target_repository = var.target_repository
 


### PR DESCRIPTION
These need to be updated together. This picks up a change in tf-cosign that adds the "conflict" behavior field that allows us to use SKIPSAME in cosign_attest, which means we will no longer re-attest identical things (and run into rekor rate limits). We still re-sign everything, so we have a signal that images are being properly rebuilt, but this will let us go a lot faster.