### PR TITLE
gitlab: add gitlab-shell image

### DIFF
--- a/images/gitlab/config/main.tf
+++ b/images/gitlab/config/main.tf
@@ -36,6 +36,18 @@ output "config" {
       path : "/etc/gitlab-${var.name}",
       type : "directory",
       permissions = 511
+      }, {
+      path : "/srv/gitlab-${var.name}",
+      type : "directory",
+      permissions = 511
+      }, {
+      path : "/var/log/gitlab-${var.name}",
+      type : "directory",
+      permissions = 511
+      }, {
+      path : "/etc/ssh",
+      type : "directory",
+      permissions = 511
     }]
     entrypoint = {
       command = "${var.entrypoint_cmd}"

--- a/images/gitlab/main.tf
+++ b/images/gitlab/main.tf
@@ -9,7 +9,7 @@ variable "target_repository" {
 }
 
 locals {
-  components = toset(["kas", "pages"])
+  components = toset(["kas", "pages", "shell"])
 
   // Normally the entrypoint is named like "{component}"
   // But some entrypoint are pointing to different entrypoint commands:
@@ -17,6 +17,7 @@ locals {
     for k, v in local.components : k => "/usr/bin/${k}"
     }, {
     "pages" : "/scripts/entrypoint.sh /scripts/start-pages",
+    "shell" : "/scripts/entrypoint.sh /scripts/process-wrapper",
   })
   versions = [for v in range(11, 14) : "1.${v}"]
   component_versions = merge([


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:


### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).


### Documentation - README

- [ ] A README file has been provided and it follows the README template.
