### PR TITLE
updating Hugo image README

### DIFF
--- a/images/hugo/README.md
+++ b/images/hugo/README.md
@@ -20,13 +20,6 @@ so this directory may be initialized with the Hugo site to serve.
 - [Image Variants](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo/image_specs/)
 - [Provenance Info](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo/provenance_info/)
 
-## Image Variants
-
-The following tagged variants are available without authentication:
-
-- `latest`: This is a distroless image for running hugo to generate a website. It does not include `apk-tools` or `bash`, so no shell will be available.
-- `latest-dev`: This is a development / builder image that includes `bash`, `apk-tools`, and `busybox`. This variant allows you to customize your final image with additional Wolfi packages.
-
 ### Pulling the Image
 Run the following to pull the image to your local system and execute the command `hugo version`:
 
@@ -42,25 +35,53 @@ hugo v0.119.0-b84644c008e0dc2c4b67bd69cccf87a41a03937e linux/amd64 BuildDate=202
 
 ## Application Setup for End Users
 
-Here is an example using the Hugo image to run the
-["quickstart"](https://gohugo.io/getting-started/quick-start/#commands) locally:
+The following is an example of using the Hugo image locally. It's based on the official [Hugo "quickstart"](https://gohugo.io/getting-started/quick-start/#commands) example.
+
+To begin, start a shell in the Hugo "dev" container:
 
 ```shell
-# Start a shell in the Hugo "dev" container:
-docker run -ti --rm -v -p 8080:8080 --entrypoint=/bin/sh \
-       cgr.dev/chainguard/hugo:latest-dev
-
-# Pass the quickstart commands (changing the bind address and port)
-hugo new site quickstart
-cd quickstart
-git init
-git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke themes/ananke
-echo "theme = 'ananke'" >> config.toml
-hugo server --bind 0.0.0.0 --port 8080
+docker run -v $PWD/data:/home/data --entrypoint=/bin/sh -p 8080:8080 -it \
+cgr.dev/chainguard/hugo:latest-dev
 ```
 
-Now open your browser to [localhost:8080](http://localhost:8080)!
+Create a new Hugo site using the quickstart commands.
+
+```shell
+hugo new site quickstart
+```
+
+Navigate into the new site's root directory.
+
+```shell
+cd quickstart
+```
+
+Initiate an empty Git repository 
+
+```shell
+git init
+```
+
+Clone a Hugo theme into the `themes` directory. 
+
+```shell
+git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke themes/ananke
+```
+
+Add a line to the site's configuration file to let Hugo know to use the new theme.
+
+```shell
+echo "theme = 'ananke'" >> hugo.toml
+```
+
+Start the Hugo development server to serve the site. Be sure to change the default bind address and port to make the site accessible outside of the container.
+
+```shell
+hugo serve --bind 0.0.0.0 --port 8080
+```
+
+Now open your browser to [localhost:8080](http://localhost:8080) to visit the sample site.
+
+When finished, you can press `CTRL + C` to stop the Hugo server from running, and then `CTRL + D` to exit the container shell.
 
 If you're interested in enterprise support, SLAs, and access to older tags, [get in touch](https://www.chainguard.dev/chainguard-images).
-
-

--- a/images/hugo/README.md
+++ b/images/hugo/README.md
@@ -13,7 +13,7 @@
 <!--monopod:end-->
 
 This is a minimal [Hugo](https://gohugo.io/) image. The image only contains
-`hugo` and supporting libraries.  The hugo process starts in `/hugo` by default
+`hugo` and supporting libraries.  The Hugo process starts in `/hugo` by default
 so this directory may be initialized with the Hugo site to serve.
 
 - [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/hugo)
@@ -37,7 +37,7 @@ hugo v0.119.0-b84644c008e0dc2c4b67bd69cccf87a41a03937e linux/amd64 BuildDate=202
 
 The following is an example of using the Hugo image locally. It's based on the official [Hugo "quickstart"](https://gohugo.io/getting-started/quick-start/#commands) example.
 
-To begin, start a shell in the Hugo "dev" container:
+To begin, start a shell in the Hugo developer (dev) container.
 
 ```shell
 docker run -v $PWD/data:/home/data --entrypoint=/bin/sh -p 8080:8080 -it \
@@ -84,4 +84,4 @@ Now open your browser to [localhost:8080](http://localhost:8080) to visit the sa
 
 When finished, you can press `CTRL + C` to stop the Hugo server from running, and then `CTRL + D` to exit the container shell.
 
-If you're interested in enterprise support, SLAs, and access to older tags, [get in touch](https://www.chainguard.dev/chainguard-images).
+If you're interested in enterprise support, SLAs, and access to older tags, [get in touch](https://www.chainguard.dev/contact?utm_source=docs).


### PR DESCRIPTION
This PR is just to update the README for the Hugo image. This update provides some more context around the application setup, corrects a few broken commands, and removes the unnecessary **Image Variants** section (now in a new tab).

I haven't made a PR here in a while so let me know if I did anything incorrectly.

## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [x] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
