### PR TITLE
pulumi: unpin the versions used in python sdk test

### DIFF
--- a/images/pulumi/examples/smoketest-python/requirements.txt
+++ b/images/pulumi/examples/smoketest-python/requirements.txt
@@ -1,2 +1,2 @@
-pulumi==3.66.0
-pulumi-kubernetes==3.26.0
+pulumi
+pulumi-kubernetes


### PR DESCRIPTION
The versions in the test are very outdated.