### PR TITLE
feat: expose javac source/target vars in Terraform

### DIFF
--- a/images/jre/tests/main.tf
+++ b/images/jre/tests/main.tf
@@ -8,6 +8,18 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
+variable "java-source-version" {
+  type        = number
+  description = "The Java source version to use for compilation in this test."
+  default     = 8
+}
+
+variable "java-target-version" {
+  type        = number
+  description = "The Java target version to use for compilation in this test."
+  default     = 8
+}
+
 variable "sdk-image" {
   description = "The SDK image to use for building the java application."
   default     = "cgr.dev/chainguard/jdk"
@@ -24,5 +36,13 @@ data "oci_exec_test" "hello-world" {
   env {
     name  = "SDK_IMAGE"
     value = var.sdk-image
+  }
+  env {
+    name  = "JAVA_SOURCE_VERSION"
+    value = var.java-source-version
+  }
+  env {
+    name  = "JAVA_TARGET_VERSION"
+    value = var.java-target-version
   }
 }


### PR DESCRIPTION
Expose the source and target environment variables in Terraform so the test can have source and target levels specified other than the original 8.