### PR TITLE
new image: tomcat

### DIFF
--- a/images/tomcat/README.md
+++ b/images/tomcat/README.md
@@ -1,0 +1,60 @@
+<!--monopod:start-->
+# tomcat
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/tomcat` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/tomcat/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/tomcat:latest
+```
+
+## Usage
+
+To run the `tomcat` program:
+
+```shell
+% docker run cgr.dev/chainguard/tomcat:latest
+02-Oct-2023 19:08:45.331 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Server version name:   Apache Tomcat/10.1.13
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Server built:          Sep 20 2023 18:44:35 UTC
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Server version number: 10.1.13.0
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log OS Name:               Linux
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log OS Version:            6.3.13-linuxkit
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Architecture:          aarch64
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Java Home:             /usr/lib/jvm/java-17-openjdk
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log JVM Version:           17.0.9+7-wolfi-r0
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log JVM Vendor:            wolfi
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log CATALINA_BASE:         /usr/share/tomcat
+02-Oct-2023 19:08:45.333 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log CATALINA_HOME:         /usr/share/tomcat
+02-Oct-2023 19:08:45.337 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+02-Oct-2023 19:08:45.337 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
+02-Oct-2023 19:08:45.337 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djdk.tls.ephemeralDHKeySize=2048
+02-Oct-2023 19:08:45.337 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+02-Oct-2023 19:08:45.337 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
+02-Oct-2023 19:08:45.337 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.lang=ALL-UNNAMED
+02-Oct-2023 19:08:45.338 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.io=ALL-UNNAMED
+02-Oct-2023 19:08:45.338 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.util=ALL-UNNAMED
+02-Oct-2023 19:08:45.338 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+02-Oct-2023 19:08:45.338 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
+02-Oct-2023 19:08:45.338 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Dcatalina.base=/usr/local/tomcat
+02-Oct-2023 19:08:45.338 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Dcatalina.home=/usr/local/tomcat
+02-Oct-2023 19:08:45.338 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Command line argument: -Djava.io.tmpdir=/usr/local/tomcat/temp
+02-Oct-2023 19:08:45.339 INFO [main] org.apache.catalina.core.AprLifecycleListener.lifecycleEvent The Apache Tomcat Native library which allows using OpenSSL was not found on the java.library.path: [/usr/lib:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib]
+02-Oct-2023 19:08:45.461 INFO [main] org.apache.coyote.AbstractProtocol.init Initializing ProtocolHandler ["http-nio-8080"]
+02-Oct-2023 19:08:45.473 INFO [main] org.apache.catalina.startup.Catalina.load Server initialization in [223] milliseconds
+02-Oct-2023 19:08:45.496 INFO [main] org.apache.catalina.core.StandardService.startInternal Starting service [Catalina]
+02-Oct-2023 19:08:45.496 INFO [main] org.apache.catalina.core.StandardEngine.startInternal Starting Servlet engine: [Apache Tomcat/10.1.13]
+02-Oct-2023 19:08:45.501 INFO [main] org.apache.coyote.AbstractProtocol.start Starting ProtocolHandler ["http-nio-8080"]
+02-Oct-2023 19:08:45.508 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in [35] milliseconds

--- a/images/tomcat/config/main.tf
+++ b/images/tomcat/config/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. elasticsearch-7)."
+  default = [
+    "openjdk-17",
+    "openjdk-17-default-jvm",
+    "tomcat-native",
+    "tomcat-10"
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/tomcat/config/main.tf
+++ b/images/tomcat/config/main.tf
@@ -5,13 +5,18 @@ terraform {
 }
 
 variable "extra_packages" {
-  description = "The additional packages to install (e.g. elasticsearch-7)."
+  description = "The additional packages to install (e.g. tomcat-10)."
   default = [
+    "tomcat-10",
+    "tomcat-native",
     "openjdk-17",
     "openjdk-17-default-jvm",
-    "tomcat-native",
-    "tomcat-10"
   ]
+}
+
+variable "java_home" {
+  description = "The JAVA_HOME environment variable."
+  default     = "/usr/lib/jvm/java-17-openjdk"
 }
 
 data "apko_config" "this" {
@@ -20,5 +25,9 @@ data "apko_config" "this" {
 }
 
 output "config" {
-  value = jsonencode(data.apko_config.this.config)
+  value = jsonencode(merge(data.apko_config.this.config, {
+    environment : {
+      "JAVA_HOME" : var.java_home
+    }
+  }))
 }

--- a/images/tomcat/config/template.apko.yaml
+++ b/images/tomcat/config/template.apko.yaml
@@ -1,0 +1,77 @@
+contents:
+  packages:
+    - bash
+    - busybox
+    # tomcat and openjdk provided by extra_packages
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+paths:
+  - path: /usr/share/tomcat/conf
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/share/tomcat/lib
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/share/tomcat/bin
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/share/tomcat/logs
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/share/tomcat/temp
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/share/tomcat/work
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/share/tomcat/webapps
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/local/tomcat
+    type: symlink
+    source: /usr/share/tomcat
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
+
+environment:
+  JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+  PATH: /usr/local/tomcat/bin:/usr/sbin:/sbin:/usr/bin:/bin
+  CATALINA_HOME: /usr/local/tomcat
+  LD_LIBRARY_PATH: /usr/lib/tomcat-native
+
+entrypoint:
+  command: catalina.sh run
+
+work-dir: /usr/local/tomcat

--- a/images/tomcat/config/template.apko.yaml
+++ b/images/tomcat/config/template.apko.yaml
@@ -66,12 +66,12 @@ paths:
     recursive: true
 
 environment:
-  JAVA_HOME: /usr/lib/jvm/java-11-openjdk
   PATH: /usr/local/tomcat/bin:/usr/sbin:/sbin:/usr/bin:/bin
   CATALINA_HOME: /usr/local/tomcat
   LD_LIBRARY_PATH: /usr/lib/tomcat-native
 
 entrypoint:
-  command: catalina.sh run
+  command: /usr/local/tomcat/bin/catalina.sh
+cmd: run
 
 work-dir: /usr/local/tomcat

--- a/images/tomcat/main.tf
+++ b/images/tomcat/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+  main_package      = "tomcat-10"
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}

--- a/images/tomcat/tests/main.tf
+++ b/images/tomcat/tests/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+variable "war_url" {
+  description = "The URL to the WAR file to deploy."
+  default     = "https://tomcat.apache.org/tomcat-10.0-doc/appdev/sample/sample.war"
+}
+
+data "oci_exec_test" "run" {
+  digest = var.digest
+  script = "${path.module}/run.sh"
+  env {
+    name  = "WAR_URL"
+    value = var.war_url
+  }
+}
+
+data "oci_exec_test" "smoke" {
+  digest = var.digest
+  script = "${path.module}/smoke.sh"
+  env {
+    name  = "WAR_URL"
+    value = var.war_url
+  }
+}

--- a/images/tomcat/tests/run.sh
+++ b/images/tomcat/tests/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+TMPDIR="$(mktemp -d)"
+
+function cleanup() {
+    rm -rf "$TMPDIR"
+}
+
+trap cleanup EXIT
+
+WAR_URL=${WAR_URL:-https://tomcat.apache.org/tomcat-10.0-doc/appdev/sample/sample.war}
+
+curl -sSL -o "${TMPDIR}/sample.war" ${WAR_URL}
+
+CONTAINER=$(docker run -v "${TMPDIR}/sample.war:/usr/share/tomcat/webapps/sample.war" -p "${FREE_PORT}:8080" -d --rm "${IMAGE_NAME}")
+sleep 3
+curl "localhost:${FREE_PORT}/sample/" | grep "Hello, World"
+docker stop $CONTAINER

--- a/images/tomcat/tests/smoke.sh
+++ b/images/tomcat/tests/smoke.sh
@@ -3,9 +3,11 @@
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 TMPDIR="$(mktemp -d)"
-NS="tomcat-10"
+NS="tomcat-${FREE_PORT}"
 
 function cleanup() {
+    kubectl describe deployment -n ${NS} -A
+    kubectl logs -n ${NS} -l app=tomcat
     kubectl delete configmap/sample-war-configmap -n ${NS}
     kubectl delete -f ${TMPDIR}/deployment.yaml -n ${NS}
     rm -rf "$TMPDIR"

--- a/images/tomcat/tests/smoke.sh
+++ b/images/tomcat/tests/smoke.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+TMPDIR="$(mktemp -d)"
+NS="tomcat-10"
+
+function cleanup() {
+    kubectl delete configmap/sample-war-configmap -n ${NS}
+    kubectl delete -f ${TMPDIR}/deployment.yaml -n ${NS}
+    rm -rf "$TMPDIR"
+}
+
+trap cleanup EXIT
+
+cat <<EOF > "${TMPDIR}/ns.yaml"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NS}
+EOF
+
+WAR_URL=${WAR_URL:-https://tomcat.apache.org/tomcat-10.0-doc/appdev/sample/sample.war}
+
+curl -sSL -o "${TMPDIR}/sample.war" "${WAR_URL}"
+
+kubectl apply -f "${TMPDIR}/ns.yaml"
+
+kubectl create configmap sample-war-configmap -n ${NS} --from-file=sample.war=${TMPDIR}/sample.war
+
+cat <<EOF > "${TMPDIR}/deployment.yaml"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tomcat-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tomcat
+  template:
+    metadata:
+      labels:
+        app: tomcat
+    spec:
+      containers:
+      - name: tomcat
+        image: ${IMAGE_NAME}
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: sample-war
+          mountPath: /usr/local/tomcat/webapps/sample.war
+          subPath: sample.war
+      volumes:
+      - name: sample-war
+        configMap:
+          name: sample-war-configmap
+          items:
+          - key: sample.war
+            path: sample.war
+
+EOF
+
+kubectl apply -f "${TMPDIR}/deployment.yaml" -n ${NS}
+
+# Wait for the deployment to be ready
+kubectl rollout status deployment/tomcat-deployment -n ${NS} --timeout=300s
+
+# Port forward to the deployment
+kubectl port-forward deployment/tomcat-deployment -n ${NS} ${FREE_PORT}:8080 &
+
+pid=$!
+echo "Port-forward PID: $pid"
+trap "echo 'Killing port-forward'; kill $pid" EXIT
+
+sleep 10
+curl localhost:${FREE_PORT}/sample/ | grep "Hello"

--- a/main.tf
+++ b/main.tf
@@ -1017,6 +1017,11 @@ module "timoni" {
   target_repository = "${var.target_repository}/timoni"
 }
 
+module "tomcat" {
+  source            = "./images/tomcat"
+  target_repository = "${var.target_repository}/tomcat"
+}
+
 module "traefik" {
   source            = "./images/traefik"
   target_repository = "${var.target_repository}/traefik"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

```
imgsize ttl.sh/jason/tomcat@sha256:a4c3e5e95f4e289d24211fd1c2a4978748763d41cd3d78c865fc02951c418b8f 
89M

imgsize tomcat
210M
```

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

```
NAME         INSTALLED  FIXED-IN  TYPE          VULNERABILITY  SEVERITY 
tomcat-jdbc  10.1.15              java-archive  CVE-2016-6325  High      
tomcat-jdbc  10.1.15              java-archive  CVE-2016-5425  High
```

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [x] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
