### PR TITLE
Fix argocd -dev tags

### DIFF
--- a/images/argocd/main.tf
+++ b/images/argocd/main.tf
@@ -44,7 +44,7 @@ resource "oci_tag" "latest" {
 resource "oci_tag" "latest-dev" {
   for_each = local.components
 
-  digest_ref = module.latest[each.key].image_ref
+  digest_ref = module.latest[each.key].dev_ref
   tag        = "latest-dev"
   depends_on = [module.test-latest]
 }


### PR DESCRIPTION
This had been pointing `:latest-dev` to the non-dev image.