### PR TITLE
Add ns randomizer for vault

### DIFF
--- a/images/vault/tests/acceptance.sh
+++ b/images/vault/tests/acceptance.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 # Wait for the pod to be running before we try to unseal, we can't use `kubectl wait` here
 count=0
 limit=40
-while [[ $(kubectl get pods -l app.kubernetes.io/name=vault -n vault-system -o 'jsonpath={..status.phase}') != "Running" ]] && [[ $count -lt $limit ]]; do
+while [[ $(kubectl get pods -l app.kubernetes.io/name=vault -n ${NAMESPACE} -o 'jsonpath={..status.phase}') != "Running" ]] && [[ $count -lt $limit ]]; do
 	sleep 3
 	count=$(($count + 1))
 done
@@ -16,12 +16,12 @@ if [[ $count -eq $limit ]]; then
 fi
 
 # Now unseal vault, which should move it to ready
-kubectl exec -n vault-system vault-0 -- vault operator init \
+kubectl exec -n ${NAMESPACE} ${NAME}-0 -- vault operator init \
 	-key-shares=1 \
 	-key-threshold=1 \
 	-format=json >cluster-keys.json
 
 KEY=$(jq -r ".unseal_keys_b64[]" cluster-keys.json)
-kubectl exec -n vault-system vault-0 -- vault operator unseal $KEY
+kubectl exec -n ${NAMESPACE} ${NAME}-0 -- vault operator unseal $KEY
 
-kubectl wait --for=condition=ready -n vault-system --timeout=120s pod/vault-0
+kubectl wait --for=condition=ready -n ${NAMESPACE} --timeout=120s pod/${NAME}-0

--- a/images/vault/tests/main.tf
+++ b/images/vault/tests/main.tf
@@ -17,9 +17,11 @@ data "oci_string" "ref" {
   input    = each.value
 }
 
+resource "random_pet" "suffix" {}
+
 resource "helm_release" "vault" {
-  name             = "vault"
-  namespace        = "vault-system"
+  name             = "vault-${random_pet.suffix.id}"
+  namespace        = "vault-system-${random_pet.suffix.id}"
   repository       = "https://helm.releases.hashicorp.com"
   chart            = "vault"
   create_namespace = true
@@ -50,6 +52,14 @@ data "oci_exec_test" "acceptance" {
   digest     = var.digests["vault"]
   script     = "${path.module}/acceptance.sh"
   depends_on = [helm_release.vault]
+  env {
+    name  = "NAME"
+    value = "vault-${random_pet.suffix.id}"
+  }
+  env {
+    name  = "NAMESPACE"
+    value = "vault-system-${random_pet.suffix.id}"
+  }
 }
 
 module "helm_cleanup" {


### PR DESCRIPTION
To allow deploying both `vault` and `vault-k8s` in the same time using the Helm chart without `still in use` error.