### PR TITLE
Rely on the trap to kill port-forward

### DIFF
--- a/images/external-dns/tests/e2e.sh
+++ b/images/external-dns/tests/e2e.sh
@@ -188,5 +188,4 @@ for i in {1..10}; do
   sleep 5
 done
 
-kill -9 $fwd_pid
 [[ "$digged" == "$ip" ]] || exit 1


### PR DESCRIPTION
I noticed we were trying to cleanup the same PID in a test that ended up hanging:
```
  + kill -9 454251
  + [[ 42.42.42.42 == \4\2\.\4\2\.\4\2\.\4\2 ]]
  + cleanup_pid
  + kill -9 454251
```