### PR TITLE
disable aws-lb tests until they're good

### DIFF
--- a/images/aws-load-balancer-controller/tests/main.tf
+++ b/images/aws-load-balancer-controller/tests/main.tf
@@ -11,10 +11,10 @@ variable "digest" {
 
 data "oci_string" "ref" { input = var.digest }
 
-// resource "random_pet" "suffix" {}
-
 /*
 TODO: Re-enable when AWS webhook cleans up after itself more reliably.
+
+resource "random_pet" "suffix" {}
 
 resource "helm_release" "aws-load-balancer-controller" {
   name = "aws-load-balancer-controller-${random_pet.suffix.id}"

--- a/images/aws-load-balancer-controller/tests/main.tf
+++ b/images/aws-load-balancer-controller/tests/main.tf
@@ -11,7 +11,7 @@ variable "digest" {
 
 data "oci_string" "ref" { input = var.digest }
 
-resource "random_pet" "suffix" {}
+// resource "random_pet" "suffix" {}
 
 /*
 TODO: Re-enable when AWS webhook cleans up after itself more reliably.

--- a/images/aws-load-balancer-controller/tests/main.tf
+++ b/images/aws-load-balancer-controller/tests/main.tf
@@ -13,6 +13,9 @@ data "oci_string" "ref" { input = var.digest }
 
 resource "random_pet" "suffix" {}
 
+/*
+TODO: Re-enable when AWS webhook cleans up after itself more reliably.
+
 resource "helm_release" "aws-load-balancer-controller" {
   name = "aws-load-balancer-controller-${random_pet.suffix.id}"
 
@@ -42,3 +45,4 @@ module "helm_cleanup" {
   name      = helm_release.aws-load-balancer-controller.id
   namespace = helm_release.aws-load-balancer-controller.namespace
 }
+*/


### PR DESCRIPTION
The helm-cleanup doesn't seem to cleanly remove the webhook, which means other installations running in the same cluster get blocked on webhook errors.