### PR TITLE
cilium-operator: new image

### DIFF
--- a/images/cilium/README.md
+++ b/images/cilium/README.md
@@ -1,0 +1,18 @@
+<!--monopod:start-->
+# cilium
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/cilium` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cilium/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+# Cilium images:
+
+## operator 
+The Cilium Operator uses Kubernetes leader election library in conjunction with lease locks to provide HA functionality. 

--- a/images/cilium/configs/operator/main.tf
+++ b/images/cilium/configs/operator/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. gops, cilium-operator-generic...)"
+  default = [
+    "gops",
+    "cilium-operator-generic",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/cilium/configs/operator/template.apko.yaml
+++ b/images/cilium/configs/operator/template.apko.yaml
@@ -1,0 +1,17 @@
+contents:
+  packages: [
+    # Packages come from extra_packages
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nobody
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/cilium-operator-generic

--- a/images/cilium/main.tf
+++ b/images/cilium/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "test-latest" {
+  source = "./tests"
+  digests = {
+    operator = module.operator.image_ref
+  }
+}
+
+resource "oci_tag" "latest" {
+  for_each = {
+    "operator" : module.operator.image_ref
+  }
+  digest_ref = each.value
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each = {
+    "operator" : module.operator.dev_ref
+  }
+  digest_ref = each.value
+  tag        = "latest-dev"
+}
+

--- a/images/cilium/operator-generic.tf
+++ b/images/cilium/operator-generic.tf
@@ -1,0 +1,11 @@
+module "operator-config" { source = "./configs/operator" }
+
+module "operator" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-operator-generic"
+  config            = module.operator-config.config
+  build-dev         = true
+}

--- a/images/cilium/tests/main.tf
+++ b/images/cilium/tests/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digests" {
+  description = "The digests to run tests over."
+  type = object({
+    operator = string
+  })
+}
+
+data "oci_exec_test" "operator-version" {
+  script = "docker run --rm $IMAGE_NAME --version"
+  digest = var.digests.operator
+}
+
+# TODO:
+# To run this test, we need to create a cluster that looks like this
+#
+# k3d cluster create -i cgr.dev/chainguard/k3s:latest \
+#     --k3s-arg '--disable=traefik@server:*' \
+#     --k3s-arg '--disable=metrics-server@server:*' \
+#     --k3s-arg '--disable-network-policy@server:*' \
+#     --k3s-arg '--flannel-backend=none@server:*' \
+#
+# for node in k3d-k3s-default-server-0; do
+#   docker exec -i $node /bin/sh <<-EOF
+#       mount bpffs -t bpf /sys/fs/bpf
+#       mount --make-shared /sys/fs/bpf
+#       mkdir -p /run/cilium/cgroupv2
+#       mount -t cgroup2 none /run/cilium/cgroupv2
+#       mount --make-shared /run/cilium/cgroupv2/
+#
+#
+# resource "helm_release" "cilium" {
+#   repository       = "https://helm.cilium.io"
+#   chart            = "cilium"
+#   name             = "cilium"
+#   namespace        = "kube-system"
+
+#   values = [jsonencode({
+#     operator = {
+#       image = {
+#         override = var.digests.operator
+#       }
+#       replicas = 1
+#     }
+#   })]
+# }

--- a/main.tf
+++ b/main.tf
@@ -191,6 +191,12 @@ module "cluster-proportional-autoscaler" {
   target_repository = "${var.target_repository}/cluster-proportional-autoscaler"
 }
 
+module "cilium" {
+  source            = "./images/cilium"
+  target_repository = "${var.target_repository}/cilium"
+}
+
+
 module "conda" {
   source            = "./images/conda"
   target_repository = "${var.target_repository}/conda"

--- a/main.tf
+++ b/main.tf
@@ -196,7 +196,6 @@ module "cilium" {
   target_repository = "${var.target_repository}/cilium"
 }
 
-
 module "conda" {
   source            = "./images/conda"
   target_repository = "${var.target_repository}/conda"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size

- [ ] The Image is smaller in size than its common public counterpart.
- [x] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:
```
❯ docker images | grep operator                                      
tcnghia/cilium-operator-generic                       latest              5d17548f4a16   4 hours ago    78MB
quay.io/cilium/operator-generic                       v1.14.2             bbfe2f667bb8   4 weeks ago    76MB
```

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes: Helm chart was used to test, but the current k3s cluster on CI won't be able to use this Helm chart. Test was done locally, and instruction included in PR.

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
