### PR TITLE
fix: pin Pulumi to the image version

### DIFF
--- a/images/pulumi/examples/smoketest-python/requirements.txt
+++ b/images/pulumi/examples/smoketest-python/requirements.txt
@@ -1,2 +1,2 @@
-pulumi
+pulumi==3.91.1
 pulumi-kubernetes


### PR DESCRIPTION
Pin the version of the Pulumi Python package to the same version that's currently being used in the image to avoid issues with divergent configurations.

This intends to fix the test that's currently failing on CI for us.