### PR TITLE
memcached-exporter bitnami variant

### DIFF
--- a/images/memcached-exporter-bitnami/README.md
+++ b/images/memcached-exporter-bitnami/README.md
@@ -1,25 +1,25 @@
 <!--monopod:start-->
-# memcached-exporter
+# memcached-exporter-bitnami
 | | |
 | - | - |
-| **OCI Reference** | `cgr.dev/chainguard/memcached-exporter` |
+| **OCI Reference** | `cgr.dev/chainguard/memcached-exporter-bitnami` |
 
 
-* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/memcached-exporter/overview/)
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/memcached-exporter-bitnami/overview/)
 * [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
 * [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
 
 ---
 <!--monopod:end-->
 
-A memcached exporter for Prometheus.
+A memcached exporter for Prometheus that require Bitnami compatibility.
 
 ## Get It!
 
 The image is available on `cgr.dev`:
 
 ```
-docker pull cgr.dev/chainguard/memcached-exporter
+docker pull cgr.dev/chainguard/memcached-exporter-bitnami
 ```
 
 ## Using Memcached
@@ -27,11 +27,11 @@ docker pull cgr.dev/chainguard/memcached-exporter
 By default the memcached-exporter serves on port 0.0.0.0:9150 at /metrics:
 
 ```sh
-docker run -p 9150:9150 cgr.dev/chainguard/memcached-exporter:latest
+docker run -p 9150:9150 cgr.dev/chainguard/memcached-exporter-bitnami:latest
 ```
 
 ```sh
-$ docker run -p 9150:9150 cgr.dev/chainguard/memcached-exporter:latest
+$ docker run -p 9150:9150 cgr.dev/chainguard/memcached-exporter-bitnami:latest
 ts=2023-04-26T17:47:53.477Z caller=main.go:58 level=info msg="Starting memcached_exporter" version="(version=0.11.2, branch=HEAD, revision=48795923bbe6c23eb044c522283e0d865bffbc77)"
 ts=2023-04-26T17:47:53.478Z caller=main.go:59 level=info msg="Build context" context="(go=go1.20.3, platform=linux/amd64, user=@fv-az251-622, date=19700101-00:00:00, tags=netgo)"
 ts=2023-04-26T17:47:53.478Z caller=tls_config.go:232 level=info msg="Listening on" address=[::]:9150

--- a/images/memcached-exporter-bitnami/config/main.tf
+++ b/images/memcached-exporter-bitnami/config/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. memcached-exporter)."
+  default     = ["memcached-exporter", "memcached-exporter-bitnami-compat"]
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    environment = {
+      BITNAMI_APP_NAME = "memcached-exporter"
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/memcached_exporter"
+    }
+  })
+}

--- a/images/memcached-exporter-bitnami/main.tf
+++ b/images/memcached-exporter-bitnami/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+  main_package      = "memcached-exporter"
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}

--- a/images/memcached-exporter-bitnami/tests/main.tf
+++ b/images/memcached-exporter-bitnami/tests/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME --version"
+}
+
+data "oci_ref" "memcached" {
+  ref = "cgr.dev/chainguard/memcached:latest"
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "helm_release" "memcached-exporter-bitnami" {
+  name       = "memcached-exporter"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
+  chart      = "memcached"
+
+  values = [jsonencode({
+    image = {
+      registry   = "cgr.dev"
+      repository = "chainguard/memcached"
+      digest     = data.oci_ref.memcached.digest
+    }
+    metrics = {
+      enabled = true
+      image = {
+        registry   = data.oci_string.ref.registry
+        repository = data.oci_string.ref.repo
+        digest     = data.oci_string.ref.digest
+      }
+    }
+  })]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.memcached-exporter-bitnami.id
+  namespace = helm_release.memcached-exporter-bitnami.namespace
+}

--- a/main.tf
+++ b/main.tf
@@ -703,6 +703,11 @@ module "memcached-exporter" {
   target_repository = "${var.target_repository}/memcached-exporter"
 }
 
+module "memcached-exporter-bitnami" {
+  source            = "./images/memcached-exporter-bitnami"
+  target_repository = "${var.target_repository}/memcached-exporter-bitnami"
+}
+
 module "metrics-server" {
   source            = "./images/metrics-server"
   target_repository = "${var.target_repository}/metrics-server"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
	- _from 86.5 MB to 16.3 MB_ 
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
