### PR TITLE
feat: add new make targets and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 cfg?=images/static/configs/wolfi.apko.yaml
 
+.PHONY: apko-build
 apko-build:
 	apko build $(cfg) apko.local image.tar \
 	--repository-append https://packages.wolfi.dev/os \
@@ -7,7 +8,46 @@ apko-build:
 	--package-append    wolfi-baselayout \
 	--arch              x86_64,aarch64
 
+.PHONY: apko-build-alpine
 apko-build-alpine:
 	apko build $(cfg) apko.local image.tar \
 	--repository-append https://dl-cdn.alpinelinux.org/alpine/edge/main \
 	--package-append    ca-certificates-bundle
+
+.PHONY: init
+init:
+	terraform init -upgrade
+
+TF_AUTO_APPROVE ?= 1
+TF_VARS :=
+
+ifdef TF_EXTRA_REPOSITORIES
+TF_VARS += -var=extra_repositories="$(TF_EXTRA_REPOSITORIES)"
+endif
+
+ifdef TF_EXTRA_KEYRING
+TF_VARS += -var=extra_keyring="$(TF_EXTRA_KEYRING)"
+endif
+
+ifdef TF_ARCHS
+TF_VARS += -var=archs="$(TF_ARCHS)"
+endif
+
+ifneq ($(TF_AUTO_APPROVE),0)
+TF_VARS += --auto-approve
+endif
+
+ifdef TF_TARGET_REPOSITORY
+TF_VARS += -var=target_repository=$(TF_TARGET_REPOSITORY)
+else
+ifndef TF_VAR_target_repository
+$(error One of [TF_TARGET_REPOSITORY, TF_VAR_target_repository] must be defined)
+endif
+endif
+
+.PHONY: all
+all: # makes all images instead of targeting specific modules
+	terraform apply $(TF_VARS)
+
+image/%:
+	terraform apply $(TF_VARS) -target=module.$*

--- a/TERRAFORM.md
+++ b/TERRAFORM.md
@@ -14,8 +14,8 @@ pretty quickly and easily iterate on one of the above scopes by entering the
 appropriate directory and running the following to execute things locally:
 
 ```shell
-terraform init
-terraform apply
+make init
+TF_VAR_target_repository=example.org/target-repo make all
 ```
 
 This is half true, since we need to define some variables, which may vary from
@@ -49,13 +49,13 @@ For example, I can build everything with:
 ```shell
 # Upgrade is useful in case there's prior state, or
 # run "git clean -fxd" first.
-terraform init -upgrade
+make init
 
 # This should have the form:
 #   ghcr.io/mattmoor
 # Individual image names will be appended to the above (e.g ko, crane, ...)
 # Bear in mind the visibility of the repository you are publishing to!
-TF_VAR_target_repository=... terraform apply
+TF_VAR_target_repository=... make all
 ```
 
 ### Building a single Image module
@@ -65,22 +65,18 @@ attest, test, and tag all of its variants.  Generally these modules expose a
 single input variable: `target_repository`, but because we define important
 `provider` settings at our top-level we invoke this slightly differently.
 Instead of invoking these modules directly, we invoke them as the `-target` of
-a "mega module" apply.
-
-For example, I can build just the "ko" image module with:
+a "mega module" apply. The Makefile in this project defines a handy target
+`images/%` that abstracts the Terraform invocation to build an image:
 
 ```shell
-TF_VAR_target_repository=... terraform apply -target=module.ko
+TF_VAR_target_repository=... make image/ko
 ```
 
-This flag may be supplied multiple times to build multiple image directories,
+This target can be supplied multiple times to build multiple image directories,
 for example ko, crane and consul:
 
 ```shell
-TF_VAR_target_repository=... terraform apply \
-    -target=module.ko \
-    -target=module.crane \
-    -target=module.consul
+TF_VAR_target_repository=... make image/ko image/crane image/consul
 ```
 
 ### Building for certain architectures
@@ -90,7 +86,7 @@ and Alpine-based images are built for all architectures supported by Alpine.
 
 During testing it can be useful to only build for certain architectures, such as the host architecture.
 
-To achieve this, set the `archs` variable, for example `-var='archs=["x86_64"]'` or `TF_VAR_archs='["x86_64"]'`.
+To achieve this, set the `archs` variable, for example `TF_ARCHS='["x86_64"]'` or `TF_VAR_archs='["x86_64"]'`.
 
 See [Assigning Values to Root Module Variables](https://developer.hashicorp.com/terraform/language/values/variables#assigning-values-to-root-module-variables).
 
@@ -100,19 +96,37 @@ The `[]`s are important here; omitting them results in an error saying `Variable
 
 During testing it can be useful to build images from packages you've built and signed locally.
 
-To achieve this, set the `extra_repositories` and `extra_keyring` variables.
-
-During testing it can be useful to only build for certain architectures, such as the host architecture, for example:
-
+To achieve this, set the `extra_repositories` and `extra_keyring` variables. For example,
+```console
+export TF_VAR_extra_repositories='["/path/to/packages"]'
+export TF_VAR_extra_keyring='["/path/to/local-signing.rsa.pub"]'
 ```
-terraform apply \
-    -var='extra_repositories=["/path/to/packages"]' \
-    -var='extra_keyring=["/path/to/local-signing.rsa.pub"]'
+
+If setting for a single invocation in the `make` command is desired, the same result can be achieved using
+```console
+make TF_EXTRA_REPOSITORIES='["/path/to/packages"]' TF_EXTRA_KEYRING='["/path/to/local-signing.rsa.pub"]' image/ko
 ```
 
 See [Assigning Values to Root Module Variables](https://developer.hashicorp.com/terraform/language/values/variables#assigning-values-to-root-module-variables).
 
-The `[]`s are important here; omitting them results in an error saying `Variables may not be used here.`
+The `[]`s are required here; omitting them results in an error saying `Variables may not be used here.`
+
+### More `make image` target options
+
+The following `make` options are valid for `make image`:
+
+* `TF_EXTRA_REPOSITORIES` for specifying extra repositories for building an image.
+* `TF_EXTRA_KEYRING` for specifying extra keyrings to verify package signatures while building an image.
+* `TF_ARCHS` for specifying architectures for which images should be built.
+* `TF_TARGET_REPOSITORY` for specifying the target repository where an image should be pushed.
+* `TF_AUTO_APPROVE` to allow the user to control whether `--auto-approve` will be used in Terraform or not. If
+    `--auto-approve` is not desired when running `make image/image-name`, make sure to either export `TF_AUTO_APPROVE=0`
+    or pass it to `make`, for example
+    ```console
+    make TF_AUTO_APPROVE=0 image/image-name
+    ```
+
+    The only false value is 0, every other value will be interpreted to be true.
 
 ### Running Tests
 
@@ -163,7 +177,7 @@ These will build the image into a tarball in the local directory, which can be l
 When creating a new image in this repository, you can run `monopod scaffold`
 from the root of this repository to generate a basic scaffolding:
 ```shell
-monopod scaffold my-new-image  --entrypoint /usr/bin/test-app
+monopod scaffold my-new-image --entrypoint /usr/bin/test-app
 ```
 
 This will generate the following folder structure, providing you with a basic


### PR DESCRIPTION
Add new `make` targets to run Terraform. This uses the recommended `terraform apply` command that was previously documented in `TERRAFORM.md`. It also updates the `TERRAFORM.md` to suggest the use of `make` now and specifies how variables should be passed in to make.