### PR TITLE
Add qdrant image.

### DIFF
--- a/images/qdrant/README.md
+++ b/images/qdrant/README.md
@@ -1,0 +1,41 @@
+<!--monopod:start-->
+# qdrant
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/qdrant` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/qdrant/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+[qdrant](https://github.com/qdrant/qdrant) Qdrant is a high-performance, massive-scale Vector Database for the next generation of AI.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/qdrant
+```
+
+## Using Qdrant
+
+This image should be a drop-in replacement for the upstream image, and works by default in the helm charts.
+
+To install, follow the steps here: https://qdrant.tech/documentation/guides/installation
+
+But override the image variable in the helm chart:
+
+```shell
+$ helm repo add qdrant https://qdrant.to/helm
+$ helm upgrade --install qdrant --set image.repository=cgr.dev/chainguard/qdrant --set image.tag=latest qdrant/qdrant
+```
+
+The only notable difference is that this image contains both a root and a non-root user, so you can't/don't need to use the `useUnprivileged` [helm variable](https://github.com/qdrant/qdrant-helm/blob/2ddefd61ccd9da092739eaf13f9a76b8b3cfd55e/charts/qdrant/values.yaml#L7C7-L7C7)
+
+Because the helm chart uses the same image for intializing file system permissions and running the final app, we have to run as a root user by default.
+The image can still be run as a non-root user (in this case `qdrant`), and the helm chart properly sets that up by default.

--- a/images/qdrant/config/main.tf
+++ b/images/qdrant/config/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "qdrant",
+    // Other packages your image needs
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/qdrant/config/template.apko.yaml
+++ b/images/qdrant/config/template.apko.yaml
@@ -1,0 +1,40 @@
+contents:
+  packages: [
+    # Package "qdrant" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+    busybox,
+    qdrant-oci-entrypoint,
+    qdrant-oci-compat,
+    bash
+  ]
+
+accounts:
+  groups:
+    - groupname: qdrant
+      gid: 1000
+    - groupname: fsgroup
+      gid: 3000
+      members: [qdrant]
+  users:
+    - username: qdrant
+      uid: 1000
+      gid: 1000
+  # We have to default to running as root, the helm chart will drop this down in the right places.
+  run-as: 0
+
+paths:
+  - path: /qdrant
+    type: directory
+    uid: 1000
+    gid: 1000
+    recursive: true
+    permissions: 0o755
+
+environment:
+  RUN_MODE: production
+
+work-dir: /qdrant
+
+entrypoint:
+  command: /usr/lib/qdrant/entrypoint.sh

--- a/images/qdrant/main.tf
+++ b/images/qdrant/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "qdrant" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.qdrant.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.qdrant.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.qdrant.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/qdrant/tests/main.tf
+++ b/images/qdrant/tests/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "helm" {
+  name             = "qdrant-${random_pet.suffix.id}"
+  namespace        = "qdrant-${random_pet.suffix.id}"
+  repository       = "https://qdrant.to/helm"
+  chart            = "qdrant"
+  create_namespace = true
+
+  values = [
+    jsonencode({
+      image = {
+        repository = data.oci_string.ref.registry_repo
+        tag        = data.oci_string.ref.pseudo_tag
+      }
+    })
+  ]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.helm.id
+  namespace = helm_release.helm.namespace
+}

--- a/main.tf
+++ b/main.tf
@@ -906,6 +906,11 @@ module "python" {
   target_repository = "${var.target_repository}/python"
 }
 
+module "qdrant" {
+  source            = "./images/qdrant"
+  target_repository = "${var.target_repository}/qdrant"
+}
+
 module "r-base" {
   source            = "./images/r-base"
   target_repository = "${var.target_repository}/r-base"


### PR DESCRIPTION
## New Image Pull Request Template

### Image Size

- [X] The Image is smaller in size than its common public counterpart.
71MB vs. 163MB

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Image Tagging

- [X] The image is tagged with :latest

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)

### Environment Variables

- [X] Environment variables added.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
