### PR TITLE
Create trino:latest image

### DIFF
--- a/images/trino/README.md
+++ b/images/trino/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# trino
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/trino` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/trino/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/trino/README.md
+++ b/images/trino/README.md
@@ -11,3 +11,27 @@
 
 ---
 <!--monopod:end-->
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/trino
+```
+
+## Usage
+
+There is a TrinoDB Helm Chart exists, [here](https://github.com/trinodb/charts), which makes it easy to deploy TrinoDB on Kubernetes.
+
+Here is the command that can be used to deploy TrinoDB on Kubernetes:
+
+```
+helm repo add trino https://trinodb.github.io/charts
+helm repo update
+helm install trino trino/trino \
+      --set image.repository=cgr.dev/chainguard/trino
+```
+
+That's it, now, you have TrinoDB running on Kubernetes.
+

--- a/images/trino/config/main.tf
+++ b/images/trino/config/main.tf
@@ -1,0 +1,85 @@
+variable "extra_packages" {
+  description = "The additional packages to install"
+  type        = list(string)
+  default     = ["trino"]
+}
+
+variable "extra_plugins" {
+  description = "The additional packages to install"
+  type        = list(string)
+  default = [
+    "trino-plugin-memory",
+    "trino-plugin-jmx",
+    "trino-plugin-tpcds",
+    "trino-plugin-tpch",
+    "trino-plugin-exchange-hdfs",
+    "trino-plugin-exchange-filesystem",
+    "trino-plugin-delta-lake",
+    "trino-plugin-redis",
+    "trino-plugin-kafka",
+    "trino-plugin-resource-group-managers",
+    "trino-plugin-blackhole",
+    "trino-plugin-elasticsearch",
+    "trino-plugin-geospatial",
+    "trino-plugin-hive",
+    "trino-plugin-http-event-listener",
+    "trino-plugin-local-file",
+    "trino-plugin-password-authenticators",
+    "trino-plugin-postgresql",
+    "trino-plugin-prometheus",
+    "trino-plugin-example-http",
+    "trino-plugin-mysql",
+    "trino-plugin-mysql-event-listener",
+    "trino-plugin-sqlserver",
+  ]
+}
+
+variable "packages" {
+  # https://github.com/runatlantis/atlantis/blob/main/Dockerfile#L44
+  description = "List of packages as runtime dependencies for Atlantis"
+  type        = list(string)
+  default = [
+    "trino-oci-entrypoint",
+    "busybox",
+  ]
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  name   = "trino"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(var.packages, var.extra_packages, var.extra_plugins)
+    }
+    accounts = module.accts.block
+    paths = [{
+      path        = "/usr/lib/trino/"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 493 // 0o755
+      recursive   = true
+      }, {
+
+      path        = "/etc/trino/"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 493 // 0o755
+      recursive   = true
+      }, {
+      path        = "/data/trino"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 511 // 0o777
+      recursive   = true
+    }]
+    entrypoint = {
+      command = "/usr/bin/run-trino"
+    }
+  })
+}

--- a/images/trino/config/main.tf
+++ b/images/trino/config/main.tf
@@ -35,7 +35,6 @@ variable "extra_plugins" {
 }
 
 variable "packages" {
-  # https://github.com/runatlantis/atlantis/blob/main/Dockerfile#L44
   description = "List of packages as runtime dependencies for Atlantis"
   type        = list(string)
   default = [

--- a/images/trino/main.tf
+++ b/images/trino/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/trino/tests/container-test.sh
+++ b/images/trino/tests/container-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Source: https://github.com/trinodb/trino/blob/master/core/docker/container-test.sh
+
+function cleanup {
+    if [[ -n ${CONTAINER_ID:-} ]]; then
+        docker rm -f "${CONTAINER_ID}"
+    fi
+}
+
+function test_trino_starts {
+    local QUERY_PERIOD=10
+    local QUERY_RETRIES=90
+
+    CONTAINER_ID=
+    trap cleanup EXIT
+
+    local CONTAINER_NAME=$1
+    # We aren't passing --rm here to make sure container is available for inspection in case of failures
+    CONTAINER_ID=$(docker run -d --health-interval=10s --health-timeout=5s --health-start-period=10s --health-cmd /usr/lib/trino/bin/health-check "${CONTAINER_NAME}")
+
+    set +e
+    I=0
+    until docker inspect "${CONTAINER_ID}" --format "{{json .State.Health.Status }}" | grep -q '"healthy"'; do
+        if [[ $((I++)) -ge ${QUERY_RETRIES} ]]; then
+            echo "🚨 Too many retries waiting for Trino to start" >&2
+            echo "Logs from ${CONTAINER_ID} follow..."
+            docker logs "${CONTAINER_ID}"
+            break
+        fi
+        sleep ${QUERY_PERIOD}
+    done
+    if ! RESULT=$(docker exec "${CONTAINER_ID}" trino --execute "SELECT 'success'" 2>/dev/null); then
+        echo "🚨 Failed to execute a query after Trino container started" >&2
+    fi
+    set -e
+
+    cleanup
+    trap - EXIT
+
+    if ! [[ ${RESULT} == '"success"' ]]; then
+        echo "🚨 Test query didn't return expected result (\"success\"): [${RESULT}]" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+function test_javahome {
+    local CONTAINER_NAME=$1    # Check if JAVA_HOME works
+    docker run --rm "${CONTAINER_NAME}" \
+        /bin/bash -c '$JAVA_HOME/bin/java -version' &>/dev/null
+
+    [[ $? == "0" ]]
+}
+
+echo "🐢 Validating ${IMAGE_NAME}"
+test_javahome "${IMAGE_NAME}"
+test_trino_starts "${IMAGE_NAME}"
+echo "🎉 Validated ${IMAGE_NAME}"

--- a/images/trino/tests/main.tf
+++ b/images/trino/tests/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "oci_exec_test" "help" {
+  digest = var.digest
+  script = "${path.module}/container-test.sh"
+}
+
+resource "helm_release" "trino" {
+  repository       = "https://trinodb.github.io/charts/"
+  name             = "trino"
+  chart            = "trino"
+  namespace        = "trino"
+  create_namespace = true
+  timeout          = 900
+
+  values = [jsonencode({
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = data.oci_string.ref.pseudo_tag
+    }
+    server = {
+      workers = 1
+    }
+  })]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.trino.id
+  namespace = helm_release.trino.namespace
+}

--- a/images/trino/tests/main.tf
+++ b/images/trino/tests/main.tf
@@ -20,7 +20,7 @@ resource "random_pet" "suffix" {}
 
 resource "helm_release" "trino" {
   repository       = "https://trinodb.github.io/charts/"
-  name             = "trino"
+  name             = "trino-${random_pet.suffix.id}"
   chart            = "trino"
   namespace        = "trino-${random_pet.suffix.id}"
   create_namespace = true

--- a/images/trino/tests/main.tf
+++ b/images/trino/tests/main.tf
@@ -16,11 +16,13 @@ data "oci_exec_test" "help" {
   script = "${path.module}/container-test.sh"
 }
 
+resource "random_pet" "suffix" {}
+
 resource "helm_release" "trino" {
   repository       = "https://trinodb.github.io/charts/"
   name             = "trino"
   chart            = "trino"
-  namespace        = "trino"
+  namespace        = "trino-${random_pet.suffix.id}"
   create_namespace = true
   timeout          = 900
 

--- a/main.tf
+++ b/main.tf
@@ -1022,6 +1022,11 @@ module "trillian" {
   target_repository = "${var.target_repository}/trillian"
 }
 
+module "trino" {
+  source            = "./images/trino"
+  target_repository = "${var.target_repository}/trino"
+}
+
 module "trust-manager" {
   source            = "./images/trust-manager"
   target_repository = "${var.target_repository}/trust-manager"

--- a/tflib/accts/main.tf
+++ b/tflib/accts/main.tf
@@ -32,3 +32,19 @@ output "block" {
     run-as = var.run-as
   }
 }
+
+output "name" {
+  value = var.name
+}
+
+output "uid" {
+  value = var.uid
+}
+
+output "gid" {
+  value = var.gid
+}
+
+output "run-as" {
+  value = var.run-as
+}


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes: The CVEs left cannot be fixed due to shaded JARs (JARs that embed their transitive deps)

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [x] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
