### PR TITLE
Adding kubernetes-event-exporter

### DIFF
--- a/images/kubernetes-event-exporter/README.md
+++ b/images/kubernetes-event-exporter/README.md
@@ -1,0 +1,24 @@
+<!--monopod:start-->
+# kubernetes-event-exporter
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/kubernetes-event-exporter` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/kubernetes-event-exporter/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+Kubernetes Event Exporter tool allows exporting the often missed Kubernetes events to various outputs so that they can be used for observability or alerting purposes. You won't believe what you are missing.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/kubernetes-event-exporter
+```
+

--- a/images/kubernetes-event-exporter/README.md
+++ b/images/kubernetes-event-exporter/README.md
@@ -12,13 +12,42 @@
 ---
 <!--monopod:end-->
 
-Kubernetes Event Exporter tool allows exporting the often missed Kubernetes events to various outputs so that they can be used for observability or alerting purposes. You won't believe what you are missing.
+# Kubernetes-Event-Exporter
 
-## Get It!
+Minimalist [wolfi](https://github.com/wolfi-dev)-based image of [Kubernetes Event Exporter]
+(https://github.com/resmoio/kubernetes-event-exporter) for exporting Kubernetes 
+events to various outputs to be used for observability or alerting purposes.
+
+
+## Get it!
 
 The image is available on `cgr.dev`:
 
 ```
-docker pull cgr.dev/chainguard/kubernetes-event-exporter
+docker pull cgr.dev/chainguard/kubernetes-event-exporter:latest
+```
+
+## Usage
+
+Project documentation suggests usage of Bitnami chart which is comprehensive.
+
+This chart bootstraps a Kubernetes Event Exporter deployment on a Kubernetes cluster using 
+the Helm package manager.
+
+To install the chart with the release name my-release:
+
+```
+helm install my-release oci://registry-1.docker.io/bitnamicharts/kubernetes-event-exporter
+
+helm upgrade my-release oci://registry-1.docker.io/bitnamicharts/kubernetes-event-exporter \
+  --set image.repository=cgr.dev/chainguard/kubernetes-event-exporter \
+  --set image.tag=latest
+
+```
+
+To uninstall/delete this deployment:
+
+```
+helm delete my-release
 ```
 

--- a/images/kubernetes-event-exporter/configs/main.tf
+++ b/images/kubernetes-event-exporter/configs/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = [""]
+}
+
+variable "entrypoint" {
+  description = "The entrypoint to use."
+  default     = "/usr/bin/kubernetes-event-exporter"
+}
+
+variable "environment" {
+  description = "Environment variables to add to the image"
+  default     = {}
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = var.entrypoint
+    }
+    environment = var.environment
+  })
+}

--- a/images/kubernetes-event-exporter/main.tf
+++ b/images/kubernetes-event-exporter/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  main_package = "kubernetes-event-exporter"
+}
+
+module "config" {
+  source         = "./configs"
+  extra_packages = ["${local.main_package}"]
+}
+
+module "latest" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = var.target_repository
+  config            = module.config.config
+  main_package      = local.main_package
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/kubernetes-event-exporter/tests/main.tf
+++ b/images/kubernetes-event-exporter/tests/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "helm_release" "kubernetes-event-exporter" {
+  name       = "kubernetes-event-exporter"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
+  chart      = "kubernetes-event-exporter"
+
+  values = [jsonencode({
+    image = {
+      registry   = data.oci_string.ref.registry
+      repository = data.oci_string.ref.repo
+      digest     = data.oci_string.ref.digest
+    }
+  })]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.kubernetes-event-exporter.id
+  namespace = helm_release.kubernetes-event-exporter.namespace
+}

--- a/main.tf
+++ b/main.tf
@@ -628,6 +628,11 @@ module "kubernetes-dns-node-cache" {
   target_repository = "${var.target_repository}/kubernetes-dns-node-cache"
 }
 
+module "kubernetes-event-exporter" {
+  source            = "./images/kubernetes-event-exporter"
+  target_repository = "${var.target_repository}/kubernetes-event-exporter"
+}
+
 module "kubernetes-ingress-defaultbackend" {
   source            = "./images/kubernetes-ingress-defaultbackend"
   target_repository = "${var.target_repository}/kubernetes-ingress-defaultbackend"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
