### PR TITLE
rabbitmq-messaging-topology-operator: new image

### DIFF
--- a/images/rabbitmq-messaging-topology-operator/README.md
+++ b/images/rabbitmq-messaging-topology-operator/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# rabbitmq-messaging-topology-operator
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/rabbitmq-messaging-topology-operator` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/rabbitmq-messaging-topology-operator/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/rabbitmq-messaging-topology-operator/README.md
+++ b/images/rabbitmq-messaging-topology-operator/README.md
@@ -11,3 +11,41 @@
 
 ---
 <!--monopod:end-->
+
+Minimal Project RabbitMQ Messaging Topology Kubernetes Operator
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/rabbitmq-messaging-topology-operator:latest
+```
+
+## Usage
+
+This image is a drop-in replacement for the upstream image.
+You can run it using kustomize with:
+
+```shell
+LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/messaging-topology-operator/releases/latest" | jq -r '.tag_name')
+
+cat <<EOF > kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "https://github.com/rabbitmq/messaging-topology-operator/releases/download/${LATEST}/messaging-topology-operator.yaml"
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: cgr.dev/chainguard/rabbitmq-messaging-topology-operator:latest
+    target:
+      version: v1
+      kind: Deployment
+      name:  messaging-topology-operator
+      namespace: rabbitmq-system
+EOF
+
+kubectl apply -f .
+```

--- a/images/rabbitmq-messaging-topology-operator/config/main.tf
+++ b/images/rabbitmq-messaging-topology-operator/config/main.tf
@@ -1,0 +1,24 @@
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. rabbitmq-messaging-topology-operator)."
+  default     = ["rabbitmq-messaging-topology-operator", "rabbitmq-messaging-topology-operator-compat"]
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  run-as = 1001
+  uid    = 1001
+  gid    = 1001
+  name   = "messaging-topology-operator"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/manager"
+    }
+  })
+}

--- a/images/rabbitmq-messaging-topology-operator/main.tf
+++ b/images/rabbitmq-messaging-topology-operator/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/rabbitmq-messaging-topology-operator/tests/main.tf
+++ b/images/rabbitmq-messaging-topology-operator/tests/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "cert-manager" {
+  name       = "cert-manager-${random_pet.suffix.id}"
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  timeout    = 600
+
+  namespace        = "cert-manager-${random_pet.suffix.id}"
+  create_namespace = true
+}
+
+data "oci_exec_test" "deploy" {
+  depends_on = [helm_release.cert-manager]
+
+  digest = var.digest
+  script = "${path.module}/test.sh"
+
+  env {
+    name  = "RABBITMQ_MESSAGING_TOPOLOGY_OPERATOR_IMAGE"
+    value = var.digest
+  }
+}

--- a/images/rabbitmq-messaging-topology-operator/tests/main.tf
+++ b/images/rabbitmq-messaging-topology-operator/tests/main.tf
@@ -10,16 +10,6 @@ variable "digest" {
 
 resource "random_pet" "suffix" {}
 
-resource "helm_release" "cert-manager" {
-  name       = "cert-manager-${random_pet.suffix.id}"
-  repository = "https://charts.jetstack.io"
-  chart      = "cert-manager"
-  timeout    = 600
-
-  namespace        = "cert-manager-${random_pet.suffix.id}"
-  create_namespace = true
-}
-
 data "oci_exec_test" "deploy" {
   #depends_on = [helm_release.cert-manager]
 
@@ -30,9 +20,4 @@ data "oci_exec_test" "deploy" {
     name  = "RABBITMQ_MESSAGING_TOPOLOGY_OPERATOR_IMAGE"
     value = var.digest
   }
-}
-
-module "helm_cleanup" {
-  source = "../../../tflib/helm-cleanup"
-  name   = helm_release.cert-manager.id
 }

--- a/images/rabbitmq-messaging-topology-operator/tests/main.tf
+++ b/images/rabbitmq-messaging-topology-operator/tests/main.tf
@@ -10,18 +10,18 @@ variable "digest" {
 
 resource "random_pet" "suffix" {}
 
-resource "helm_release" "cert-manager" {
-  name       = "cert-manager-${random_pet.suffix.id}"
-  repository = "https://charts.jetstack.io"
-  chart      = "cert-manager"
-  timeout    = 600
-
-  namespace        = "cert-manager-${random_pet.suffix.id}"
-  create_namespace = true
-}
+##resource "helm_release" "cert-manager" {
+#  name       = "cert-manager-${random_pet.suffix.id}"
+#  repository = "https://charts.jetstack.io"
+#  chart      = "cert-manager"
+#  timeout    = 600
+#
+#  namespace        = "cert-manager-${random_pet.suffix.id}"
+#  create_namespace = true
+#}
 
 data "oci_exec_test" "deploy" {
-  depends_on = [helm_release.cert-manager]
+  #depends_on = [helm_release.cert-manager]
 
   digest = var.digest
   script = "${path.module}/test.sh"

--- a/images/rabbitmq-messaging-topology-operator/tests/main.tf
+++ b/images/rabbitmq-messaging-topology-operator/tests/main.tf
@@ -10,15 +10,15 @@ variable "digest" {
 
 resource "random_pet" "suffix" {}
 
-##resource "helm_release" "cert-manager" {
-#  name       = "cert-manager-${random_pet.suffix.id}"
-#  repository = "https://charts.jetstack.io"
-#  chart      = "cert-manager"
-#  timeout    = 600
-#
-#  namespace        = "cert-manager-${random_pet.suffix.id}"
-#  create_namespace = true
-#}
+resource "helm_release" "cert-manager" {
+  name       = "cert-manager-${random_pet.suffix.id}"
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  timeout    = 600
+
+  namespace        = "cert-manager-${random_pet.suffix.id}"
+  create_namespace = true
+}
 
 data "oci_exec_test" "deploy" {
   #depends_on = [helm_release.cert-manager]
@@ -30,4 +30,9 @@ data "oci_exec_test" "deploy" {
     name  = "RABBITMQ_MESSAGING_TOPOLOGY_OPERATOR_IMAGE"
     value = var.digest
   }
+}
+
+module "helm_cleanup" {
+  source = "../../../tflib/helm-cleanup"
+  name   = helm_release.cert-manager.id
 }

--- a/images/rabbitmq-messaging-topology-operator/tests/test.sh
+++ b/images/rabbitmq-messaging-topology-operator/tests/test.sh
@@ -39,6 +39,15 @@ function certs() {
 
 certs
 
+helm repo add jetstack https://charts.jetstack.io
+
+helm install cert-manager \
+    --namespace cert-manager-rmq-mto \
+    --create-namespace \
+    --set installCRDs=true \
+    --wait \
+    jetstack/cert-manager
+
 CLUSTER_LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/cluster-operator/releases/latest" | jq -r '.tag_name')
 kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/download/${CLUSTER_LATEST}/cluster-operator.yml"
 

--- a/images/rabbitmq-messaging-topology-operator/tests/test.sh
+++ b/images/rabbitmq-messaging-topology-operator/tests/test.sh
@@ -27,7 +27,7 @@ EOF
 manifests
 
 function certs() {
-  openSSL genrsa -out ca.key 2048
+  openssl genrsa -out ca.key 2048
   openssl req -x509 -new -nodes -days 1 -key ca.key -out ca.crt -subj "/CN=testdomain.com"
   openssl req -x509 -nodes -days 1 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=testdomain.com"
   kubectl create namespace rabbitmq-system

--- a/images/rabbitmq-messaging-topology-operator/tests/test.sh
+++ b/images/rabbitmq-messaging-topology-operator/tests/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+function manifests() {
+  # if image tag is latest then find the latest version of the git release
+  LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/messaging-topology-operator/releases/latest" | jq -r '.tag_name')
+
+  cat <<EOF > kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - "https://github.com/rabbitmq/messaging-topology-operator/releases/download/${LATEST}/messaging-topology-operator.yaml"
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: ${RABBITMQ_MESSAGING_TOPOLOGY_OPERATOR_IMAGE}
+    target:
+      version: v1
+      kind: Deployment
+      name:  messaging-topology-operator
+      namespace: rabbitmq-system
+EOF
+}
+
+manifests
+
+function certs() {
+  openSSL genrsa -out ca.key 2048
+  openssl req -x509 -new -nodes -days 1 -key ca.key -out ca.crt -subj "/CN=testdomain.com"
+  openssl req -x509 -nodes -days 1 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=testdomain.com"
+  kubectl create secret webhook-secret-cert -n rabbitmq-system --from-file=./ca.crt --from-file=./tls.crt --from-file=./tls.key
+}
+
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"
+
+
+CLUSTER_LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/cluster-operator/releases/latest" | jq -r '.tag_name')
+kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/download/${CLUSTER_LATEST}/cluster-operator.yml"
+
+kubectl apply -k .
+
+kubectl rollout status --timeout=5m --namespace rabbitmq-system deployment messaging-topology-operator

--- a/images/rabbitmq-messaging-topology-operator/tests/test.sh
+++ b/images/rabbitmq-messaging-topology-operator/tests/test.sh
@@ -62,6 +62,6 @@ kubectl rollout status --timeout=5m --namespace rabbitmq-system deployment messa
 
 kubectl delete -k "${TMPDIR}"
 
-helm uninstall cert-manager-rmq-mto
+helm uninstall cert-manager-rmq-mto -n cert-manager-rmq-mto
 
 rm -rf "${KUSTOMIZE_FILE}" "${CAKEY}" "${CACRT}" "${TLSKEY}" "${TLSCRT}"

--- a/images/rabbitmq-messaging-topology-operator/tests/test.sh
+++ b/images/rabbitmq-messaging-topology-operator/tests/test.sh
@@ -35,6 +35,14 @@ function certs() {
 
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"
 
+helm repo add jetstack https://charts.jetstack.io
+
+helm install cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --set installCRDs=true \
+    --wait \
+    jetstack/cert-manager
 
 CLUSTER_LATEST=$(curl -s "https://api.github.com/repos/rabbitmq/cluster-operator/releases/latest" | jq -r '.tag_name')
 kubectl apply -f "https://github.com/rabbitmq/cluster-operator/releases/download/${CLUSTER_LATEST}/cluster-operator.yml"

--- a/images/rabbitmq-messaging-topology-operator/tests/test.sh
+++ b/images/rabbitmq-messaging-topology-operator/tests/test.sh
@@ -30,10 +30,11 @@ function certs() {
   openSSL genrsa -out ca.key 2048
   openssl req -x509 -new -nodes -days 1 -key ca.key -out ca.crt -subj "/CN=testdomain.com"
   openssl req -x509 -nodes -days 1 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=testdomain.com"
-  kubectl create secret webhook-secret-cert -n rabbitmq-system --from-file=./ca.crt --from-file=./tls.crt --from-file=./tls.key
+  kubectl create namespace rabbitmq-system
+  kubectl create secret generic webhook-server-cert -n rabbitmq-system --from-file=./ca.crt --from-file=./tls.crt --from-file=./tls.key
 }
 
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"
+certs
 
 helm repo add jetstack https://charts.jetstack.io
 

--- a/main.tf
+++ b/main.tf
@@ -898,6 +898,11 @@ module "rabbitmq-cluster-operator" {
   target_repository = "${var.target_repository}/rabbitmq-cluster-operator"
 }
 
+module "rabbitmq-messaging-topology-operator" {
+  source            = "./images/rabbitmq-messaging-topology-operator"
+  target_repository = "${var.target_repository}/rabbitmq-messaging-topology-operator"
+}
+
 module "redis" {
   source            = "./images/redis"
   target_repository = "${var.target_repository}/redis"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [x] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
