### PR TITLE
Sigstore timestamp authority images

### DIFF
--- a/images/sigstore-scaffolding/main.tf
+++ b/images/sigstore-scaffolding/main.tf
@@ -23,7 +23,6 @@ locals {
     "tsa-createcertchain",
     "tuf-createsecret",
     "tuf-server",
-    "tsa-server",
   ])
 }
 

--- a/images/sigstore-scaffolding/tests/main.tf
+++ b/images/sigstore-scaffolding/tests/main.tf
@@ -109,7 +109,7 @@ variable "cosign-cli" {
 }
 
 locals {
-  all-images = merge(var.scaffolding-images, var.support-images, var.rekor-images, var.trillian-images, { "ctlog-server" : var.ctlog-server }, { "fulcio-server" : var.fulcio-server }, { "cosign-cli" : var.cosign-cli }, { "tsa-server" : var.tsa-server })
+  all-images = merge(var.scaffolding-images, var.support-images, var.rekor-images, var.trillian-images, { "ctlog-server" : var.ctlog-server }, { "fulcio-server" : var.fulcio-server }, { "cosign-cli" : var.cosign-cli })
 }
 
 data "oci_ref" "images" {

--- a/images/sigstore-scaffolding/tests/main.tf
+++ b/images/sigstore-scaffolding/tests/main.tf
@@ -84,6 +84,12 @@ variable "trillian-images" {
   }
 }
 
+variable "tsa-server" {
+  description = "The TSA image to use in testing"
+  type        = string
+  default     = "cgr.dev/chainguard/timestamp-authority-server"
+}
+
 variable "ctlog-server" {
   description = "The image digests to run tests over."
   type        = string
@@ -103,7 +109,7 @@ variable "cosign-cli" {
 }
 
 locals {
-  all-images = merge(var.scaffolding-images, var.support-images, var.rekor-images, var.trillian-images, { "ctlog-server" : var.ctlog-server }, { "fulcio-server" : var.fulcio-server }, { "cosign-cli" : var.cosign-cli })
+  all-images = merge(var.scaffolding-images, var.support-images, var.rekor-images, var.trillian-images, { "ctlog-server" : var.ctlog-server }, { "fulcio-server" : var.fulcio-server }, { "cosign-cli" : var.cosign-cli }, { "tsa-server" : var.tsa-server })
 }
 
 data "oci_ref" "images" {
@@ -181,6 +187,17 @@ resource "helm_release" "scaffold" {
   set {
     name  = "fulcio.ctlog.namespace.name"
     value = "ctlog-${random_pet.suffix.id}"
+  }
+
+  // Override the TSA namespace
+  set {
+    name  = "tsa.forceNamespace"
+    value = "tsa-${random_pet.suffix.id}"
+  }
+
+    set {
+    name  = "tsa.namespace.name"
+    value = "tsa-${random_pet.suffix.id}"
   }
 
   // Override the trillian namespace

--- a/images/sigstore-scaffolding/tests/main.tf
+++ b/images/sigstore-scaffolding/tests/main.tf
@@ -195,7 +195,7 @@ resource "helm_release" "scaffold" {
     value = "tsa-${random_pet.suffix.id}"
   }
 
-    set {
+  set {
     name  = "tsa.namespace.name"
     value = "tsa-${random_pet.suffix.id}"
   }

--- a/images/sigstore-scaffolding/tests/values.tf
+++ b/images/sigstore-scaffolding/tests/values.tf
@@ -185,9 +185,5 @@ locals {
     server:
       args:
         signer: memory
-      image:
-        registry: ${data.oci_string.images["tsa-server"].registry}
-        repository: ${data.oci_string.images["tsa-server"].repo}
-        version: ${data.oci_string.images["tsa-server"].digest}
   EOF
 }

--- a/images/sigstore-scaffolding/tests/values.tf
+++ b/images/sigstore-scaffolding/tests/values.tf
@@ -178,15 +178,16 @@ locals {
     serviceaccount: tuf-secret-copy-job
     backoffLimit: 6
 
-  # TODO: Enable TSA
-  # Warning  FailedMount  114s (x12 over 10m)  kubelet            MountVolume.SetUp failed for volume "tsa-key" : secret "tsa-server-secret" not found
   tsa:
-    enabled: false
+    enabled: true
     namespace:
-      name: tsa-system
       create: true
-    forceNamespace: tsa-system
     server:
-      fullnameOverride: tsa-server
+      args:
+        signer: memory
+      image:
+        registry: ${data.oci_string.images["tsa-server"].registry}
+        repository: ${data.oci_string.images["tsa-server"].repo}
+        version: ${data.oci_string.images["tsa-server"].digest}
   EOF
 }

--- a/images/timestamp-authority/README.md
+++ b/images/timestamp-authority/README.md
@@ -1,0 +1,18 @@
+<!--monopod:start-->
+# timestamp-authority
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/timestamp-authority` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/timestamp-authority/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+## Sigstore timestamp-authority
+
+timestamp-authority is one of the core components of the sigstore stack.  For more information
+on this see [`sigstore-scaffolding`](../sigstore-scaffolding/).

--- a/images/timestamp-authority/config/main.tf
+++ b/images/timestamp-authority/config/main.tf
@@ -12,7 +12,7 @@ module "accts" { source = "../../../tflib/accts" }
 locals {
   binaries = {
     "server" = "timestamp-server"
-    "cli" = "timestamp-cli"
+    "cli"    = "timestamp-cli"
   }
 }
 

--- a/images/timestamp-authority/config/main.tf
+++ b/images/timestamp-authority/config/main.tf
@@ -1,0 +1,29 @@
+variable "name" {
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = []
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+locals {
+  binaries = {
+    "server" = "timestamp-server"
+    "cli" = "timestamp-cli"
+  }
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat(["timestamp-authority-${var.name}"], var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/${local.binaries["${var.name}"]}"
+    }
+  })
+}

--- a/images/timestamp-authority/main.tf
+++ b/images/timestamp-authority/main.tf
@@ -9,22 +9,7 @@ variable "target_repository" {
 }
 
 locals {
-  components = toset([
-    "cloudsqlproxy",
-    "ctlog-createctconfig",
-    "ctlog-managectroots",
-    "ctlog-verifyfulcio",
-    "fulcio-createcerts",
-    "getoidctoken",
-    "rekor-createsecret",
-    "trillian-createdb",
-    "trillian-createtree",
-    "trillian-updatetree",
-    "tsa-createcertchain",
-    "tuf-createsecret",
-    "tuf-server",
-    "tsa-server",
-  ])
+  components = toset(["server", "cli"])
 }
 
 module "config" {
@@ -44,8 +29,8 @@ module "latest" {
 }
 
 module "test-latest" {
-  source             = "./tests"
-  scaffolding-images = { for k, v in module.latest : k => v.image_ref }
+  source     = "../sigstore-scaffolding/tests"
+  tsa-server = module.latest["server"].image_ref
 }
 
 resource "oci_tag" "latest" {

--- a/main.tf
+++ b/main.tf
@@ -1037,6 +1037,11 @@ module "tigera-operator" {
   target_repository = "${var.target_repository}/tigera-operator"
 }
 
+module "timestamp-authority" {
+  source            = "./images/timestamp-authority"
+  target_repository = "${var.target_repository}/timestamp-authority"
+}
+
 module "timoni" {
   source            = "./images/timoni"
   target_repository = "${var.target_repository}/timoni"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).
20MB vs 45MB

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).



Notes:

opened https://github.com/wolfi-dev/os/pull/8234 to address them

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ x The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
