### PR TITLE
Add cilium-hubble-ui and cilium-hubble-ui images

### DIFF
--- a/images/cilium/configs/hubble-ui-backend/main.tf
+++ b/images/cilium/configs/hubble-ui-backend/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. gops, cilium-operator-generic...)"
+  default = [
+    "hubble-ui-backend",
+    "gops"
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/cilium/configs/hubble-ui-backend/template.apko.yaml
+++ b/images/cilium/configs/hubble-ui-backend/template.apko.yaml
@@ -1,0 +1,27 @@
+contents:
+  packages: [
+    # hubble-ui-backend and gops come from extra_packages
+  ]
+
+accounts:
+  groups:
+    - groupname: hubble-ui-backend
+      gid: 65532
+  users:
+    - username: hubble-ui-backend
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/backend
+
+environment:
+  GOPS_CONFIG_DIR: /etc/hubble-ui/gops
+
+paths:
+  - path: /etc/hubble-ui/gops
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755

--- a/images/cilium/configs/hubble-ui/main.tf
+++ b/images/cilium/configs/hubble-ui/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. hubble-ui...)"
+  default = [
+    "hubble-ui"
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/cilium/configs/hubble-ui/template.apko.yaml
+++ b/images/cilium/configs/hubble-ui/template.apko.yaml
@@ -1,0 +1,62 @@
+contents:
+  # hubble-ui comes from extra_packages
+  packages:
+    - nginx
+
+accounts:
+  groups:
+    - groupname: nginx
+      gid: 65532
+  users:
+    - username: nginx
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+paths:
+  - path: /s6
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/lib/nginx
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /run/nginx
+    uid: 65532
+    gid: 65532
+    type: directory
+    permissions: 0o755
+    recursive: true
+  - path: /var/log/nginx
+    uid: 65532
+    gid: 65532
+    type: directory
+    permissions: 0o755
+    recursive: true
+  - path: /var/lib/nginx/tmp
+    uid: 65532
+    gid: 65532
+    type: directory
+    permissions: 0o755
+    recursive: true
+  - path: /etc/nginx
+    uid: 65532
+    gid: 65532
+    type: directory
+    permissions: 0o755
+    recursive: true
+  - path: /etc/frontend
+    uid: 65532
+    gid: 65532
+    type: directory
+    permissions: 0o755
+    recursive: true
+
+entrypoint:
+  type: service-bundle
+  services:
+    nginx: /usr/sbin/nginx -c /etc/frontend/nginx.conf -g "daemon off;"

--- a/images/cilium/hubble-ui-backend.tf
+++ b/images/cilium/hubble-ui-backend.tf
@@ -1,0 +1,11 @@
+module "hubble-ui-backend-config" { source = "./configs/hubble-ui-backend" }
+
+module "hubble-ui-backend" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-hubble-ui-backend"
+  config            = module.hubble-ui-backend-config.config
+  build-dev         = true
+}

--- a/images/cilium/hubble-ui.tf
+++ b/images/cilium/hubble-ui.tf
@@ -1,0 +1,11 @@
+module "hubble-ui-config" { source = "./configs/hubble-ui" }
+
+module "hubble-ui" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-hubble-ui"
+  config            = module.hubble-ui-config.config
+  build-dev         = true
+}

--- a/images/cilium/main.tf
+++ b/images/cilium/main.tf
@@ -11,9 +11,11 @@ variable "target_repository" {
 module "test-latest" {
   source = "./tests"
   digests = {
-    agent        = module.agent.image_ref
-    hubble-relay = module.hubble-relay.image_ref
-    operator     = module.operator.image_ref
+    agent             = module.agent.image_ref
+    hubble-relay      = module.hubble-relay.image_ref
+    hubble-ui         = module.hubble-ui.image_ref
+    hubble-ui-backend = module.hubble-ui-backend.image_ref
+    operator          = module.operator.image_ref
   }
 }
 
@@ -22,6 +24,8 @@ resource "oci_tag" "latest" {
   for_each = {
     "agent" : module.agent.image_ref
     "hubble-relay" : module.hubble-relay.image_ref
+    "hubble-ui" : module.hubble-ui.image_ref
+    "hubble-ui-backend" : module.hubble-ui-backend.image_ref
     "operator" : module.operator.image_ref
   }
   digest_ref = each.value
@@ -33,6 +37,8 @@ resource "oci_tag" "latest-dev" {
   for_each = {
     "agent" : module.agent.dev_ref
     "hubble-relay" : module.hubble-relay.dev_ref
+    "hubble-ui" : module.hubble-ui.dev_ref
+    "hubble-ui-backend" : module.hubble-ui-backend.dev_ref
     "operator" : module.operator.dev_ref
   }
   digest_ref = each.value

--- a/images/cilium/tests/cilium-install.sh
+++ b/images/cilium/tests/cilium-install.sh
@@ -63,9 +63,12 @@ rm cilium-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
 
 # Install cilium
 $TMPDIR/cilium install --context k3d-$CLUSTER_NAME \
+    --helm-set hubble.relay.enabled=true \
+    --helm-set hubble.ui.enabled=true \
     --helm-set image.override=$AGENT_IMAGE \
     --helm-set hubble.relay.image.override=$HUBBLE_RELAY_IMAGE \
-    --helm-set hubble.relay.enabled=true \
+    --helm-set hubble.ui.image.override=$HUBBLE_UI_IMAGE \
+    --helm-set hubble.ui.backend.image.override=$HUBBLE_UI_BACKEND_IMAGE \
     --helm-set operator.image.override=$OPERATOR_IMAGE
 
 $TMPDIR/cilium status --context k3d-$CLUSTER_NAME --wait

--- a/images/cilium/tests/main.tf
+++ b/images/cilium/tests/main.tf
@@ -7,9 +7,11 @@ terraform {
 variable "digests" {
   description = "The digests to run tests over."
   type = object({
-    agent        = string
-    operator     = string
-    hubble-relay = string
+    agent             = string
+    hubble-relay      = string
+    hubble-ui         = string
+    hubble-ui-backend = string
+    operator          = string
   })
 }
 
@@ -22,18 +24,20 @@ data "oci_exec_test" "cilium-install" {
   script          = "${path.module}/cilium-install.sh"
   digest          = var.digests.agent
   timeout_seconds = 900
-  env {
+  env = [{
     name  = "AGENT_IMAGE"
     value = var.digests.agent
-  }
-
-  env {
-    name  = "OPERATOR_IMAGE"
-    value = var.digests.operator
-  }
-
-  env {
+    }, {
     name  = "HUBBLE_RELAY_IMAGE"
     value = var.digests.hubble-relay
-  }
+    }, {
+    name  = "HUBBLE_UI_IMAGE"
+    value = var.digests.hubble-ui
+    }, {
+    name  = "HUBBLE_UI_BACKEND_IMAGE"
+    value = var.digests.hubble-ui-backend
+    }, {
+    name  = "OPERATOR_IMAGE"
+    value = var.digests.operator
+  }]
 }


### PR DESCRIPTION
## Chainguard Images Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
