### PR TITLE
Add `atlantis` image

### DIFF
--- a/images/atlantis/README.md
+++ b/images/atlantis/README.md
@@ -1,0 +1,29 @@
+<!--monopod:start-->
+# atlantis
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/atlantis` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/atlantis/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimal image for Atlantis.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/atlantis:latest
+```
+
+## Usage
+
+This image is a drop-in replacement for the upstream image. Please refer to the [installation guide](https://www.runatlantis.io/docs/installation-guide.html) for more details.
+
+Atlantis has an [official Helm chart](https://github.com/runatlantis/helm-charts/tree/main), more instructions can be find in the [deployment guide](https://www.runatlantis.io/docs/deployment.html#kubernetes-helm-chart).

--- a/images/atlantis/config/main.tf
+++ b/images/atlantis/config/main.tf
@@ -1,0 +1,38 @@
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  type        = list(string)
+  default     = []
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      # List of packages as runtime dependencies for Atlantis
+      # https://github.com/runatlantis/atlantis/blob/main/Dockerfile#L44
+      packages = concat([
+        "atlantis${var.suffix}",
+        "busybox",
+        "conftest${var.suffix}",
+        "curl",
+        "git",
+        "git-lfs",
+        "openssh-server",
+        "libcap",
+        "dumb-init",
+        "gnupg",
+        "openssl",
+      ], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/atlantis"
+    }
+  })
+}

--- a/images/atlantis/main.tf
+++ b/images/atlantis/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/atlantis/tests/main.tf
+++ b/images/atlantis/tests/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "helm_release" "atlantis" {
+  name       = "runatlantis"
+  repository = "https://runatlantis.github.io/helm-charts"
+  chart      = "atlantis"
+
+  values = [jsonencode({
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = data.oci_string.ref.pseudo_tag
+      pullPolicy = "Always"
+    }
+  })]
+
+  set {
+    name  = "github.user"
+    value = "not_used_tacocat_user"
+  }
+
+  set {
+    name  = "github.token"
+    value = "not_used_tacocat_token"
+  }
+
+  set {
+    name  = "github.secret"
+    value = "not_used_tacocat_shhhh"
+  }
+
+  set {
+    name  = "orgAllowlist"
+    value = "not_used_tacocat_user"
+  }
+}
+
+module "helm_cleanup_atlantis" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.atlantis.id
+  namespace = helm_release.atlantis.namespace
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME version"
+}

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,11 @@ module "aspnet-runtime" {
   target_repository = "${var.target_repository}/aspnet-runtime"
 }
 
+module "atlantis" {
+  source            = "./images/atlantis"
+  target_repository = "${var.target_repository}/atlantis"
+}
+
 module "aws-cli" {
   source            = "./images/aws-cli"
   target_repository = "${var.target_repository}/aws-cli"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documented in the notes section.

Notes: No functional tests at this moment

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
