### PR TITLE
include prometheus-pushgateway in its image by default

### DIFF
--- a/images/prometheus-pushgateway-bitnami/config/main.tf
+++ b/images/prometheus-pushgateway-bitnami/config/main.tf
@@ -1,22 +1,13 @@
-variable "name" {
-  description = "Package name (e.g. prometheus-pushgateway)"
-}
-
-variable "suffix" {
-  description = "Package name suffix (e.g. version stream)"
-  default     = ""
-}
-
 variable "extra_packages" {
   description = "Additional packages to install."
   type        = list(string)
-  default     = []
+  default     = ["prometheus-pushgateway"]
 }
 
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["${var.name}${var.suffix}-bitnami-compat"], var.extra_packages)
+      packages = concat(["prometheus-pushgateway-bitnami-compat"], var.extra_packages)
     }
 
     entrypoint = {

--- a/images/prometheus-pushgateway-bitnami/main.tf
+++ b/images/prometheus-pushgateway-bitnami/main.tf
@@ -8,15 +8,9 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-variable "suffix" {
-  default     = ""
-  description = "The pushgateway component version suffix."
-}
-
 module "config" {
-  source = "./config"
-  name   = "prometheus-pushgateway"
-  suffix = var.suffix
+  source         = "./config"
+  extra_packages = ["prometheus-pushgateway"]
 }
 
 module "latest" {


### PR DESCRIPTION
This dependency had been brought in by a runtime dep in the compat package, which was removed in https://github.com/wolfi-dev/os/commit/321780e52434e1dc0f5734c50d48405fc9e30503 to avoid conflicts with other users of this config module.