### PR TITLE
add gitlab-pages image

### DIFF
--- a/images/gitlab/config/main.tf
+++ b/images/gitlab/config/main.tf
@@ -5,7 +5,11 @@ terraform {
 }
 
 variable "name" {
-  description = "Package name (e.g. kas, sidekiq, ...)"
+  description = "Package name (e.g. kas, pages, shell, ...)"
+}
+
+variable "entrypoint_cmd" {
+  description = "Entrypoint command to be executed (e.g. /usr/bin/kas, /usr/local/bin/start-pages, ...)"
 }
 
 variable "suffix" {
@@ -27,8 +31,14 @@ output "config" {
       packages = concat(["gitlab-${var.name}${var.suffix}"], var.extra_packages)
     }
     accounts = module.accts.block
+
+    paths = [{
+      path : "/etc/gitlab-${var.name}",
+      type : "directory",
+      permissions = 511
+    }]
     entrypoint = {
-      command = "/usr/bin/${var.name}"
+      command = "${var.entrypoint_cmd}"
     }
   })
 }

--- a/images/gitlab/tests/main.tf
+++ b/images/gitlab/tests/main.tf
@@ -46,6 +46,20 @@ resource "helm_release" "gitlab" {
           tag        = data.oci_string.ref["pages"].pseudo_tag
           repository = data.oci_string.ref["pages"].registry_repo
         }
+        resources = {
+          requests = {
+            memory = "250M"
+            cpu    = "50m"
+          }
+        }
+      }
+      webservice = {
+        resources = {
+          requests = {
+            cpu    = "50m"
+            memory = "250M"
+          }
+        }
       }
       sidekiq = {
         enabled = false


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

Found the following CVEs after scanning the image:

```
 ✔ Scanned for vulnerabilities     [3 vulnerabilities]
   ├── 0 critical, 0 high, 3 medium, 0 low, 0 negligible
   └── 3 fixed
[0001]  WARN some package(s) are missing CPEs. This may result in missing vulnerabilities. You may autogenerate these using: --add-cpes-if-none
NAME              INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
golang.org/x/net  v0.10.0    0.17.0    go-module  GHSA-qppj-fm5r-hxr3  Medium
golang.org/x/net  v0.10.0    0.17.0    go-module  GHSA-4374-p667-p6c8  Medium
golang.org/x/net  v0.10.0    0.13.0    go-module  GHSA-2wrh-6pvc-2jm9  Medium
0.71.0
```

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:



### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

