### PR TITLE
refactor: improve JRE tests to clean up files/folders

### DIFF
--- a/images/jre/tests/02-hello-world.sh
+++ b/images/jre/tests/02-hello-world.sh
@@ -2,25 +2,25 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail
 
-cat > HelloWorld.java <<EOF
-class HelloWorld {
-  public static void main(String[] args) {
-    System.out.println("Hello, World!");
-  }
-}
-EOF
-
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TMP=$(mktemp -d)
+
+function cleanup() {
+    rm -rf "${TMP}"
+}
+trap cleanup EXIT
+
+cp "${SCRIPT_DIR}"/*.java "${TMP}"
 
 # Make this writeable by the nonroot container user
 chmod 777 "${TMP}"
 
-docker run --rm -v $(pwd)/HelloWorld.java:/src/HelloWorld.java -v "${TMP}:/tmp" \
+docker run --rm -v "${TMP}:/tmp" \
   `# Build using the latest JDK image` \
   --entrypoint "javac" "${SDK_IMAGE}" \
   `# Targeting Java 8 so that all our JREs can run the produced .class file` \
   -source 8 -target 8 \
-  /src/HelloWorld.java -d /tmp
+  /tmp/HelloWorld.java -d /tmp
 
 # Now we have the .class file, run it to test our JRE.
 docker run --rm -v "${TMP}:/tmp" --entrypoint "java" "${IMAGE_NAME}" -cp /tmp HelloWorld

--- a/images/jre/tests/HelloWorld.java
+++ b/images/jre/tests/HelloWorld.java
@@ -1,0 +1,5 @@
+class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}


### PR DESCRIPTION
Refactor the JRE tests to make sure that files created for the test are cleaned up after it finishes and source control the `HelloWorld` class.