### PR TITLE
istio test: don't install CRD validation webhook

### DIFF
--- a/images/istio/tests/main.tf
+++ b/images/istio/tests/main.tf
@@ -76,6 +76,8 @@ resource "helm_release" "base" {
     global = {
       istioNamespace = local.namespace
     }
+    # Disable the CRD validation webhook to avoid contention w/ tests of other versions,
+    # as this is a cluster-wide resource that we can't customize the name.
     defaultRevision = ""
   })]
 }

--- a/images/istio/tests/main.tf
+++ b/images/istio/tests/main.tf
@@ -76,6 +76,7 @@ resource "helm_release" "base" {
     global = {
       istioNamespace = local.namespace
     }
+    defaultRevision = ""
   })]
 }
 


### PR DESCRIPTION
This is a cluster resource with non-customizable name. It interferes with running multiple Istio tests in parallel in the same cluster.

See https://github.com/istio/istio/blob/master/manifests/charts/base/templates/default.yaml 