### PR TITLE
deflake prom-mongodb-exporter test

### DIFF
--- a/images/prometheus-mongodb-exporter/tests/main.tf
+++ b/images/prometheus-mongodb-exporter/tests/main.tf
@@ -47,15 +47,12 @@ data "oci_exec_test" "check-metrics-container" {
   digest = var.digest
   script = <<EOF
 set -e
-sleep 10
-for i in {1..20}; do
-  sleep 1
-  status=$(kubectl get pods -n prometheus-mongodb-exporter-${random_pet.suffix.id} -ojsonpath="{.items[0].status.containerStatuses[0].ready}")
-  if [ "$status" == "true" ]; then
-    echo "Metrics container ready"
-    exit 0
-  fi
-done
+sleep 30
+status=$(kubectl get pods -n prometheus-mongodb-exporter-${random_pet.suffix.id} -ojsonpath="{.items[0].status.containerStatuses[0].ready}")
+if [ "$status" == "true" ]; then
+  echo "Metrics container ready"
+  exit 0
+fi
 
 echo "Metrics container not ready after 30 seconds!"
 kubectl get pods -n prometheus-mongodb-exporter-${random_pet.suffix.id} -oyaml

--- a/images/prometheus-mongodb-exporter/tests/main.tf
+++ b/images/prometheus-mongodb-exporter/tests/main.tf
@@ -44,8 +44,9 @@ resource "helm_release" "bitnami" {
 // So instead of waiting for the Helm chart to become ready, we only check the metrics container status.
 // This won't be ready immediately, but it should be ready within 30 seconds, or else something is wrong.
 data "oci_exec_test" "check-metrics-container" {
-  digest = var.digest
-  script = <<EOF
+  depends_on = [helm_release.bitnami]
+  digest     = var.digest
+  script     = <<EOF
 set -e
 sleep 30
 status=$(kubectl get pods -n prometheus-mongodb-exporter-${random_pet.suffix.id} -ojsonpath="{.items[0].status.containerStatuses[0].ready}")


### PR DESCRIPTION
Instead of trying to be clever and waiting 10s then polling for another 20s, just wait 30s to see if the container is ready.

If no containers are ready after the initial 10s (like when the cluster is overloaded) then the kubectl invocation fails, causing a test flake.