### PR TITLE
tigera-operator deconflict helm chart name

### DIFF
--- a/images/tigera-operator/tests/main.tf
+++ b/images/tigera-operator/tests/main.tf
@@ -11,12 +11,14 @@ variable "digest" {
 
 data "oci_string" "ref" { input = var.digest }
 
+resource "random_pet" "suffix" {}
+
 resource "helm_release" "tigera-operator" {
-  name = "tigera-operator"
+  name = "tigera-operator-${random_pet.suffix.id}"
 
   repository       = "https://projectcalico.docs.tigera.io/charts"
   chart            = "tigera-operator"
-  namespace        = "tigera-operator"
+  namespace        = "tigera-operator-${random_pet.suffix.id}"
   create_namespace = true
 
   values = [jsonencode({


### PR DESCRIPTION
When testing multiple tigera-operator installations, the names conflict. This attempts to resolve that conflict.