### PR TITLE
give cert-manager tests more time to happen and teardown

### DIFF
--- a/images/cert-manager/tests/helm.sh
+++ b/images/cert-manager/tests/helm.sh
@@ -8,7 +8,7 @@ ns=cert-manager-${rand}
 
 function cleanup() {
     # Uninstall everything, and make double triple sure it's fully uninstalled.
-    helm uninstall ${name} -n ${ns} --wait --cascade=foreground
+    helm uninstall ${name} -n ${ns} --wait --cascade=foreground --timeout=10m
 
     kubectl delete pods -n ${ns} --all --wait=true
     kubectl delete ns ${ns} --wait=true

--- a/images/cert-manager/tests/main.tf
+++ b/images/cert-manager/tests/main.tf
@@ -59,7 +59,7 @@ webhook:
 EOV
 
 # Run with `flock` to ensure that only one test runs at a time.
-flock -e -w 600 /tmp/cert-manager ./helm.sh $${rand}
+flock -e -w 1200 /tmp/cert-manager ./helm.sh $${rand}
 EOF
   working_dir = path.module
 }


### PR DESCRIPTION
Running multiple of these on a crowded cluster makes this take longer.