### PR TITLE
Add crossplane images

### DIFF
--- a/images/crossplane/README.md
+++ b/images/crossplane/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# crossplane
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/crossplane` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/crossplane/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/crossplane/config/main.tf
+++ b/images/crossplane/config/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. crossplane-xfn)."
+  type        = list(string)
+}
+
+variable "entrypoint" {
+  description = "The entrypoint of the image (e.g. /usr/bin/xfn)."
+  type        = string
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = var.entrypoint
+    }
+  })
+}

--- a/images/crossplane/main.tf
+++ b/images/crossplane/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  components = {
+    "crossplane" : {
+      packages = ["crossplane"]
+      repo     = var.target_repository
+    }
+    # TODO: This is moving into its own repo:
+    # https://github.com/crossplane/function-runtime-oci
+    "xfn" : {
+      packages : ["crossplane-xfn", "crun"]
+      repo : "${var.target_repository}-xfn"
+    }
+  }
+}
+
+module "latest-config" {
+  for_each       = local.components
+  source         = "./config"
+  extra_packages = each.value.packages
+  entrypoint     = "/usr/bin/${each.key}"
+}
+
+module "latest" {
+  for_each          = local.components
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = each.value.repo
+  config            = module.latest-config[each.key].config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source  = "./tests"
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+}

--- a/images/crossplane/tests/main.tf
+++ b/images/crossplane/tests/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digests" {
+  description = "The image digest to run tests over."
+  type = object({
+    crossplane = string
+    xfn        = string
+  })
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+resource "helm_release" "crossplane" {
+  name       = "crossplane"
+  repository = "https://charts.crossplane.io/stable"
+  chart      = "crossplane"
+
+  create_namespace = true
+  namespace        = "crossplane-system"
+
+  values = [jsonencode({
+    image = {
+      repository = data.oci_string.ref["crossplane"].registry_repo
+      tag        = data.oci_string.ref["crossplane"].pseudo_tag
+    }
+
+    # From: https://docs.crossplane.io/latest/concepts/composition-functions/#enabling-functions
+    args = ["--enable-composition-functions"]
+    xfn = {
+      enabled = true
+      image = {
+        repository = data.oci_string.ref["xfn"].registry_repo
+        tag        = data.oci_string.ref["xfn"].pseudo_tag
+      }
+    }
+  })]
+}
+
+module "helm-cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.crossplane.id
+  namespace = helm_release.crossplane.namespace
+}

--- a/main.tf
+++ b/main.tf
@@ -236,6 +236,11 @@ module "crane" {
   target_repository = "${var.target_repository}/crane"
 }
 
+module "crossplane" {
+  source            = "./images/crossplane"
+  target_repository = "${var.target_repository}/crossplane"
+}
+
 module "crossplane-aws" {
   source            = "./images/crossplane-aws"
   target_repository = "${var.target_repository}/crossplane-aws"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
