### PR TITLE
: add argo-workflows

### DIFF
--- a/images/argo/README.md
+++ b/images/argo/README.md
@@ -1,0 +1,81 @@
+<!--monopod:start-->
+# argo
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/argo` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/argo/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+[argo](https://argoproj.github.io/argo-workflows/) Workflow Engine for Kubernetes
+
+
+## Get It!
+
+The images available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/argo-exec
+docker pull cgr.dev/chainguard/argo-cli
+docker pull cgr.dev/chainguard/argo-workflowcontroller
+```
+
+## Using argo
+
+Argo provides two upstream methods for installing, helm, and raw manifests.
+
+The Chainguard Images for Argo are designed to be a drop in replacement for either method. To use them, simply replace the appropriate `image:` path with the Chainguard specific Argo image. Below is an example values file for doing this with helm:
+
+```yaml
+
+images:
+  tag: "latest"
+controller:
+  image:
+    # -- Registry to use for the controller
+    registry: cgr.dev
+    # -- Registry to use for the controller
+    repository: chainguard/argo-workflow-controller
+executor:
+  image:
+    # -- Registry to use for the Workflow Executors
+    registry: cgr.dev
+    # -- Repository to use for the Workflow Executors
+    repository: chainguard/argo-exec
+server:
+  # -- Deploy the Argo Server
+  image:
+    # -- Registry to use for the server
+    registry: cgr.dev
+    # -- Repository to use for the server
+    repository: chainguard/argo-cli
+```
+
+Using the above values, the helm commands become:
+
+```bash
+helm repo add argo https://argoproj.github.io/argo-helm
+
+helm install argo-workflows argo/argo-workflows \
+	--namespace argo-workflows \
+	--create-namespace \
+	--set images.tag="latest" \
+	--set global.image.tag="latest" \
+  --set controller.image.registry="cgr.dev" \
+  --set controller.image.repository="chainguard/argo-workflow-controller" \
+  --set executor.image.registry="cgr.dev" \
+  --set executor.image.repository="chainguard/argo-exec" \
+  --set server.image.registry="cgr.dev" \
+  --set server.image.repository="chainguard/argo-cli"
+```
+
+
+> NOTE: Setting the tag to "latest" is not recommended, and only shown for illustrative purposes.
+
+
+ 

--- a/images/argo/cli.tf
+++ b/images/argo/cli.tf
@@ -1,0 +1,11 @@
+module "cli-config" { source = "./configs/cli" }
+
+module "cli" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-cli"
+  config            = module.cli-config.config
+  build-dev         = true
+}

--- a/images/argo/configs/cli/main.tf
+++ b/images/argo/configs/cli/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install "
+
+  default = [
+    "argo-workflows-known-hosts"
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/argo/configs/cli/template.apko.yaml
+++ b/images/argo/configs/cli/template.apko.yaml
@@ -1,0 +1,15 @@
+contents:
+  packages:
+    - argo-workflow-cli
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+entrypoint:
+  command: argo

--- a/images/argo/configs/exec/main.tf
+++ b/images/argo/configs/exec/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install "
+
+  default = [
+    "argo-workflows-known-hosts"
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/argo/configs/exec/template.apko.yaml
+++ b/images/argo/configs/exec/template.apko.yaml
@@ -1,0 +1,16 @@
+contents:
+  packages:
+    - argo-workflow-executor
+    - argo-workflow-executor-compat
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+entrypoint:
+  command: argoexec

--- a/images/argo/configs/workflowcontroller/main.tf
+++ b/images/argo/configs/workflowcontroller/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install "
+
+  default = [
+    "argo-workflows-known-hosts"
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/argo/configs/workflowcontroller/template.apko.yaml
+++ b/images/argo/configs/workflowcontroller/template.apko.yaml
@@ -1,0 +1,16 @@
+contents:
+  packages:
+    - argo-workflow-controller
+    - argo-workflow-controller-compat
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+entrypoint:
+  command:  workflow-controller

--- a/images/argo/exec.tf
+++ b/images/argo/exec.tf
@@ -1,0 +1,11 @@
+module "exec-config" { source = "./configs/exec" }
+
+module "exec" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-exec"
+  config            = module.exec-config.config
+  build-dev         = true
+}

--- a/images/argo/main.tf
+++ b/images/argo/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "test-latest" {
+  source = "./tests"
+  digests = {
+    cli                 = module.cli.image_ref
+    exec                = module.exec.image_ref
+    worfkflowcontroller = module.workflowcontroller.image_ref
+  }
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  for_each = {
+    "cli" : module.cli.image_ref
+    "exec" : module.exec.image_ref
+    "workflowcontroller" : module.workflowcontroller.image_ref
+  }
+  digest_ref = each.value
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  for_each = {
+    "cli" : module.cli.dev_ref
+    "exec" : module.exec.dev_ref
+    "workflowcontroller" : module.workflowcontroller.dev_ref
+  }
+  digest_ref = each.value
+  tag        = "latest-dev"
+}

--- a/images/argo/tests/check-argo-workflow.sh
+++ b/images/argo/tests/check-argo-workflow.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+cat <<EOF > hello.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello  
+spec:
+  entrypoint: main # the first template to run in the workflows        
+  templates:
+  - name: main           
+    container: # this is a container template
+      image: docker/whalesay # this image prints "hello world" to the console
+      command: ["cowsay"]
+      args: [ "hello world" ]
+EOF
+
+
+kubectl -n argo-workflows apply -f hello.yaml
+
+kubectl -n argo-workflows wait workflows/hello --for condition=Completed --timeout 2m
+
+kubectl logs -n argo-workflows pod/hello
+trap "kubectl -n argo-workflows delete workflows/hello" EXIT

--- a/images/argo/tests/main.tf
+++ b/images/argo/tests/main.tf
@@ -67,7 +67,7 @@ resource "helm_release" "argo" {
 
 data "oci_exec_test" "check-argo" {
   digest      = var.digests["cli"] # we are testing the whole helm release digest here is a place holder
-  script      = "./check-argo-workflow"
+  script      = "./check-argo-workflow.sh"
   working_dir = path.module
   depends_on  = [helm_release.argo]
 

--- a/images/argo/tests/main.tf
+++ b/images/argo/tests/main.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    cli                 = string
+    exec                = string
+    worfkflowcontroller = string
+  })
+}
+
+
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+
+resource "helm_release" "argo" {
+  name = "argo-workflows"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argo-workflows"
+
+  namespace        = "argo-workflows"
+  create_namespace = true
+
+  values = [
+    jsonencode({
+      image = {
+        tag = ""
+      }
+      server = {
+        image = {
+          registry   = join("", [data.oci_string.ref["cli"].registry, ""])
+          repository = data.oci_string.ref["cli"].repo
+          tag        = data.oci_string.ref["cli"].pseudo_tag
+
+        }
+        executor = {
+          image = {
+            registry   = join("", [data.oci_string.ref["exec"].registry, ""])
+            repository = data.oci_string.ref["exec"].repo
+            tag        = data.oci_string.ref["exec"].pseudo_tag
+          }
+        }
+        controller = {
+          image = {
+            registry   = join("", [data.oci_string.ref["worfkflowcontroller"].registry, ""])
+            repository = data.oci_string.ref["worfkflowcontroller"].repo
+            tag        = data.oci_string.ref["worfkflowcontroller"].pseudo_tag
+          }
+        }
+
+      }
+
+    }),
+  ]
+}
+
+
+data "oci_exec_test" "check-argo" {
+  digest      = var.digests["cli"] # we are testing the whole helm release digest here is a place holder
+  script      = "./check-argo-workflow"
+  working_dir = path.module
+  depends_on  = [helm_release.argo]
+
+}
+
+module "helm_cleanup" {
+  depends_on = [data.oci_exec_test.check-argo]
+  source     = "../../../tflib/helm-cleanup"
+  name       = helm_release.argo.id
+  namespace  = helm_release.argo.namespace
+}

--- a/images/argo/workflowcontroller.tf
+++ b/images/argo/workflowcontroller.tf
@@ -1,0 +1,11 @@
+module "workflowcontroller-config" { source = "./configs/workflowcontroller" }
+
+module "workflowcontroller" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-workflowcontroller"
+  config            = module.workflowcontroller-config.config
+  build-dev         = true
+}

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,11 @@ module "apko" {
   target_repository = "${var.target_repository}/apko"
 }
 
+module "argo" {
+  source            = "./images/argo"
+  target_repository = "${var.target_repository}/argo"
+}
+
 module "argocd" {
   source            = "./images/argocd"
   target_repository = "${var.target_repository}/argocd"


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
