### PR TITLE
updating Hugo Image README

### DIFF
--- a/images/hugo/README.md
+++ b/images/hugo/README.md
@@ -20,13 +20,6 @@ so this directory may be initialized with the Hugo site to serve.
 - [Image Variants](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo/image_specs/)
 - [Provenance Info](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo/provenance_info/)
 
-## Image Variants
-
-The following tagged variants are available without authentication:
-
-- `latest`: This is a distroless image for running hugo to generate a website. It does not include `apk-tools` or `bash`, so no shell will be available.
-- `latest-dev`: This is a development / builder image that includes `bash`, `apk-tools`, and `busybox`. This variant allows you to customize your final image with additional Wolfi packages.
-
 ### Pulling the Image
 Run the following to pull the image to your local system and execute the command `hugo version`:
 
@@ -42,24 +35,54 @@ hugo v0.119.0-b84644c008e0dc2c4b67bd69cccf87a41a03937e linux/amd64 BuildDate=202
 
 ## Application Setup for End Users
 
-Here is an example using the Hugo image to run the
-["quickstart"](https://gohugo.io/getting-started/quick-start/#commands) locally:
+The following is an example of using the Hugo image locally. It's based on the official [Hugo "quickstart"](https://gohugo.io/getting-started/quick-start/#commands) example.
+
+To begin, start a shell in the Hugo "dev" container:
 
 ```shell
-# Start a shell in the Hugo "dev" container:
-docker run -ti --rm -v -p 8080:8080 --entrypoint=/bin/sh \
-       cgr.dev/chainguard/hugo:latest-dev
-
-# Pass the quickstart commands (changing the bind address and port)
-hugo new site quickstart
-cd quickstart
-git init
-git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke themes/ananke
-echo "theme = 'ananke'" >> config.toml
-hugo server --bind 0.0.0.0 --port 8080
+docker run -v $PWD/data:/home/data --entrypoint=/bin/sh -p 8080:8080 -it \
+cgr.dev/chainguard/hugo:latest-dev
 ```
 
-Now open your browser to [localhost:8080](http://localhost:8080)!
+Create a new Hugo site using the quickstart commands.
+
+```shell
+hugo new site quickstart
+```
+
+Navigate into the new site's root directory.
+
+```shell
+cd quickstart
+```
+
+Initiate an empty Git repository 
+
+```shell
+git init
+```
+
+Clone a Hugo theme into the `themes` directory. 
+
+```shell
+git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke themes/ananke
+```
+
+Add a line to the site's configuration file to let Hugo know to use the new theme.
+
+```shell
+echo "theme = 'ananke'" >> hugo.toml
+```
+
+Start the Hugo development server to serve the site. Be sure to change the default bind address and port to make the site accessible outside of the container.
+
+```shell
+hugo serve --bind 0.0.0.0 --port 8080
+```
+
+Now open your browser to [localhost:8080](http://localhost:8080) to visit the sample site.
+
+When finished, you can press `CTRL + C` to stop the Hugo server from running, and then `CTRL + D` to exit the container shell.
 
 If you're interested in enterprise support, SLAs, and access to older tags, [get in touch](https://www.chainguard.dev/chainguard-images).
 

--- a/images/hugo/README.md
+++ b/images/hugo/README.md
@@ -85,5 +85,3 @@ Now open your browser to [localhost:8080](http://localhost:8080) to visit the sa
 When finished, you can press `CTRL + C` to stop the Hugo server from running, and then `CTRL + D` to exit the container shell.
 
 If you're interested in enterprise support, SLAs, and access to older tags, [get in touch](https://www.chainguard.dev/chainguard-images).
-
-

--- a/images/kor/README.md
+++ b/images/kor/README.md
@@ -1,0 +1,65 @@
+<!--monopod:start-->
+# kor
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/kor` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/kor/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+# Kor - Kubernetes Orphaned Resources Finder
+
+Kor is a tool to discover unused Kubernetes resources. Currently, Kor can identify and list unused:
+- ConfigMaps  
+- Secrets
+- Services
+- ServiceAccounts
+- Deployments
+- StatefulSets
+- Roles
+- HPAs
+- PVCs
+- Ingresses
+- PDBs
+- CRDs
+
+![Kor Screenshot](/images/screenshot.png)
+
+for more information refer [kor](https://github.com/yonahd/kor)
+
+## Installation
+
+### Docker
+Run a container with your kubeconfig mounted:
+```sh
+docker run --rm -i cgr.dev/chainguard/kor:latest
+
+docker run --rm -i -v "/path/to/.kube/config:/root/.kube/config" cgr.dev/chainguard/kor:latest all
+```
+
+### Helm
+Run as a cronjob in your Cluster (with an option for sending slack updates)
+
+```sh
+git clone https://github.com/yonahd/kor.git
+```
+
+```sh
+helm upgrade --install kor \
+    --namespace kor \
+    --create-namespace \
+    --set cronJob.enabled=true \
+    --set cronJob.image.repository=cgr.dev/chainguard/kor \
+    --set cronJob.image.tag=latest \
+    --set prometheusExporter.enabled=true \
+    --set prometheusExporter.deployment.image.repository=cgr.dev/chainguard/kor \
+    --set prometheusExporter.deployment.image.tag=latest \
+    --wait \
+    --timeout=300s \
+    ./kor/charts/kor
+```

--- a/images/kor/config/main.tf
+++ b/images/kor/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install."
+  default     = ["kor", "busybox"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/kor/config/template.apko.yaml
+++ b/images/kor/config/template.apko.yaml
@@ -1,0 +1,15 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/kor

--- a/images/kor/main.tf
+++ b/images/kor/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+  main_package      = "kor"
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}

--- a/images/kor/tests/main.tf
+++ b/images/kor/tests/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "oci_exec_test" "helm-install" {
+  digest = var.digest
+  script = "${path.module}/script.sh"
+
+  env {
+    name  = "IMAGE_REGISTRY_REPO"
+    value = data.oci_string.ref.registry_repo
+  }
+  env {
+    name  = "IMAGE_TAG"
+    value = data.oci_string.ref.pseudo_tag
+  }
+}

--- a/images/kor/tests/script.sh
+++ b/images/kor/tests/script.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+git clone https://github.com/yonahd/kor.git
+
+# Set up a trap to remove the directory on script exit
+cleanup() {
+    echo "Cleaning up..."
+    rm -rf kor
+    helm uninstall kor -n kor
+    echo "Cleanup complete."
+}
+
+# Register the cleanup function to be called on script exit (EXIT signal)
+trap cleanup EXIT
+
+helm upgrade -i kor \
+    --namespace kor \
+    --create-namespace \
+    --set cronJob.enabled=true \
+    --set cronJob.image.repository=$IMAGE_REGISTRY_REPO \
+    --set cronJob.image.tag=$IMAGE_TAG \
+    --set prometheusExporter.enabled=true \
+    --set prometheusExporter.deployment.image.repository=$IMAGE_REGISTRY_REPO \
+    --set prometheusExporter.deployment.image.tag=$IMAGE_TAG \
+    ./kor/charts/kor
+
+# check that kor is up and running app=kor-exporter label
+kubectl wait --for=condition=ready pod -l app=kor-exporter -n kor --timeout=300s

--- a/main.tf
+++ b/main.tf
@@ -543,6 +543,11 @@ module "ko" {
   target_repository = "${var.target_repository}/ko"
 }
 
+module "kor" {
+  source            = "./images/kor"
+  target_repository = "${var.target_repository}/kor"
+}
+
 module "kube-bench" {
   source            = "./images/kube-bench"
   target_repository = "${var.target_repository}/kube-bench"


### PR DESCRIPTION
This PR is just to update the README for the Hugo image. This update provides some more context around the application setup, corrects a few broken commands, and removes the unnecessary **Image Variants** section (now in a new tab).

I haven't made a PR here in a while so let me know if I did anything incorrectly.

## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [x] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
