### PR TITLE
rabbitmq-cluster-operator: new image

### DIFF
--- a/images/rabbitmq-cluster-operator/README.md
+++ b/images/rabbitmq-cluster-operator/README.md
@@ -1,0 +1,126 @@
+<!--monopod:start-->
+# cosign
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/cosign` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimalist Wolfi-based Cosign images for signing and verifying images using Sigstore.
+
+- [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign)
+- [Provenance Information](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign/provenance_info/)
+<!-- TODO: add Getting Started Guide - [Getting Started Guide](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign/getting-started-cosign/) -->
+
+## Image Variants
+
+Our `latest` tag uses the most recent build of the [Wolfi Cosign](https://github.com/wolfi-dev/os/blob/main/cosign.yaml) package. The following tagged variant is available without authentication:
+
+- `latest`: This is an image for running `cosign` commands. It does not include a shell or other applications.
+
+### Cosign Version
+This will automatically pull the image to your local system and execute the command `cosign version`:
+
+```shell
+docker run --rm cgr.dev/chainguard/cosign version
+```
+
+You should see output similar to this:
+
+```
+  ______   ______        _______. __    _______ .__   __.
+ /      | /  __  \      /       ||  |  /  _____||  \ |  |
+|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
+|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
+|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
+ \______| \______/  |_______/    |__|  \______| |__| \__|
+cosign: A tool for Container Signing, Verification and Storage in an OCI registry.
+
+...
+Platform:      linux/arm64
+```
+
+
+
+## Usage
+
+### Signing a container image
+
+For example, from GitHub Actions:
+
+
+```yaml
+on:
+  push:
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+  DOCKER_CONFIG: .docker-tmp
+jobs:
+  push-and-sign:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+    steps:
+      - name: Login to registry
+        run: |
+          set -x
+          mkdir -p "${DOCKER_CONFIG}"
+          echo '{}' > "${DOCKER_CONFIG}/config.json"
+          echo "${{ github.token }}" | docker login \
+            -u "${{ github.repository_owner }}" \
+            --password-stdin ghcr.io
+      - name: Push image with docker
+        run: |
+          set -x
+          docker pull alpine:latest
+          docker tag alpine:latest "${IMAGE}"
+          docker push "${IMAGE}"
+      - name: Sign image with cosign
+        run: |
+          set -x
+          env | grep -v ^HOME= > github-actions.txt
+          docker run --rm --env-file=./github-actions.txt \
+            -v "${PWD}/${DOCKER_CONFIG}:/tmp/${DOCKER_CONFIG}" \
+            -e DOCKER_CONFIG="/tmp/${DOCKER_CONFIG}" \
+            cgr.dev/chainguard/cosign \
+            sign "${IMAGE}" \
+              --yes \
+              -a sha=${{ github.sha }} \
+              -a run_id=${{ github.run_id }} \
+              -a run_attempt=${{ github.run_attempt }}
+
+```
+
+### Verifying a container image signature
+
+To verify an image signature, use the image to run Cosign's `verify` command. Since as of Cosign 2.0, Cosign defaults to using Sigstore's keyless mode, you'll need to also specify the OIDC issuer and signer identity to tell Cosign who you trust for the verification process.
+
+For convenience, you can export those values as environment variables in your shell, and then tell Docker to pass those environment variables into the running Cosign container.
+
+For example, to use the Cosign image to verify the signature of the Cosign image itself:
+
+```shell
+export COSIGN_CERTIFICATE_OIDC_ISSUER=https://token.actions.githubusercontent.com
+export COSIGN_CERTIFICATE_IDENTITY=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+
+docker run --rm \
+  -e COSIGN_CERTIFICATE_OIDC_ISSUER \
+  -e COSIGN_CERTIFICATE_IDENTITY \
+  cgr.dev/chainguard/cosign \
+  verify cgr.dev/chainguard/cosign
+```
+
+## Detailed Environment Information
+
+To obtain detailed information about the environment, you can run the `cosign env` command:
+
+```shell
+docker run --rm cgr.dev/chainguard/cosign env --show-descriptions=false
+```

--- a/images/rabbitmq-cluster-operator/README.md
+++ b/images/rabbitmq-cluster-operator/README.md
@@ -12,3 +12,12 @@
 ---
 <!--monopod:end-->
 
+Minimal Project RabbitMQ Cluster Kubernetes Operator
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/rabbitmq-cluster-operator:latest
+```

--- a/images/rabbitmq-cluster-operator/README.md
+++ b/images/rabbitmq-cluster-operator/README.md
@@ -1,126 +1,14 @@
 <!--monopod:start-->
-# cosign
+# rabbitmq-cluster-operator
 | | |
 | - | - |
-| **OCI Reference** | `cgr.dev/chainguard/cosign` |
+| **OCI Reference** | `cgr.dev/chainguard/rabbitmq-cluster-operator` |
 
 
-* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign/overview/)
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/rabbitmq-cluster-operator/overview/)
 * [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
 * [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
 
 ---
 <!--monopod:end-->
 
-Minimalist Wolfi-based Cosign images for signing and verifying images using Sigstore.
-
-- [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign)
-- [Provenance Information](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign/provenance_info/)
-<!-- TODO: add Getting Started Guide - [Getting Started Guide](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cosign/getting-started-cosign/) -->
-
-## Image Variants
-
-Our `latest` tag uses the most recent build of the [Wolfi Cosign](https://github.com/wolfi-dev/os/blob/main/cosign.yaml) package. The following tagged variant is available without authentication:
-
-- `latest`: This is an image for running `cosign` commands. It does not include a shell or other applications.
-
-### Cosign Version
-This will automatically pull the image to your local system and execute the command `cosign version`:
-
-```shell
-docker run --rm cgr.dev/chainguard/cosign version
-```
-
-You should see output similar to this:
-
-```
-  ______   ______        _______. __    _______ .__   __.
- /      | /  __  \      /       ||  |  /  _____||  \ |  |
-|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
-|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
-|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
- \______| \______/  |_______/    |__|  \______| |__| \__|
-cosign: A tool for Container Signing, Verification and Storage in an OCI registry.
-
-...
-Platform:      linux/arm64
-```
-
-
-
-## Usage
-
-### Signing a container image
-
-For example, from GitHub Actions:
-
-
-```yaml
-on:
-  push:
-env:
-  IMAGE: ghcr.io/${{ github.repository }}
-  DOCKER_CONFIG: .docker-tmp
-jobs:
-  push-and-sign:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      packages: write
-    steps:
-      - name: Login to registry
-        run: |
-          set -x
-          mkdir -p "${DOCKER_CONFIG}"
-          echo '{}' > "${DOCKER_CONFIG}/config.json"
-          echo "${{ github.token }}" | docker login \
-            -u "${{ github.repository_owner }}" \
-            --password-stdin ghcr.io
-      - name: Push image with docker
-        run: |
-          set -x
-          docker pull alpine:latest
-          docker tag alpine:latest "${IMAGE}"
-          docker push "${IMAGE}"
-      - name: Sign image with cosign
-        run: |
-          set -x
-          env | grep -v ^HOME= > github-actions.txt
-          docker run --rm --env-file=./github-actions.txt \
-            -v "${PWD}/${DOCKER_CONFIG}:/tmp/${DOCKER_CONFIG}" \
-            -e DOCKER_CONFIG="/tmp/${DOCKER_CONFIG}" \
-            cgr.dev/chainguard/cosign \
-            sign "${IMAGE}" \
-              --yes \
-              -a sha=${{ github.sha }} \
-              -a run_id=${{ github.run_id }} \
-              -a run_attempt=${{ github.run_attempt }}
-
-```
-
-### Verifying a container image signature
-
-To verify an image signature, use the image to run Cosign's `verify` command. Since as of Cosign 2.0, Cosign defaults to using Sigstore's keyless mode, you'll need to also specify the OIDC issuer and signer identity to tell Cosign who you trust for the verification process.
-
-For convenience, you can export those values as environment variables in your shell, and then tell Docker to pass those environment variables into the running Cosign container.
-
-For example, to use the Cosign image to verify the signature of the Cosign image itself:
-
-```shell
-export COSIGN_CERTIFICATE_OIDC_ISSUER=https://token.actions.githubusercontent.com
-export COSIGN_CERTIFICATE_IDENTITY=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
-
-docker run --rm \
-  -e COSIGN_CERTIFICATE_OIDC_ISSUER \
-  -e COSIGN_CERTIFICATE_IDENTITY \
-  cgr.dev/chainguard/cosign \
-  verify cgr.dev/chainguard/cosign
-```
-
-## Detailed Environment Information
-
-To obtain detailed information about the environment, you can run the `cosign env` command:
-
-```shell
-docker run --rm cgr.dev/chainguard/cosign env --show-descriptions=false
-```

--- a/images/rabbitmq-cluster-operator/README.md
+++ b/images/rabbitmq-cluster-operator/README.md
@@ -21,3 +21,31 @@ The image is available on `cgr.dev`:
 ```
 docker pull cgr.dev/chainguard/rabbitmq-cluster-operator:latest
 ```
+
+## Usage
+
+This image is a drop-in replacement for the upstream image.
+You can run it using kustomize with:
+
+```shell
+LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/cluster-operator/releases/latest" | jq -r '.tag_name')
+
+cat <<EOF > kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "https://github.com/rabbitmq/cluster-operator/releases/download/${LATEST}/cluster-operator.yml"
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: cgr.dev/chainguard/rabbitmq-cluster-operator:latest
+    target:
+      version: v1
+      kind: Deployment
+      name: rabbitmq-cluster-operator
+      namespace: rabbitmq-system
+EOF
+
+kubectl apply -f .
+```

--- a/images/rabbitmq-cluster-operator/config/main.tf
+++ b/images/rabbitmq-cluster-operator/config/main.tf
@@ -1,0 +1,24 @@
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. rabbitmq-cluster-operator)."
+  default     = ["rabbitmq-cluster-operator", "rabbitmq-cluster-operator-compat"]
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  run-as = 1000
+  uid    = 1000
+  gid    = 1000
+  name   = "rabbitmq-cluster-operator"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/manager"
+    }
+  })
+}

--- a/images/rabbitmq-cluster-operator/main.tf
+++ b/images/rabbitmq-cluster-operator/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/rabbitmq-cluster-operator/tests/main.tf
+++ b/images/rabbitmq-cluster-operator/tests/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "deploy" {
+  digest = var.digest
+  script = "${path.module}/test.sh"
+
+  env {
+    name = "RABBITMQ_CLUSTER_OPERATOR_IMAGE"
+    value = var.digest
+  }
+}

--- a/images/rabbitmq-cluster-operator/tests/main.tf
+++ b/images/rabbitmq-cluster-operator/tests/main.tf
@@ -13,7 +13,7 @@ data "oci_exec_test" "deploy" {
   script = "${path.module}/test.sh"
 
   env {
-    name = "RABBITMQ_CLUSTER_OPERATOR_IMAGE"
+    name  = "RABBITMQ_CLUSTER_OPERATOR_IMAGE"
     value = var.digest
   }
 }

--- a/images/rabbitmq-cluster-operator/tests/test.sh
+++ b/images/rabbitmq-cluster-operator/tests/test.sh
@@ -2,11 +2,14 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
+TMPDIR="$(mktemp -d)"
+KUSTOMIZE_FILE="${TMPDIR}/kustomization.yaml"
+
 function manifests() {
   # if image tag is latest then find the latest version of the git release
   LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/cluster-operator/releases/latest" | jq -r '.tag_name')
 
-  cat <<EOF > kustomization.yaml
+  cat <<EOF > "${KUSTOMIZE_FILE}"
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -26,7 +29,10 @@ EOF
 
 manifests
 
-kubectl apply -k .
+kubectl apply -k "${TMPDIR}"
 
 kubectl rollout status --timeout=5m --namespace rabbitmq-system deployment rabbitmq-cluster-operator
 
+kubectl delete -k "${TMPDIR}"
+
+rm -rf "${KUSTOMIZE_FILE}"

--- a/images/rabbitmq-cluster-operator/tests/test.sh
+++ b/images/rabbitmq-cluster-operator/tests/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+function manifests() {
+  # if image tag is latest then find the latest version of the git release
+  LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/cluster-operator/releases/latest" | jq -r '.tag_name')
+
+  cat <<EOF > kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "https://github.com/rabbitmq/cluster-operator/releases/download/${LATEST}/cluster-operator.yml"
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: ${RABBITMQ_CLUSTER_OPERATOR_IMAGE}
+    target:
+      version: v1
+      kind: Deployment
+      name: rabbitmq-cluster-operator
+      namespace: rabbitmq-system
+EOF
+}
+
+manifests
+
+kubectl apply -k .
+
+kubectl rollout status --timeout=5m --namespace rabbitmq-system deployment rabbitmq-cluster-operator
+

--- a/main.tf
+++ b/main.tf
@@ -878,6 +878,11 @@ module "rabbitmq" {
   target_repository = "${var.target_repository}/rabbitmq"
 }
 
+module "rabbitmq-cluster-operator" {
+  source            = "./images/rabbitmq-cluster-operator"
+  target_repository = "${var.target_repository}/rabbitmq-cluster-operator"
+}
+
 module "redis" {
   source            = "./images/redis"
   target_repository = "${var.target_repository}/redis"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [X] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [X] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [X] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [X] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [X] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
