### PR TITLE
adding grype image config

### DIFF
--- a/images/grype/README.md
+++ b/images/grype/README.md
@@ -29,7 +29,8 @@ This will automatically pull the image to your local system and execute the comm
 
 ```shell
 docker run --rm cgr.dev/chainguard/grype help
-```
+
+
 A vulnerability scanner for container images, filesystems, and SBOMs.
 
 Supports the following image sources:
@@ -53,3 +54,4 @@ You can also pipe in Syft JSON directly:
 
 Usage:
   grype [command]
+```

--- a/images/grype/README.md
+++ b/images/grype/README.md
@@ -24,11 +24,11 @@ Our `latest` tag uses the most recent build of the [Wolfi grype](https://github.
 
 - `latest`: This is an image for running `grype` commands. It does not include a shell or other applications.
 
-### grype Version
-This will automatically pull the image to your local system and execute the command `grype version`:
+### grype help
+This will automatically pull the image to your local system and execute the command `grype help`:
 
 ```shell
-docker run --rm cgr.dev/chainguard/grype version
+docker run --rm cgr.dev/chainguard/grype help
 ```
 A vulnerability scanner for container images, filesystems, and SBOMs.
 

--- a/images/grype/README.md
+++ b/images/grype/README.md
@@ -1,0 +1,55 @@
+<!--monopod:start-->
+# grype
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/grype` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/grype/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimalist Wolfi-based grype images for signing and verifying images using Sigstore.
+
+- [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/grype)
+- [Provenance Information](https://edu.chainguard.dev/chainguard/chainguard-images/reference/grype/provenance_info/)
+<!-- TODO: add Getting Started Guide - [Getting Started Guide](https://edu.chainguard.dev/chainguard/chainguard-images/reference/grype/getting-started-grype/) -->
+
+## Image Variants
+
+Our `latest` tag uses the most recent build of the [Wolfi grype](https://github.com/wolfi-dev/os/blob/main/grype.yaml) package. The following tagged variant is available without authentication:
+
+- `latest`: This is an image for running `grype` commands. It does not include a shell or other applications.
+
+### grype Version
+This will automatically pull the image to your local system and execute the command `grype version`:
+
+```shell
+docker run --rm cgr.dev/chainguard/grype version
+```
+A vulnerability scanner for container images, filesystems, and SBOMs.
+
+Supports the following image sources:
+    grype yourrepo/yourimage:tag             defaults to using images from a Docker daemon
+    grype path/to/yourproject                a Docker tar, OCI tar, OCI directory, SIF container, or generic filesystem directory
+
+You can also explicitly specify the scheme to use:
+    grype podman:yourrepo/yourimage:tag          explicitly use the Podman daemon
+    grype docker:yourrepo/yourimage:tag          explicitly use the Docker daemon
+    grype docker-archive:path/to/yourimage.tar   use a tarball from disk for archives created from "docker save"
+    grype oci-archive:path/to/yourimage.tar      use a tarball from disk for OCI archives (from Podman or otherwise)
+    grype oci-dir:path/to/yourimage              read directly from a path on disk for OCI layout directories (from Skopeo or otherwise)
+    grype singularity:path/to/yourimage.sif      read directly from a Singularity Image Format (SIF) container on disk
+    grype dir:path/to/yourproject                read directly from a path on disk (any directory)
+    grype sbom:path/to/syft.json                 read Syft JSON from path on disk
+    grype registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
+    grype purl:path/to/purl/file                 read a newline separated file of purls from a path on disk
+
+You can also pipe in Syft JSON directly:
+	syft yourimage:tag -o json | grype
+
+Usage:
+  grype [command]

--- a/images/grype/config/main.tf
+++ b/images/grype/config/main.tf
@@ -1,0 +1,21 @@
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. grype)."
+  default     = ["grype"]
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      # From the upstream .ko.yaml
+      # We need a shell for a lot of redirection/piping to work
+      packages = concat(["busybox"], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/grype"
+    }
+    cmd = "help"
+  })
+}

--- a/images/grype/main.tf
+++ b/images/grype/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/grype/tests/main.tf
+++ b/images/grype/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME help"
+}

--- a/main.tf
+++ b/main.tf
@@ -375,6 +375,11 @@ module "gradle" {
   target_repository = "${var.target_repository}/gradle"
 }
 
+module "grype" {
+  source            = "./images/grype"
+  target_repository = "${var.target_repository}/grype"
+}
+
 module "guacamole-server" {
   source            = "./images/guacamole-server"
   target_repository = "${var.target_repository}/guacamole-server"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size

- [ ] The Image is smaller in size than its common public counterpart.
- [X] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes: The delta looks to be that we add busybox

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes: 228 packages found, 0 CVEs

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [X] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

Notes: Run through grype documentation examples

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [X] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [X] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [X] Environment variables not added and not required.

### SIGTERM

- [] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
