### PR TITLE
Add `ntia-conformance-checker` image

### DIFF
--- a/images/ntia-conformance-checker/README.md
+++ b/images/ntia-conformance-checker/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# ntia-conformance-checker
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/ntia-conformance-checker` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/ntia-conformance-checker/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/ntia-conformance-checker/config/main.tf
+++ b/images/ntia-conformance-checker/config/main.tf
@@ -1,0 +1,17 @@
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = ["py3-ntia-conformance-checker"]
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = { packages = var.extra_packages }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/ntia-checker"
+    }
+  })
+}

--- a/images/ntia-conformance-checker/main.tf
+++ b/images/ntia-conformance-checker/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/ntia-conformance-checker/tests/main.tf
+++ b/images/ntia-conformance-checker/tests/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "check-ply" {
+  digest      = var.digest
+  script      = "docker run --rm -v $(pwd)/sbom.json:/sbom.json $IMAGE_NAME --file /sbom.json"
+  working_dir = path.module
+}

--- a/images/ntia-conformance-checker/tests/sbom.json
+++ b/images/ntia-conformance-checker/tests/sbom.json
@@ -1,0 +1,72 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "apk-ca-certificates-bundle-20230506-r0",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-05-06T20:26:39Z",
+    "creators": [
+      "Tool: melange (v0.3.0-146-g08fae69)",
+      "Organization: Chainguard, Inc"
+    ],
+    "licenseListVersion": "3.18"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/",
+  "documentDescribes": [
+    "SPDXRef-Package-ca-certificates-bundle-20230506-r0"
+  ],
+  "files": [
+    {
+      "SPDXID": "SPDXRef-File--etc-ssl-certs-ca-certificates.crt",
+      "fileName": "etc/ssl/certs/ca-certificates.crt",
+      "licenseConcluded": "NOASSERTION",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "b132b312a42c8be5d632069aecc6797b629f1264"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "824cefcee69de918c76b7b92776f304c3a4b7f6281539118bc1d41a9dd8476d9"
+        },
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "18d8c151a80c14db8a2b419503d589495ea2377e8f28bbe6f087bcc13d4c9d429616bfc57d3d7fcd40b3406760a036f8737a34ea29be53e3edf7c55e05809108"
+        }
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-ca-certificates-bundle-20230506-r0",
+      "name": "ca-certificates-bundle",
+      "versionInfo": "20230506-r0",
+      "supplier": "Organization: Chainguard, Inc.",
+      "filesAnalyzed": true,
+      "hasFiles": [
+        "SPDXRef-File--etc-ssl-certs-ca-certificates.crt"
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "MPL-2.0 AND MIT",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "\n",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:apk/wolfi/ca-certificates-bundle@20230506-r0?arch=x86_64",
+          "referenceType": "purl"
+        }
+      ],
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "d98736c880d3536649f0593cd6ef1168a5683a06"
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-ca-certificates-bundle-20230506-r0",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-File--etc-ssl-certs-ca-certificates.crt"
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -770,6 +770,11 @@ module "node-problem-detector" {
   target_repository = "${var.target_repository}/node-problem-detector"
 }
 
+module "ntia-conformance-checker" {
+  source            = "./images/ntia-conformance-checker"
+  target_repository = "${var.target_repository}/ntia-conformance-checker"
+}
+
 module "ntpd-rs" {
   source            = "./images/ntpd-rs"
   target_repository = "${var.target_repository}/ntpd-rs"


### PR DESCRIPTION
## New Image Pull Request Template

### Image Size

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [x] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation
- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

### Environment Testing + Documentation

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [ ] For utilities/tooling bring up help e.g. `–help`

### Environment Variables

- [x] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
