### PR TITLE
fix up bash image

### DIFF
--- a/images/bash/config/main.tf
+++ b/images/bash/config/main.tf
@@ -4,6 +4,11 @@ variable "extra_packages" {
   default     = []
 }
 
+module "accts" {
+  source = "../../tflib/accts"
+  run-as = 0
+}
+
 output "config" {
   value = jsonencode({
     contents = {
@@ -13,6 +18,7 @@ output "config" {
         "curl",
       ], var.extra_packages)
     }
+    accounts = module.accts.block
     entrypoint = {
       command = "/bin/bash -c"
     }

--- a/images/bash/config/main.tf
+++ b/images/bash/config/main.tf
@@ -5,7 +5,7 @@ variable "extra_packages" {
 }
 
 module "accts" {
-  source = "../../tflib/accts"
+  source = "../../../tflib/accts"
   run-as = 0
 }
 

--- a/images/bash/configs/latest.apko.yaml
+++ b/images/bash/configs/latest.apko.yaml
@@ -1,8 +1,0 @@
-contents:
-  packages:
-    - curl
-    - bash
-    - busybox
-
-entrypoint:
-  command: /bin/bash -c

--- a/images/bash/main.tf
+++ b/images/bash/main.tf
@@ -2,13 +2,15 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
+module "config" { source = "./config" }
+
 module "latest" {
   source = "../../tflib/publisher"
 
   name = basename(path.module)
 
   target_repository = var.target_repository
-  config            = file("${path.module}/configs/latest.apko.yaml")
+  config            = module.config.config
 }
 
 module "version-tags" {

--- a/images/bash/tests/main.tf
+++ b/images/bash/tests/main.tf
@@ -10,5 +10,5 @@ variable "digest" {
 
 data "oci_exec_test" "runs" {
   digest = var.digest
-  script = "${path.module}/01-runs.sh"
+  script = "${path.module}/runs.sh"
 }

--- a/images/bash/tests/runs.sh
+++ b/images/bash/tests/runs.sh
@@ -3,3 +3,5 @@
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 docker run --rm $IMAGE_NAME ls > /dev/null
+
+docker run --rm $IMAGE_NAME whoami | grep root


### PR DESCRIPTION
The config module was defined in https://github.com/chainguard-images/images/pull/1445 (seemingly by accident) but not yet used. This uses the module and deletes the config yaml.

Notably, the current live image runs as root and doesn't even define a nonroot user. With this change, it'll include a nonroot user as well.

I've also added a test to demonstrate that the user runs as root.