### PR TITLE
Add caddy image

### DIFF
--- a/images/caddy/README.md
+++ b/images/caddy/README.md
@@ -1,0 +1,10 @@
+# Chainguard Images Template
+
+This is a template README.md for new images.
+
+1. Include a brief description of the image here, and instructions about how to use it.
+1. Run `monopod readme`, which will update the top section of this file and the root README.md file.
+1. Update your new `config/template.apko.yaml` file to specify packages you want the image to include, and any other necessary image config.
+1. Call this module from the `main.tf` in the root of this repo, in alphabetical order. (`lint.sh` will yell at you if you don't)
+
+If you need to support version streams, you can leave `packages` empty in `latest.apko.yaml`, and instead add packages to the images using the `extra_packages` TF variable in `config/main.tf`.

--- a/images/caddy/README.md
+++ b/images/caddy/README.md
@@ -1,10 +1,35 @@
-# Chainguard Images Template
+<!--monopod:start-->
+# caddy
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/caddy` |
 
-This is a template README.md for new images.
 
-1. Include a brief description of the image here, and instructions about how to use it.
-1. Run `monopod readme`, which will update the top section of this file and the root README.md file.
-1. Update your new `config/template.apko.yaml` file to specify packages you want the image to include, and any other necessary image config.
-1. Call this module from the `main.tf` in the root of this repo, in alphabetical order. (`lint.sh` will yell at you if you don't)
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/caddy/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
 
-If you need to support version streams, you can leave `packages` empty in `latest.apko.yaml`, and instead add packages to the images using the `extra_packages` TF variable in `config/main.tf`.
+---
+<!--monopod:end-->
+
+# Caddy
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/caddy:latest
+```
+
+## Usage
+
+This image comes with a default configuration `Caddyfile` located in `/etc/caddy/Caddyfile`.
+
+Please refer to [upstream's excellent (and comprehensive) documentation](https://caddyserver.com/docs/) on the subject of configuring Caddy for your needs.
+
+The following example runs `caddy` with a custom configuration file:
+
+```
+docker run -it --rm -v "$(pwd)/Caddyfile:/etc/caddy/Caddyfile" cgr.dev/chainguard/caddy caddy run --config /etc/caddy/Caddyfile
+```

--- a/images/caddy/config/main.tf
+++ b/images/caddy/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = [ "caddy" ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/caddy/config/main.tf
+++ b/images/caddy/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  default = [ "caddy" ]
+  default     = ["caddy"]
 }
 
 data "apko_config" "this" {

--- a/images/caddy/config/template.apko.yaml
+++ b/images/caddy/config/template.apko.yaml
@@ -1,0 +1,18 @@
+contents:
+  packages:
+    - caddy
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/caddy
+
+cmd: run

--- a/images/caddy/main.tf
+++ b/images/caddy/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "caddy-config" { source = "./config" }
+
+module "caddy" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.caddy-config.config
+  build-dev         = true
+
+}
+
+module "test-caddy" {
+  source = "./tests"
+  digest = module.caddy.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-caddy]
+  digest_ref = module.caddy.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-caddy]
+  digest_ref = module.caddy.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/caddy/tests/Caddyfile
+++ b/images/caddy/tests/Caddyfile
@@ -1,0 +1,26 @@
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+:80 {
+	# Set this path to your site's directory.
+	root * /usr/share/caddy
+
+	# Enable the static file server.
+	file_server
+
+	# Another common task is to set up a reverse proxy:
+	# reverse_proxy localhost:8080
+
+	# Or serve a PHP site through php-fpm:
+	# php_fastcgi localhost:9000
+}
+
+# Refer to the Caddy docs for more information:
+# https://caddyserver.com/docs/caddyfile

--- a/images/caddy/tests/index.html
+++ b/images/caddy/tests/index.html
@@ -1,0 +1,1 @@
+hello world

--- a/images/caddy/tests/main.tf
+++ b/images/caddy/tests/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+// Invoke the image's version command.
+// $IMAGE_NAME is populated with the image name by digest.
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME version"
+}
+
+// Invoke a script with the test.
+// $IMAGE_NAME is populated with the image name by digest.
+data "oci_exec_test" "manifest" {
+  digest      = var.digest
+  script      = "./run_test.sh"
+  working_dir = path.module
+}
+

--- a/images/caddy/tests/run_test.sh
+++ b/images/caddy/tests/run_test.sh
@@ -2,11 +2,14 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-ID=$(docker run -p 2019 -d ${IMAGE_NAME})
+echo "hello world" > index.html
+ID=$(docker run -p ${FREE_PORT}:80 -v $PWD/index.html:/usr/share/caddy/index.html -v $PWD/Caddyfile:/etc/caddy/Caddyfile -d ${IMAGE_NAME} run --config /etc/caddy/Caddyfile)
 
 docker logs $ID
 
-trap "docker logs $ID; docker stop $ID" EXIT
+trap "docker logs $ID && docker rm -f $ID" EXIT
+sleep 5
 
-# The healthcheck endpoint requires auth, so just hit the normal URL.
-curl localhost:$(docker port $ID | cut -d ' ' -f 3)
+# The healthcheck endpoin
+curl http://localhost:${FREE_PORT} | grep "hello world"
+

--- a/images/caddy/tests/run_test.sh
+++ b/images/caddy/tests/run_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+ID=$(docker run -p 2019 -d ${IMAGE_NAME})
+
+docker logs $ID
+
+trap "docker logs $ID; docker stop $ID" EXIT
+
+# The healthcheck endpoint requires auth, so just hit the normal URL.
+curl localhost:$(docker port $ID | cut -d ' ' -f 3)

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,11 @@ module "busybox" {
   }
 }
 
+module "caddy" {
+  source            = "./images/caddy"
+  target_repository = "${var.target_repository}/caddy"
+}
+
 module "cadvisor" {
   source            = "./images/cadvisor"
   target_repository = "${var.target_repository}/cadvisor"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->

@amouat and myself worked on getting support for Caddy 🎉 

Adding caddy image.

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).



### Documentation - README

- [x] A README file has been provided and it follows the README template.
