### PR TITLE
cert-manager: deconflict helm tests

### DIFF
--- a/images/cert-manager/tests/helm.sh
+++ b/images/cert-manager/tests/helm.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+rand=$1
+name=cert-manager-${rand}
+ns=cert-manager-${rand}
+
+function cleanup() {
+    # Uninstall everything, and make double triple sure it's fully uninstalled.
+    helm uninstall ${name} -n ${ns} --wait --cascade=foreground
+
+    kubectl delete pods -n ${ns} --all --wait=true
+    kubectl delete ns ${ns} --wait=true
+
+    for crd in $(kubectl get crds -o name | grep cert-manager); do
+        kubectl delete $crd
+        kubectl wait --for=delete $crd --timeout=120s
+    done
+}
+trap cleanup EXIT
+
+cat /tmp/values-${rand}.yaml
+
+helm install ${name} cert-manager -n ${ns} --repo https://charts.jetstack.io --create-namespace -f /tmp/values-${rand}.yaml
+
+# Wait for the pods to be ready.
+kubectl wait --for=condition=Ready -n ${ns} pod --all --timeout=120s

--- a/main.tf
+++ b/main.tf
@@ -196,6 +196,14 @@ module "cert-manager" {
   target_repository = "${var.target_repository}/cert-manager"
 }
 
+// This isn't intended to be run in production, but it's useful for testing
+// that the cert-manager test module can be run by multiple modules. To test this, run:
+// terraform apply -target=module.cert-manager -target=module.cert-manager-again-for-testing -auto-approve
+module "cert-manager-again-for-testing" {
+  source            = "./images/cert-manager"
+  target_repository = "${var.target_repository}/cert-manager"
+}
+
 module "cluster-autoscaler" {
   source            = "./images/cluster-autoscaler"
   target_repository = "${var.target_repository}/cluster-autoscaler"


### PR DESCRIPTION
Using the same technique introduced in #1858 

This now passes for me locally:

```
terraform apply -target=module.spire-again-for-testing -target=module.spire -auto-approve
```