### PR TITLE
cilium: bump the test cluster nodes

### DIFF
--- a/images/cilium/tests/k3d.yaml
+++ b/images/cilium/tests/k3d.yaml
@@ -1,6 +1,7 @@
 apiVersion: k3d.io/v1alpha5
 kind: Simple
 image: cgr.dev/chainguard/k3s:latest
+servers: 2
 registries:
   use:
     # For local runs, this can be removed

--- a/images/cilium/tests/main.tf
+++ b/images/cilium/tests/main.tf
@@ -23,7 +23,7 @@ data "oci_exec_test" "operator-version" {
 data "oci_exec_test" "cilium-install" {
   script          = "${path.module}/cilium-install.sh"
   digest          = var.digests.agent
-  timeout_seconds = 900
+  timeout_seconds = 1200
   env = [{
     name  = "AGENT_IMAGE"
     value = var.digests.agent


### PR DESCRIPTION
Use at least 2 nodes to exercise cross-node connectivity.