### PR TITLE
make kyverno-policy-controller config reusable

### DIFF
--- a/images/kyverno-policy-reporter/config/main.tf
+++ b/images/kyverno-policy-reporter/config/main.tf
@@ -1,12 +1,3 @@
-variable "package" {
-  description = "Package name (e.g. kyverno-policy-reporter, kyverno-policy-reporter-ui)"
-}
-
-variable "suffix" {
-  description = "Package name suffix (e.g. version stream)"
-  default     = ""
-}
-
 variable "entrypoint" {
   description = "The entrypoint command for the container"
 }
@@ -22,7 +13,7 @@ module "accts" { source = "../../../tflib/accts" }
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["${var.package}${var.suffix}", "${var.package}${var.suffix}-compat"], var.extra_packages)
+      packages = var.extra_packages
     }
     accounts = module.accts.block
     work-dir = "/app"

--- a/images/kyverno-policy-reporter/main.tf
+++ b/images/kyverno-policy-reporter/main.tf
@@ -31,17 +31,17 @@ locals {
 }
 
 module "config" {
-  for_each   = local.components
-  source     = "./config"
-  package    = local.packages[each.key]
-  entrypoint = local.entrypoints[each.key]
+  for_each       = local.components
+  source         = "./config"
+  extra_packages = [local.packages[each.key], "${local.packages[each.key]}-compat"]
+  entrypoint     = local.entrypoints[each.key]
 }
 
 module "latest" {
   for_each          = local.components
   source            = "../../tflib/publisher"
   name              = basename(path.module)
-  target_repository = "${var.target_repository}-${each.key}"
+  target_repository = local.repositories[each.key]
   config            = module.config[each.key].config
   build-dev         = true
 }

--- a/images/kyverno-policy-reporter/tests/main.tf
+++ b/images/kyverno-policy-reporter/tests/main.tf
@@ -24,12 +24,14 @@ data "oci_string" "ref" {
   input    = each.value
 }
 
+resource "random_pet" "suffix" {}
+
 resource "helm_release" "kyverno" {
-  name       = "kyverno"
+  name       = "kyverno-${random_pet.suffix.id}"
   repository = "https://kyverno.github.io/kyverno"
   chart      = "kyverno"
 
-  namespace        = "kyverno"
+  namespace        = "kyverno-${random_pet.suffix.id}"
   create_namespace = true
 
   values = [jsonencode({

--- a/images/kyverno/tests/main.tf
+++ b/images/kyverno/tests/main.tf
@@ -22,12 +22,6 @@ data "oci_string" "ref" {
   input    = each.value
 }
 
-data "oci_exec_test" "help" {
-  for_each = var.digests
-  digest   = each.value
-  script   = "docker run --rm $IMAGE_NAME --help"
-}
-
 resource "random_pet" "suffix" {}
 
 resource "helm_release" "kyverno" {


### PR DESCRIPTION
Take the packages as an input, so other instantiations can install other versions.

Also deconflict the helm test, and remove unnecessary test for regular Kyverno.