### PR TITLE
convert argocd to version streamable config

### DIFF
--- a/images/argocd/configs/main.tf
+++ b/images/argocd/configs/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+locals {
+  packages = {
+    "server"      = "argo-cd${var.suffix}"
+    "repo-server" = "argo-cd${var.suffix}-repo-server"
+  }
+}
+
+variable "name" {
+  description = "Package name (e.g. server or repo-server)"
+}
+
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.${var.name}.apko.yaml")
+  extra_packages  = concat(["busybox", local.packages[var.name], "argo-cd${var.suffix}-compat"], var.extra_packages)
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}
+
+output "main_package" {
+  value = local.packages[var.name]
+}

--- a/images/argocd/configs/template.repo-server.apko.yaml
+++ b/images/argocd/configs/template.repo-server.apko.yaml
@@ -1,9 +1,5 @@
 contents:
   packages:
-    - busybox
-    - argo-cd-repo-server
-    - argo-cd-compat
-    - gpg
 
 accounts:
   groups:

--- a/images/argocd/configs/template.server.apko.yaml
+++ b/images/argocd/configs/template.server.apko.yaml
@@ -1,9 +1,5 @@
 contents:
   packages:
-    - busybox
-    - argo-cd
-    - argo-cd-compat
-    - gpg
 
 accounts:
   groups:

--- a/images/argocd/main.tf
+++ b/images/argocd/main.tf
@@ -9,15 +9,22 @@ variable "target_repository" {
 }
 
 locals {
-  components = toset(["argocd", "repo-server"])
+  components = toset(["server", "repo-server"])
+}
+
+module "config" {
+  for_each = local.components
+  source   = "./configs"
+  name     = each.key
 }
 
 module "latest" {
-  for_each          = local.components
-  source            = "../../tflib/publisher"
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
   name              = basename(path.module)
-  target_repository = (each.key == "argocd" ? var.target_repository : "${var.target_repository}-repo-server")
-  config            = file("${path.module}/configs/latest.${each.key}.apko.yaml")
+  target_repository = (each.key == "argo-cd" ? var.target_repository : "${var.target_repository}-repo-server")
+  config            = module.config[each.key].config
   build-dev         = true
 }
 
@@ -27,15 +34,17 @@ module "test-latest" {
 }
 
 resource "oci_tag" "latest" {
-  for_each = module.latest
+  for_each = local.components
 
-  digest_ref = each.value.image_ref
+  digest_ref = module.latest[each.key].image_ref
   tag        = "latest"
+  depends_on = [module.test-latest]
 }
 
 resource "oci_tag" "latest-dev" {
-  for_each = module.latest
+  for_each = local.components
 
-  digest_ref = each.value.dev_ref
+  digest_ref = module.latest[each.key].image_ref
   tag        = "latest-dev"
+  depends_on = [module.test-latest]
 }

--- a/images/argocd/tests/main.tf
+++ b/images/argocd/tests/main.tf
@@ -8,7 +8,7 @@ terraform {
 variable "digests" {
   description = "The image digests to run tests over."
   type = object({
-    argocd      = string
+    server      = string
     repo-server = string
   })
 }
@@ -35,8 +35,8 @@ resource "helm_release" "argocd" {
   values = [
     jsonencode({
       image = {
-        tag        = data.oci_string.ref["argocd"].pseudo_tag
-        repository = data.oci_string.ref["argocd"].registry_repo
+        tag        = data.oci_string.ref["server"].pseudo_tag
+        repository = data.oci_string.ref["server"].registry_repo
       }
       repoServer = {
         image = {
@@ -44,12 +44,31 @@ resource "helm_release" "argocd" {
           repository = data.oci_string.ref["repo-server"].registry_repo
         }
       }
+      # redis-ha = {
+      #   enabled = true
+      #   #   image = {
+      #   #     repository = "cgr.dev/chainguard/redis"
+      #   #     tag        = "latest"
+      #   #   }
+      #   haproxy = {
+      #     image = {
+      #       repository = "k3d-k3d.localhost:5005/cg/haproxy"
+      #       tag        = "2.8@sha256:d9a67188af5cb89f5398399f704e75079a25e241481d22205de38637bd9052c0"
+      #     }
+      #
+      #     containerSecurityContext = {
+      #       capabilities = {
+      #         add = ["NET_BIND_SERVICE"]
+      #       }
+      #     }
+      #   }
+      # }
     }),
   ]
 }
 
-module "helm_cleanup" {
-  source    = "../../../tflib/helm-cleanup"
-  name      = helm_release.argocd.id
-  namespace = helm_release.argocd.namespace
-}
+# module "helm_cleanup" {
+#   source    = "../../../tflib/helm-cleanup"
+#   name      = helm_release.argocd.id
+#   namespace = helm_release.argocd.namespace
+# }


### PR DESCRIPTION
convert argocd module to support version streams.

notable is that this ends up removing `gpg` from `argocd` (not `argocd-repo-server`), which was included erroneously.