### PR TITLE
re-add JAVA_HOME for gradle image

### DIFF
--- a/images/gradle/config/template.apko.yaml
+++ b/images/gradle/config/template.apko.yaml
@@ -21,6 +21,7 @@ entrypoint:
 
 environment:
   LANG: en_US.UTF-8
+  JAVA_HOME: /usr/lib/jvm/default-jvm
 
 paths:
   - path: /home/build


### PR DESCRIPTION
This was dropped in https://github.com/chainguard-images/images/pull/1749