### PR TITLE
Make fluentd respect arguments

### DIFF
--- a/images/fluentd/config/template.apko.yaml
+++ b/images/fluentd/config/template.apko.yaml
@@ -2,9 +2,7 @@ contents:
   packages: [] # fluentd comes via var.extra_packages
 
 entrypoint:
-  type: service-bundle
-  services:
-    fluentd: /usr/bin/fluentd
+  command: /usr/bin/fluentd
 
 environment:
   FLUENTD_CONF: "fluent.conf"


### PR DESCRIPTION
Remove the s6 dependency for fluentd so it respects command line arguments passed through k8s manifests. Also allows fluentd to run with a read-only filesystem.