### PR TITLE
kubeflow pipelines frontend

### DIFF
--- a/images/kubeflow-pipelines/configs/main.tf
+++ b/images/kubeflow-pipelines/configs/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "name" {
+  description = "The name of the component (e.g. kubeflow-pipelines-apiserver)."
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = []
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.${var.name}.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/kubeflow-pipelines/configs/template.api-server.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.api-server.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
-    - kubeflow-pipelines-cache_server
-    - busybox
+   # - kubeflow-pipelines-apiserver
+    - wget
 
 accounts:
   groups:
@@ -14,6 +14,12 @@ accounts:
   run-as: 65532
 
 paths:
+  - path: /config
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
   - path: /third_party
     type: directory
     permissions: 0o777
@@ -21,5 +27,4 @@ paths:
     gid: 65532
     recursive: true
 
-entrypoint:
-  command: /usr/bin/cache_server
+cmd: /usr/bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true

--- a/images/kubeflow-pipelines/configs/template.cache-deployer.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.cache-deployer.apko.yaml
@@ -1,7 +1,11 @@
 contents:
   packages:
-    - kubeflow-pipelines-scheduledworkflow
+    - kubeflow-pipelines-cache-deployer-compat
     - busybox
+    - bash
+    - kubectl-latest
+    - openssl
+    # - kubeflow-pipelines-cache-deployer
 
 accounts:
   groups:
@@ -14,11 +18,14 @@ accounts:
   run-as: 65532
 
 paths:
-  - path: /third_party
+  - path: /kfp/cache/deployer
     type: directory
     permissions: 0o777
     uid: 65532
     gid: 65532
     recursive: true
 
-cmd: /usr/bin/scheduledworkflow --logtostderr=true --namespace=""
+work-dir: /kfp/cache/deployer
+
+entrypoint:
+  command: /bin/bash /kfp/cache/deployer/deploy-cache-service.sh

--- a/images/kubeflow-pipelines/configs/template.cache-server.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.cache-server.apko.yaml
@@ -1,10 +1,7 @@
 contents:
   packages:
-    - kubeflow-pipelines-cache-deployer-compat
+   # - kubeflow-pipelines-cache_server
     - busybox
-    - bash
-    - kubectl-latest
-    - openssl
 
 accounts:
   groups:
@@ -17,14 +14,12 @@ accounts:
   run-as: 65532
 
 paths:
-  - path: /kfp/cache/deployer
+  - path: /third_party
     type: directory
     permissions: 0o777
     uid: 65532
     gid: 65532
     recursive: true
 
-work-dir: /kfp/cache/deployer
-
 entrypoint:
-  command: /bin/bash /kfp/cache/deployer/deploy-cache-service.sh
+  command: /usr/bin/cache_server

--- a/images/kubeflow-pipelines/configs/template.frontend.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.frontend.apko.yaml
@@ -1,0 +1,18 @@
+contents:
+  packages:
+   # - kubeflow-pipelines-frontend
+  
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  API_SERVER_ADDRESS: http://localhost:3001
+
+cmd: node ./server/dist/server.js ./client 3000

--- a/images/kubeflow-pipelines/configs/template.metadata-writer.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.metadata-writer.apko.yaml
@@ -1,6 +1,7 @@
 contents:
   packages:
-    - kubeflow-pipelines-metadata-writer-compat
+   - kubeflow-pipelines-metadata-writer-compat
+   # kubeflow-pipelines-metadata-writer
 
 accounts:
   groups:

--- a/images/kubeflow-pipelines/configs/template.persistenceagent.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.persistenceagent.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-    - kubeflow-pipelines-persistence_agent
+    # - kubeflow-pipelines-persistence_agent
     - busybox
 
 accounts:

--- a/images/kubeflow-pipelines/configs/template.scheduledworkflow.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.scheduledworkflow.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
-    - kubeflow-pipelines-apiserver
-    - wget
+    # - kubeflow-pipelines-scheduledworkflow
+    - busybox
 
 accounts:
   groups:
@@ -14,12 +14,6 @@ accounts:
   run-as: 65532
 
 paths:
-  - path: /config
-    type: directory
-    permissions: 0o777
-    uid: 65532
-    gid: 65532
-    recursive: true
   - path: /third_party
     type: directory
     permissions: 0o777
@@ -27,4 +21,4 @@ paths:
     gid: 65532
     recursive: true
 
-cmd: /usr/bin/apiserver --config=/config --sampleconfig=/config/sample_config.json -logtostderr=true
+cmd: /usr/bin/scheduledworkflow --logtostderr=true --namespace=""

--- a/images/kubeflow-pipelines/configs/template.viewer-crd-controller.apko.yaml
+++ b/images/kubeflow-pipelines/configs/template.viewer-crd-controller.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-    - kubeflow-pipelines-viewer-crd-controller
+    # - kubeflow-pipelines-viewer-crd-controller
     - busybox
 
 accounts:

--- a/images/kubeflow-pipelines/tests/main.tf
+++ b/images/kubeflow-pipelines/tests/main.tf
@@ -14,6 +14,7 @@ variable "digests" {
     scheduledworkflow     = string
     viewer-crd-controller = string
     cache-deployer        = string
+    frontend              = string
   })
 }
 
@@ -84,5 +85,14 @@ data "oci_exec_test" "smoke" {
   env {
     name  = "IMAGE_REPOSITORY_VIEWERCRDCONTROLLER_TAG"
     value = data.oci_string.ref["viewer-crd-controller"].pseudo_tag
+  }
+
+  env {
+    name  = "IMAGE_REPOSITORY_FRONTEND"
+    value = data.oci_string.ref["frontend"].registry_repo
+  }
+  env {
+    name  = "IMAGE_REPOSITORY_FRONTEND_TAG"
+    value = data.oci_string.ref["frontend"].pseudo_tag
   }
 }

--- a/images/kubeflow-pipelines/tests/smoke-test.sh
+++ b/images/kubeflow-pipelines/tests/smoke-test.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 # Ref: https://www.kubeflow.org/docs/components/pipelines/v1/installation/localcluster-deployment/#deploying-kubeflow-pipelines
 
 NAMESPACE=kubeflow
-PIPELINE_VERSION=2.0.1
+PIPELINE_VERSION=2.0.3
 
 function manifests() {
   cat <<EOF > kustomization.yaml
@@ -32,9 +32,9 @@ images:
   - name: gcr.io/ml-pipeline/scheduledworkflow
     newName: ${IMAGE_REPOSITORY_SCHEDULEDWORKFLOW}
     newTag: ${IMAGE_REPOSITORY_SCHEDULEDWORKFLOW_TAG}
-  - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newName: ${IMAGE_REPOSITORY_VIEWERCRDCONTROLLER}
-    newTag: ${IMAGE_REPOSITORY_VIEWERCRDCONTROLLER_TAG}
+  - name: gcr.io/ml-pipeline/frontend
+    newName: ${IMAGE_REPOSITORY_FRONTEND}
+    newTag: ${IMAGE_REPOSITORY_FRONTEND_TAG}
 namespace: ${NAMESPACE}
 EOF
 }


### PR DESCRIPTION
## Chainguard Images Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The image pull request checklist includes 10 sections:

* Every section begins with a heading level 3 (e.g., ### Section One).
* You are required to check at least one box per section -- no exceptions!
-->



### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes: due to some npm packages

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [x] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
