### PR TITLE
add default cmd to haproxy

### DIFF
--- a/images/haproxy/configs/latest.apko.yaml
+++ b/images/haproxy/configs/latest.apko.yaml
@@ -28,3 +28,4 @@ paths:
 
 entrypoint:
   command: /usr/local/bin/docker-entrypoint.sh
+cmd: "haproxy -f /usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
match the upstream image for the cases where k8s is running it without any `cmd`

```
➜ crane config haproxy:2.6.14-alpine | jq
...

    "Cmd": [
      "/bin/sh",
      "-c",
      "#(nop) ",
      "CMD [\"haproxy\" \"-f\" \"/usr/local/etc/haproxy/haproxy.cfg\"]"
    ],
    "Image": "sha256:e6ad97047b8546a6d81d7e99ea2363ca36f219323869f6b4e87105f6942ab7be",
    "Volumes": null,
    "WorkingDir": "",
    "Entrypoint": [
      "docker-entrypoint.sh"
    ],
```