### PR TITLE
Add cleanup for node smoke-test

### DIFF
--- a/images/node/tests/01-dockerfile.sh
+++ b/images/node/tests/01-dockerfile.sh
@@ -2,11 +2,19 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
+TAG="smoke-test-${FREE_PORT}"
+CONTAINER="node-example-${FREE_PORT}"
+
+function cleanup() {
+  docker kill ${CONTAINER}
+  docker rmi ${TAG}
+}
+
+trap cleanup EXIT
+
 docker run --rm "${IMAGE_NAME}" --version
 
 # The image can be used to build an example application.
-docker build --build-arg BASE=${IMAGE_NAME} --tag smoke-test --file ./../example/Dockerfile ../example
-docker run --rm -p ${FREE_PORT}:8000 -d --name example-${FREE_PORT} smoke-test
-sleep 3
-curl http://localhost:${FREE_PORT}/test | grep payload
-docker kill example-${FREE_PORT}
+docker build --build-arg BASE=${IMAGE_NAME} --tag ${TAG} --file ./../example/Dockerfile ../example
+docker run --rm -p ${FREE_PORT}:8000 -d --name ${CONTAINER} ${TAG}
+curl --retry 3 --retry-all-errors http://localhost:${FREE_PORT}/test | grep payload


### PR DESCRIPTION
This was leaving a smoke-test image behind.
