### PR TITLE
Add temporal-ui-server

### DIFF
--- a/images/temporal-ui-server/README.md
+++ b/images/temporal-ui-server/README.md
@@ -1,0 +1,23 @@
+<!--monopod:start-->
+# temporal-ui-server
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/temporal-ui-server` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/temporal-ui-server/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Minimal image for temporal.io's [ui-server](https://github.com/temporalio/ui-server).
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/temporal-ui-server:latest
+```

--- a/images/temporal-ui-server/config/main.tf
+++ b/images/temporal-ui-server/config/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = [
+    "temporal-ui-server",
+    "temporal-ui-server-oci-entrypoint",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/temporal-ui-server/config/template.apko.yaml
+++ b/images/temporal-ui-server/config/template.apko.yaml
@@ -1,0 +1,29 @@
+contents:
+  packages: [
+    # Package "temporal-ui-server" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+  ]
+
+accounts:
+  groups:
+    - groupname: ui-server
+      gid: 65532
+  users:
+    - username: ui-server
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+paths:
+  - path: /home/ui-server
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+entrypoint:
+  command: /home/ui-server/start-ui-server.sh
+
+work-dir: /home/ui-server/

--- a/images/temporal-ui-server/main.tf
+++ b/images/temporal-ui-server/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+
+  build-dev = true
+
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/temporal-ui-server/tests/main.tf
+++ b/images/temporal-ui-server/tests/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --entrypoint /home/ui-server/ui-server --rm $IMAGE_NAME -v"
+}
+
+data "oci_exec_test" "run" {
+  digest      = var.digest
+  script      = "./run.sh"
+  working_dir = path.module
+}
+

--- a/images/temporal-ui-server/tests/run.sh
+++ b/images/temporal-ui-server/tests/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+CONTAINER_NAME="temporal-ui-server-${FREE_PORT}"
+
+docker run -d -p ${FREE_PORT}:8080 --name ${CONTAINER_NAME} ${IMAGE_NAME}
+
+trap "docker rm -f ${CONTAINER_NAME}" EXIT
+
+# TODO: Really test this once we have a temporal server available.
+curl --retry-all-errors --retry 3 localhost:${FREE_PORT}

--- a/main.tf
+++ b/main.tf
@@ -1025,6 +1025,11 @@ module "telegraf" {
   target_repository = "${var.target_repository}/telegraf"
 }
 
+module "temporal-ui-server" {
+  source            = "./images/temporal-ui-server"
+  target_repository = "${var.target_repository}/temporal-ui-server"
+}
+
 module "terraform" {
   source            = "./images/terraform"
   target_repository = "${var.target_repository}/terraform"


### PR DESCRIPTION
## New Image Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
