### PR TITLE
Withdraw stale repos

### DIFF
--- a/withdrawn-repos.txt
+++ b/withdrawn-repos.txt
@@ -1,3 +1,26 @@
 nri-kube-events
 nri-kubernetes
 nri-prometheus
+
+# Renamed to calicoctl
+calico
+# Renamed to calico-pod2daemon-flexvol
+calico-pod2daemon
+# Renamed to dask-gateway
+dask-gateway-dask-gateway
+# Renamed to dask-gateway-server
+dask-gateway-dask-gateway-server
+# Renamed to kubernetes-csi-external-attacher
+external-attacher
+# Renamed to kubernetes-csi-external-resizer
+external-resizer
+# Renamed to flux-helm-controller
+helm-controller
+# Renamed to flux-kustomize-controller
+kustomize-controller
+# Renamed to flux-notification-controller
+notification-controller
+# Renamed to spire-oidc-discovery-provider
+oidc-discovery-provider
+# Renamed to opentofu
+opentf


### PR DESCRIPTION
More documentation in this [Chainguard internal document](https://docs.google.com/document/d/1iXnsaw2mrTa5mc1DxbBZtbrbVNMfpxmJwl7PU9m5DA8/edit).

Withdrawn image | Replacement
-- | --
cgr.dev/chainguard/calico | cgr.dev/chainguard/calicoctl
cgr.dev/chainguard/calico-pod2daemon | cgr.dev/chainguard/calico-pod2daemon-flexvol
cgr.dev/chainguard/dask-gateway-dask-gateway | cgr.dev/chainguard/dask-gateway
cgr.dev/chainguard/dask-gateway-dask-gateway-server | cgr.dev/chainguard/dask-gateway-server
cgr.dev/chainguard/external-attacher | cgr.dev/chainguard/kubernetes-csi-external-attacher
cgr.dev/chainguard/external-resizer | cgr.dev/chainguard/kubernetes-csi-external-resizer
cgr.dev/chainguard/helm-controller | cgr.dev/chainguard/flux-helm-controller
cgr.dev/chainguard/kustomize-controller | cgr.dev/chainguard/flux-kustomize-controller
cgr.dev/chainguard/notification-controller | cgr.dev/chainguard/flux-notification-controller
cgr.dev/chainguard/oidc-discovery-provider | cgr.dev/chainguard/spire-oidc-discovery-provider
cgr.dev/chainguard/opentf | cgr.dev/chainguard/opentofu
cgr.dev/chainguard/source-controller | cgr.dev/chainguard/flux-source-controller


The goal is to merge and withdraw these repositories on October 16, 2023.