### PR TITLE
ingress-nginx-controller: attempt to fix missing directory

### DIFF
--- a/images/ingress-nginx-controller/config/latest.apko.yaml
+++ b/images/ingress-nginx-controller/config/latest.apko.yaml
@@ -94,6 +94,12 @@ paths:
     type: directory
     permissions: 0o755
     recursive: true
+  - path: /etc/nginx/geoip
+    uid: 101
+    gid: 101
+    type: directory
+    permissions: 0o755
+    recursive: true
   - path: /usr/local/nginx
     uid: 101
     gid: 101


### PR DESCRIPTION
Attempt to fix failing test

```
F1027 02:33:19.950616       1 nginx.go:197] Error creating file watchers: lstat /etc/nginx/geoip/: no such file or directory
```