### PR TITLE
use default JAVA_HOME

### DIFF
--- a/images/bazel/config/template.apko.yaml
+++ b/images/bazel/config/template.apko.yaml
@@ -26,6 +26,6 @@ entrypoint:
   command: /usr/bin/bazel
 
 environment:
-  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+  JAVA_HOME: /usr/lib/jvm/default-jvm
 
 work-dir: /home/bazel

--- a/images/gradle/config/main.tf
+++ b/images/gradle/config/main.tf
@@ -9,20 +9,11 @@ variable "extra_packages" {
   default     = []
 }
 
-variable "java_home" {
-  description = "The JAVA_HOME environment variable."
-  default     = "/usr/lib/jvm/java-17-openjdk"
-}
-
 data "apko_config" "this" {
   config_contents = file("${path.module}/template.apko.yaml")
   extra_packages  = var.extra_packages
 }
 
 output "config" {
-  value = jsonencode(merge(data.apko_config.this.config, {
-    environment : {
-      "JAVA_HOME" : var.java_home
-    }
-  }))
+  value = jsonencode(data.apko_config.this.config)
 }

--- a/images/opensearch/config/template.apko.yaml
+++ b/images/opensearch/config/template.apko.yaml
@@ -22,7 +22,7 @@ paths:
     recursive: true
 
 environment:
-  JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+  JAVA_HOME: /usr/lib/jvm/default-jvm
 
 entrypoint:
   command: /usr/bin/docker-entrypoint.sh

--- a/images/tomcat/config/main.tf
+++ b/images/tomcat/config/main.tf
@@ -14,20 +14,11 @@ variable "extra_packages" {
   ]
 }
 
-variable "java_home" {
-  description = "The JAVA_HOME environment variable."
-  default     = "/usr/lib/jvm/java-17-openjdk"
-}
-
 data "apko_config" "this" {
   config_contents = file("${path.module}/template.apko.yaml")
   extra_packages  = var.extra_packages
 }
 
 output "config" {
-  value = jsonencode(merge(data.apko_config.this.config, {
-    environment : {
-      "JAVA_HOME" : var.java_home
-    }
-  }))
+  value = jsonencode(data.apko_config.this.config)
 }

--- a/images/tomcat/config/template.apko.yaml
+++ b/images/tomcat/config/template.apko.yaml
@@ -67,6 +67,7 @@ paths:
 
 environment:
   PATH: /usr/local/tomcat/bin:/usr/sbin:/sbin:/usr/bin:/bin
+  JAVA_HOME: /usr/lib/jvm/default-jvm
   CATALINA_HOME: /usr/local/tomcat
   LD_LIBRARY_PATH: /usr/lib/tomcat-native
 

--- a/images/zookeeper/config/template.apko.yaml
+++ b/images/zookeeper/config/template.apko.yaml
@@ -48,8 +48,8 @@ paths:
     gid: 1001
     permissions: 0o755
     recursive: true
-    
+
 environment:
   LANG: en_US.UTF-8
-  JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+  JAVA_HOME: /usr/lib/jvm/default-jvm
   BITNAMI_APP_NAME: zookeeper


### PR DESCRIPTION
The default-jvm package provides the correct Java at a constant path, which means we don't need to update JAVA_HOME to point to the versioned path.

Draft to see tests pass.