### PR TITLE
Cleanup `csi-attacher-*` when tests complete.

### DIFF
--- a/images/kubernetes-csi-external-attacher/tests/deploy.sh
+++ b/images/kubernetes-csi-external-attacher/tests/deploy.sh
@@ -4,6 +4,7 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 
 : "${NAMESPACE:=default}"
 kubectl create ns $NAMESPACE || true
+trap "kubectl delete ns $NAMESPACE" EXIT
 
 curl https://raw.githubusercontent.com/kubernetes-csi/external-attacher/master/deploy/kubernetes/deployment.yaml \
     | sed "s|registry.k8s.io/k8s-staging-sig-storage/csi-attacher:.*|${IMAGE_NAME}|g" \


### PR DESCRIPTION
Seeing a lot of these leftover in downstream mega-module builds:
```
    csi-attacher-relaxing-gorilla  csi-attacher-5689f748b7-d8j5g                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         15m
    csi-attacher-relaxing-gorilla  csi-attacher-5689f748b7-fvfzr                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         15m
    csi-attacher-glorious-cod      csi-attacher-5b5d67c6f8-4tr99                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         15m
    csi-attacher-glorious-cod      csi-attacher-5b5d67c6f8-j29fh                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         15m
    csi-attacher-relaxing-gorilla  csi-attacher-5689f748b7-hzpmb                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         15m
    csi-attacher-glorious-cod      csi-attacher-5b5d67c6f8-6z6n5                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         15m
    csi-attacher-mighty-goshawk    csi-attacher-7b6678c989-h9zgc                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         14m
    csi-attacher-mighty-goshawk    csi-attacher-7b6678c989-s9v5s                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         14m
    csi-attacher-mighty-goshawk    csi-attacher-7b6678c989-wkjtn                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         14m
    csi-attacher-settling-husky    csi-attacher-677dcd6f96-lfbzv                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         14m
    csi-attacher-settling-husky    csi-attacher-677dcd6f96-zzp87                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         14m
    csi-attacher-settling-husky    csi-attacher-677dcd6f96-rkq9b                          0 (0%)        0 (0%)      0 (0%)           0 (0%)         14m
```
