### PR TITLE
add prometheus-pushgateway-bitnami image

### DIFF
--- a/images/prometheus-pushgateway-bitnami/README.md
+++ b/images/prometheus-pushgateway-bitnami/README.md
@@ -1,0 +1,15 @@
+<!--monopod:start-->
+# prometheus-pushgateway-bitnami
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/prometheus-pushgateway-bitnami` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-pushgateway-bitnami/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimalist Wolfi-based [prometheus-pushgateway-bitnami]() image. This is intended to be a drop in replacement for deployments that require Bitnami compatibility.

--- a/images/prometheus-pushgateway-bitnami/config/main.tf
+++ b/images/prometheus-pushgateway-bitnami/config/main.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  description = "Package name (e.g. prometheus-pushgateway)"
+}
+
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(["${var.name}${var.suffix}-bitnami-compat"], var.extra_packages)
+    }
+
+    entrypoint = {
+      command = "/opt/bitnami/pushgateway/bin/pushgateway"
+    }
+  })
+}

--- a/images/prometheus-pushgateway-bitnami/main.tf
+++ b/images/prometheus-pushgateway-bitnami/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+variable "suffix" {
+  default     = ""
+  description = "The pushgateway component version suffix."
+}
+
+module "config" {
+  source = "./config"
+  name   = "prometheus-pushgateway"
+  suffix = var.suffix
+}
+
+module "latest" {
+  source = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = "${var.target_repository}-bitnami"
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/prometheus-pushgateway-bitnami/tests/02-healthy.sh
+++ b/images/prometheus-pushgateway-bitnami/tests/02-healthy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+CONTAINER_NAME=${CONTAINER_NAME:-"prometheus-smoketest-${FREE_PORT}"}
+
+docker run -p ${FREE_PORT}:9091 -d --name $CONTAINER_NAME $IMAGE_NAME
+trap "docker logs $CONTAINER_NAME && docker rm -f $CONTAINER_NAME" EXIT
+sleep 5
+curl -L localhost:${FREE_PORT}/-/healthy | grep "OK"

--- a/images/prometheus-pushgateway-bitnami/tests/main.tf
+++ b/images/prometheus-pushgateway-bitnami/tests/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" {
+  input = var.digest
+}
+
+data "oci_exec_test" "healthy" {
+  digest = var.digest
+  script = "${path.module}/02-healthy.sh"
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "prometheus_community_pushgateway" {
+  name             = "pushgateway-${random_pet.suffix.id}"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-pushgateway"
+  namespace        = "pushgateway-system-${random_pet.suffix.id}"
+  create_namespace = true
+
+  values = [
+    jsonencode({
+      image = {
+        repository = data.oci_string.ref.registry_repo
+        tag        = data.oci_string.ref.pseudo_tag
+      }
+      service = {
+        type = "ClusterIP"
+      }
+    }),
+  ]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.prometheus_community_pushgateway.id
+  namespace = helm_release.prometheus_community_pushgateway.namespace
+}

--- a/main.tf
+++ b/main.tf
@@ -822,6 +822,12 @@ module "prometheus-node-exporter" {
   target_repository = "${var.target_repository}/prometheus-node-exporter"
 }
 
+module "prometheus-pushgateway-bitnami" {
+  source = "./images/prometheus-pushgateway-bitnami"
+  # -bitnami is added in the module
+  target_repository = "${var.target_repository}/prometheus-pushgateway"
+}
+
 module "prometheus-redis-exporter" {
   source            = "./images/prometheus-redis-exporter"
   target_repository = "${var.target_repository}/prometheus-redis-exporter"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

- add prometheus-pushgateway-bitnami image


### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
