### PR TITLE
Add test to validate Keycloak in prod mode, with keystore generation

### DIFF
--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -90,7 +90,7 @@ TEST_container_starts_ok() {
     trap "docker stop ${container_id} && rm -rf ${KEYSTORE_PATH}" EXIT
 
     # Check if the container is running
-    sleep 20
+    sleep 60
     if ! docker ps --filter "name=local-keycloak" --format '{{.Names}}' | grep -q "^local-keycloak$"; then
         echo "FAILED: Container local-keycloak is not running."
         exit 1

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -152,8 +152,8 @@ TEST_container_starts_ok() {
 }
 
 TEST_keycloak_api_accessible() {
-  local retries=10
-  local delay=10
+  local retries=15
+  local delay=20
   local attempt=0
 
   while [[ $attempt -le $retries ]]; do

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -158,7 +158,7 @@ TEST_keycloak_api_accessible() {
 
   while [[ $attempt -le $retries ]]; do
     docker ps
-    local response_code=$(curl -kIso /dev/null -w "%{http_code}" "$KEYCLOAK_URL/realms/master")
+    local response_code=$(curl -kIso /dev/null -w "%{http_code}" "https://0.0.0.0:$KEYCLOAK_PORT/realms/master")
     if [[ "$response_code" == "200" ]]; then
       echo "API endpoint is accessible and running."
       return 0

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -90,7 +90,7 @@ TEST_container_starts_ok() {
     trap "docker stop ${container_id} && rm -rf ${KEYSTORE_PATH}" EXIT
 
     # Check if the container is running
-    sleep 60
+    sleep 140
     if ! docker ps --filter "name=local-keycloak" --format '{{.Names}}' | grep -q "^local-keycloak$"; then
         echo "FAILED: Container local-keycloak is not running."
         exit 1

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -49,6 +49,8 @@ start_container() {
 search_logs() {
   local logs=$(docker logs "${container_id}" 2>&1)
 
+  echo "Docker logs are: \n ${logs}"
+
   for term in "${terms[@]}"; do
     if echo "$logs" | grep -Fq "$term"; then
       echo "Found log term: $term"

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -137,7 +137,7 @@ TEST_keycloak_api_accessible() {
   local attempt=0
 
   while [[ $attempt -le $retries ]]; do
-    local response_code=$(curl -k -I -s -o /dev/null -w "%{http_code}" "$KEYCLOAK_URL/realms/master")
+    local response_code=$(curl -kIso /dev/null -w "%{http_code}" "$KEYCLOAK_URL/realms/master")
     if [[ "$response_code" == "200" ]]; then
       echo "API endpoint is accessible and running."
       return 0

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -11,7 +11,7 @@
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 KEYCLOAK_HOSTNAME="localhost"
-KEYCLOAK_PORT="8443"
+KEYCLOAK_PORT=$FREE_PORT
 KEYCLOAK_URL="https://$KEYCLOAK_HOSTNAME:$KEYCLOAK_PORT"
 KEYSTORE_PATH="/tmp/server.keystore"
 KEYSTORE_PASSWORD="placeholder"
@@ -37,7 +37,7 @@ start_container() {
   docker run \
   -v "$KEYSTORE_PATH:/usr/share/java/keycloak/conf/server.keystore" \
   --detach --rm \
-  --name local-keycloak -p $KEYCLOAK_PORT:$KEYCLOAK_PORT \
+  --name local-keycloak -p $KEYCLOAK_PORT:8443 \
   -e KEYCLOAK_ADMIN=admin \
   -e KEYCLOAK_ADMIN_PASSWORD=$KEYSTORE_PASSWORD \
   "${IMAGE_NAME}" \

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -153,10 +153,11 @@ TEST_container_starts_ok() {
 
 TEST_keycloak_api_accessible() {
   local retries=15
-  local delay=20
+  local delay=30
   local attempt=0
 
   while [[ $attempt -le $retries ]]; do
+    docker ps
     local response_code=$(curl -kIso /dev/null -w "%{http_code}" "$KEYCLOAK_URL/realms/master")
     if [[ "$response_code" == "200" ]]; then
       echo "API endpoint is accessible and running."

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -27,10 +27,10 @@ declare -a missing_terms=()
 create_keystore() {  
   rm -rf "$KEYSTORE_PATH"
   keytool -v -keystore $KEYSTORE_PATH \
-  -alias $KEYCLOAK_HOSTNAME \
-  -genkeypair -sigalg SHA512withRSA -keyalg RSA \
-  -dname CN=$KEYCLOAK_HOSTNAME \
-  -storepass $KEYSTORE_PASSWORD
+    -alias $KEYCLOAK_HOSTNAME \
+    -genkeypair -sigalg SHA512withRSA -keyalg RSA \
+    -dname CN=$KEYCLOAK_HOSTNAME \
+    -storepass $KEYSTORE_PASSWORD
 }
 
 start_container() {  

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -159,7 +159,7 @@ TEST_keycloak_api_accessible() {
 TEST_keycloak_api_get_users() {
     # Validate users can be retrieved from the Keycloak API.
     local users_json=$(keycloak_api_get_users)
-    local exttracted_username=$(echo "$users_json" | jq -r '.[] | select(.username=="admin") | .username')
+    local extracted_username=$(echo "$users_json" | jq -r '.[] | select(.username=="admin") | .username')
     
     # There'll only be one user after fresh install / launch - 'admin'.
     if [[ "$exttracted_username" == "admin" ]]; then

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -40,7 +40,7 @@ start_container() {
   --name local-keycloak -p $KEYCLOAK_PORT:$KEYCLOAK_PORT \
   -e KEYCLOAK_ADMIN=admin \
   -e KEYCLOAK_ADMIN_PASSWORD=$KEYSTORE_PASSWORD \
-  electricthunder/keycloak:latest \
+  "${IMAGE_NAME}" \
   start \
   --hostname=$KEYCLOAK_HOSTNAME \
   --https-key-store-password=$KEYSTORE_PASSWORD

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -35,15 +35,15 @@ create_keystore() {
 
 start_container() {  
   docker run \
-  -v "$KEYSTORE_PATH:/usr/share/java/keycloak/conf/server.keystore" \
-  --detach --rm \
-  --name local-keycloak -p $KEYCLOAK_PORT:8443 \
-  -e KEYCLOAK_ADMIN=admin \
-  -e KEYCLOAK_ADMIN_PASSWORD=$KEYSTORE_PASSWORD \
-  "${IMAGE_NAME}" \
-  start \
-  --hostname=$KEYCLOAK_HOSTNAME \
-  --https-key-store-password=$KEYSTORE_PASSWORD
+    -v "$KEYSTORE_PATH:/usr/share/java/keycloak/conf/server.keystore" \
+    --detach --rm \
+    --name local-keycloak -p $KEYCLOAK_PORT:8443 \
+    -e KEYCLOAK_ADMIN=admin \
+    -e KEYCLOAK_ADMIN_PASSWORD=$KEYSTORE_PASSWORD \
+    "${IMAGE_NAME}" \
+    start \
+    --hostname=$KEYCLOAK_HOSTNAME \
+    --https-key-store-password=$KEYSTORE_PASSWORD
 }
 
 search_logs() {

--- a/images/keycloak/tests/01-docker-production-mode.sh
+++ b/images/keycloak/tests/01-docker-production-mode.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+#
+# Tests Keycloak in production mode. This requires a keystore to be created
+# and mounted into the Keycloak container image.
+#
+# Validation includes ensuring Keycloak is running, and that we can authenticate
+# with the API to retrieve a list of users.
+#
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+KEYCLOAK_HOSTNAME="localhost"
+KEYCLOAK_PORT="8443"
+KEYCLOAK_URL="https://$KEYCLOAK_HOSTNAME:$KEYCLOAK_PORT"
+KEYSTORE_PATH="/tmp/server.keystore"
+KEYSTORE_PASSWORD="placeholder"
+
+# Define log entries we are looking for in the keycloak logs here.
+declare -a terms=(
+  "Listening on: https://0.0.0.0:8443"
+  "Profile prod activated"
+)
+
+declare -a missing_terms=()
+
+create_keystore() {  
+  rm -rf "$KEYSTORE_PATH"
+  keytool -v -keystore $KEYSTORE_PATH \
+  -alias $KEYCLOAK_HOSTNAME \
+  -genkeypair -sigalg SHA512withRSA -keyalg RSA \
+  -dname CN=$KEYCLOAK_HOSTNAME \
+  -storepass $KEYSTORE_PASSWORD
+}
+
+start_container() {  
+  docker run \
+  -v "$KEYSTORE_PATH:/usr/share/java/keycloak/conf/server.keystore" \
+  --detach --rm \
+  --name local-keycloak -p $KEYCLOAK_PORT:$KEYCLOAK_PORT \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=$KEYSTORE_PASSWORD \
+  electricthunder/keycloak:latest \
+  start \
+  --hostname=$KEYCLOAK_HOSTNAME \
+  --https-key-store-password=$KEYSTORE_PASSWORD
+  sleep 20
+}
+
+search_logs() {
+  local logs=$(docker logs "${container_id}" 2>&1)
+
+  for term in "${terms[@]}"; do
+    if echo "$logs" | grep -Fq "$term"; then
+      echo "Found log term: $term"
+    else
+      echo "Log term NOT found: $term"
+      missing_terms+=("$term")
+    fi
+  done
+}
+
+keycloak_api_get_users() {
+    # Get Keycloak access token
+    local response=$(curl -k -s -w "\nHTTP_STATUS_CODE:%{http_code}\n" -X POST $KEYCLOAK_URL/realms/master/protocol/openid-connect/token \
+        --user admin-cli:Psip5UvTO1EXUEwzb15nxLWnwdU1Nlcg \
+        -H 'content-type: application/x-www-form-urlencoded' \
+        -d "username=admin&password=$KEYSTORE_PASSWORD&grant_type=password")
+
+    local response_code=$(echo "$response" | grep "HTTP_STATUS_CODE:" | cut -d':' -f2)
+    local content=$(echo "$response" | sed '/HTTP_STATUS_CODE/d')
+
+    if [[ "$response_code" != "200" ]]; then
+        echo "FAILED: HTTP response code is $response_code"
+        exit 1
+    fi
+
+    local access_token=$(echo "$content" | jq --raw-output '.access_token')
+
+    # Get list of users that exist in Keycloak
+    curl -k -X GET $KEYCLOAK_URL/admin/realms/master/users -H "Authorization: Bearer $access_token" | jq
+}
+
+
+TEST_container_starts_ok() {
+  # Create Keystore and launch Keycloak
+  create_keystore
+  local -r container_id=$(start_container)
+  trap "docker stop ${container_id} && rm -rf ${KEYSTORE_PATH}" EXIT
+
+  # Look for each log term. Will record any which are not found.
+  search_logs
+
+  if [[ ${#missing_terms[@]} -ne 0 ]]; then
+    echo "The following terms were not found:"
+    printf '%s\n' "${missing_terms[@]}"
+    exit 1
+  fi
+}
+
+TEST_keycloak_api_accessible() {
+  local response_code=$(curl -k -I -s -o /dev/null -w "%{http_code}" "$KEYCLOAK_URL/realms/master")
+
+  if [[ "$response_code" == "200" ]]; then
+    echo "API endpoint is accessible and running."
+  else
+    echo "FAILED: API is not responding. Status code: $response_code"
+    exit 1
+  fi
+}
+
+TEST_keycloak_api_get_users() {
+    # Validate users can be retrieved from the Keycloak API.
+    local users_json=$(keycloak_api_get_users)
+    local exttracted_username=$(echo "$users_json" | jq -r '.[] | select(.username=="admin") | .username')
+    
+    # There'll only be one user after fresh install / launch - 'admin'.
+    if [[ "$exttracted_username" == "admin" ]]; then
+        echo "Test passed: Found an entry with username 'admin'"
+    else
+        echo "FAILED: No entry with username 'admin' found in the response: ${users_json}"
+        exit 1
+    fi
+}
+
+TEST_container_starts_ok
+TEST_keycloak_api_accessible
+TEST_keycloak_api_get_users

--- a/images/keycloak/tests/main.tf
+++ b/images/keycloak/tests/main.tf
@@ -28,6 +28,13 @@ data "oci_string" "ref" {
 
 resource "random_pet" "suffix" {}
 
+# Use shell test to validate Keycloak in production - as this requires
+# keystore creation and volume-mouting.
+data "oci_exec_test" "docker-test" {
+  digest = var.digest
+  script = "${path.module}/01-docker-production-mode.sh"
+}
+
 resource "helm_release" "test" {
   name       = "keycloak-${random_pet.suffix.id}"
   repository = "oci://registry-1.docker.io/bitnamicharts"

--- a/images/keycloak/tests/main.tf
+++ b/images/keycloak/tests/main.tf
@@ -29,7 +29,7 @@ data "oci_string" "ref" {
 resource "random_pet" "suffix" {}
 
 # Use shell test to validate Keycloak in production - as this requires
-# keystore creation and volume-mouting.
+# a keystore to be generated.
 data "oci_exec_test" "docker-test" {
   digest = var.digest
   script = "${path.module}/01-docker-production-mode.sh"

--- a/images/keycloak/tests/main.tf
+++ b/images/keycloak/tests/main.tf
@@ -35,21 +35,21 @@ data "oci_exec_test" "docker-test" {
   script = "${path.module}/01-docker-production-mode.sh"
 }
 
-resource "helm_release" "test" {
-  name       = "keycloak-${random_pet.suffix.id}"
-  repository = "oci://registry-1.docker.io/bitnamicharts"
-  chart      = "keycloak"
-  values = [jsonencode({
-    image = {
-      registry   = ""
-      repository = data.oci_string.ref.registry_repo,
-      digest     = data.oci_string.ref.digest
-    },
-    args = var.args
-  })]
-}
+# resource "helm_release" "test" {
+#   name       = "keycloak-${random_pet.suffix.id}"
+#   repository = "oci://registry-1.docker.io/bitnamicharts"
+#   chart      = "keycloak"
+#   values = [jsonencode({
+#     image = {
+#       registry   = ""
+#       repository = data.oci_string.ref.registry_repo,
+#       digest     = data.oci_string.ref.digest
+#     },
+#     args = var.args
+#   })]
+# }
 
-module "helm_cleanup" {
-  source = "../../../tflib/helm-cleanup"
-  name   = helm_release.test.id
-}
+# module "helm_cleanup" {
+#   source = "../../../tflib/helm-cleanup"
+#   name   = helm_release.test.id
+# }


### PR DESCRIPTION
> **DRAFT: Debugging some CI issues with the test**

Added new test to validate Keycloak running in production mode. This entails creating a keystore and volume mounting it into a Keycloak container. 

Validates by checking the service is running and that an API call can be made with credentials.