### PR TITLE
Add netcat-openbsd to zookeeper image

### DIFF
--- a/images/zookeeper/config/template.apko.yaml
+++ b/images/zookeeper/config/template.apko.yaml
@@ -1,6 +1,8 @@
 contents:
   packages:
     - busybox
+    # Helm charts for zookeeper use nc -q in probes, which busybox does not have.
+    - netcat-openbsd
     - glibc-locale-en
     - bash
     # zookeeper comes via var.extra_packages


### PR DESCRIPTION
The bitnami zookeeper charts use nc -q in their probes, which breaks our tests: https://github.com/bitnami/charts/pull/20572