### PR TITLE
Add an image for `sigstore/policy-controller`

### DIFF
--- a/images/sigstore-policy-controller/README.md
+++ b/images/sigstore-policy-controller/README.md
@@ -1,0 +1,30 @@
+<!--monopod:start-->
+# sigstore-policy-controller
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/sigstore-policy-controller` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/sigstore-policy-controller/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+# Minimal `sigstore/policy-controller` image
+
+This image can be used with the upstream helm chart with the following
+overrides:
+
+```bash
+IMAGE=cgr.dev/chainguard/sigstore-policy-controller
+
+helm repo add sigstore https://sigstore.github.io/helm-charts
+
+helm install policy-controller sigstore/policy-controller \
+	--namespace policy-controller \
+	--create-namespace \
+	--set webhook.image.repository="${IMAGE}" \
+	--set webhook.image.version="$(crane digest ${IMAGE})"
+```

--- a/images/sigstore-policy-controller/config/main.tf
+++ b/images/sigstore-policy-controller/config/main.tf
@@ -1,0 +1,17 @@
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = ["policy-controller"]
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = { packages = var.extra_packages }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/policy-controller"
+    }
+  })
+}

--- a/images/sigstore-policy-controller/main.tf
+++ b/images/sigstore-policy-controller/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/sigstore-policy-controller/tests/chainguard-images.yaml
+++ b/images/sigstore-policy-controller/tests/chainguard-images.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: chainguard-images
+spec:
+  images:
+    - glob: cgr.dev/chainguard/**
+  authorities:
+    - keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+      ctlog:
+        url: https://rekor.sigstore.dev

--- a/images/sigstore-policy-controller/tests/e2e_test.sh
+++ b/images/sigstore-policy-controller/tests/e2e_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -ex
+
+kubectl create namespace "${TEST_NAMESPACE}"
+
+# Enable enforcement
+kubectl label namespace "${TEST_NAMESPACE}" --overwrite policy.sigstore.dev/include=true
+sleep 10
+
+# Test with policy enforcement enabled and default deny with no policies.
+if kubectl create -n "${TEST_NAMESPACE}" -f unsigned-image.yaml ; then
+  echo Failed to block Pod with unsigned image.
+  exit 1
+fi
+if kubectl create -n "${TEST_NAMESPACE}" -f signed-image.yaml ; then
+  echo Failed to block Pod with signed image.
+  exit 1
+fi
+
+kubectl apply -f chainguard-images.yaml
+trap "kubectl delete -f chainguard-images.yaml" EXIT
+sleep 10 # give the policy time to roll out
+
+# Test with policy enforcement enabled and default deny with chainguard policy.
+if kubectl create -n "${TEST_NAMESPACE}" -f unsigned-image.yaml ; then
+  echo Failed to block Pod with unsigned image.
+  exit 1
+fi
+if ! kubectl create -n "${TEST_NAMESPACE}" -f signed-image.yaml ; then
+  echo Failed to allow Pod with signed image.
+  exit 1
+fi
+
+# Disable enforcement
+kubectl label namespace "${TEST_NAMESPACE}" --overwrite policy.sigstore.dev/include=false
+
+# Test with policy enforcement disabled
+if ! kubectl create -n "${TEST_NAMESPACE}" -f unsigned-image.yaml ; then
+  echo Failed to allow Pod with unsigned image.
+  exit 1
+fi
+if ! kubectl create -n "${TEST_NAMESPACE}" -f signed-image.yaml ; then
+  echo Failed to allow Pod with signed image.
+  exit 1
+fi

--- a/images/sigstore-policy-controller/tests/main.tf
+++ b/images/sigstore-policy-controller/tests/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "digest" {
+  input = var.digest
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "policy-controller" {
+  name       = "pc-${random_pet.suffix.id}"
+  repository = "https://sigstore.github.io/helm-charts"
+  chart      = "policy-controller"
+
+  namespace        = "policy-controller"
+  create_namespace = true
+
+  set {
+    name  = "webhook.image.repository"
+    value = data.oci_string.digest.registry_repo
+  }
+  set {
+    name  = "webhook.image.version"
+    value = data.oci_string.digest.digest
+  }
+}
+
+data "oci_exec_test" "upstream-cosigned-tests" {
+  depends_on = [helm_release.policy-controller]
+
+  digest      = var.digest
+  script      = "./e2e_test.sh"
+  working_dir = path.module
+
+  env {
+    name  = "TEST_NAMESPACE"
+    value = "pc-test-${random_pet.suffix.id}"
+  }
+}
+
+module "helm_cleanup" {
+  depends_on = [data.oci_exec_test.upstream-cosigned-tests]
+  source     = "../../../tflib/helm-cleanup"
+  name       = helm_release.policy-controller.id
+  namespace  = helm_release.policy-controller.namespace
+}

--- a/images/sigstore-policy-controller/tests/signed-image.yaml
+++ b/images/sigstore-policy-controller/tests/signed-image.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: signed-
+spec:
+  restartPolicy: Never
+  containers:
+  - name: sample
+    image: cgr.dev/chainguard/busybox:latest-glibc
+    command: [/bin/sh, -c, "exit 0"]

--- a/images/sigstore-policy-controller/tests/unsigned-image.yaml
+++ b/images/sigstore-policy-controller/tests/unsigned-image.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: unsigned-
+spec:
+  restartPolicy: Never
+  containers:
+  - name: sample
+    image: docker.io/alpine:latest
+    command: [/bin/sh, -c, "exit 0"]

--- a/main.tf
+++ b/main.tf
@@ -977,6 +977,11 @@ module "semgrep" {
   target_repository = "${var.target_repository}/semgrep"
 }
 
+module "sigstore-policy-controller" {
+  source            = "./images/sigstore-policy-controller"
+  target_repository = "${var.target_repository}/sigstore-policy-controller"
+}
+
 module "sigstore-scaffolding" {
   source            = "./images/sigstore-scaffolding"
   target_repository = "${var.target_repository}/sigstore-scaffolding"


### PR DESCRIPTION
## New Image Pull Request Template

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [x] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

A single low CVE from the package:
```
NAME                           INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY 
github.com/sigstore/cosign/v2  v2.2.0     2.2.1     go-module  GHSA-vfp6-jrw2-99g9  Low
```

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
