### PR TITLE
Add Apache Solr image.

### DIFF
--- a/images/solr/README.md
+++ b/images/solr/README.md
@@ -1,0 +1,64 @@
+<!--monopod:start-->
+# solr
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/solr` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/solr/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+[solr](https://github.com/apache/solr) Solr is the popular, blazing fast open source search platform for all your enterprise, e-commerce, and analytics needs, built on Apache Lucene.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/solr
+```
+
+## Using Solr
+
+This image should be a drop-in replacement for the `slim` variant of the upstream image.
+Documentation is available there: https://hub.docker.com/_/solr
+
+You can run it locally with:
+
+```shell
+$ docker run -p 8983:8983 cgr.dev/chainguard/solr
+Starting Solr
+Java 17 detected. Enabled workaround for SOLR-16463
+[0.002s][warning][pagesize] UseLargePages disabled, no large pages configured and available on the system.
+CompileCommand: exclude com/github/benmanes/caffeine/cache/BoundedLocalCache.put bool exclude = true
+WARNING: A command line option has enabled the Security Manager
+WARNING: The Security Manager is deprecated and will be removed in a future release
+2023-11-23 17:22:03.082 INFO  (main) [] o.e.j.s.Server jetty-10.0.17; built: 2023-10-09T18:22:21.150Z; git: af15f12297adf5c5083e1f2f8f4c5974438bca25; jvm 17.0.10+1-wolfi-r0
+2023-11-23 17:22:03.346 WARN  (main) [] o.e.j.u.DeprecationWarning Using @Deprecated Class org.eclipse.jetty.servlet.listener.ELContextCleaner
+2023-11-23 17:22:03.362 INFO  (main) [] o.a.s.s.CoreContainerProvider Using logger factory org.apache.logging.slf4j.Log4jLoggerFactory
+2023-11-23 17:22:03.366 INFO  (main) [] o.a.s.s.CoreContainerProvider  ___      _       Welcome to Apache Solr? version 9.4.0-SNAPSHOT 71e101bb37497f730078d9afe1991b60d10bfe96 [snapshot build, details omitted]
+2023-11-23 17:22:03.367 INFO  (main) [] o.a.s.s.CoreContainerProvider / __| ___| |_ _   Starting in standalone mode on port 8983
+2023-11-23 17:22:03.367 INFO  (main) [] o.a.s.s.CoreContainerProvider \__ \/ _ \ | '_|  Install dir: /usr/share/java/solr
+2023-11-23 17:22:03.367 INFO  (main) [] o.a.s.s.CoreContainerProvider |___/\___/_|_|    Start time: 2023-11-23T17:22:03.367155177Z
+2023-11-23 17:22:03.368 INFO  (main) [] o.a.s.s.CoreContainerProvider Solr started with "-XX:+CrashOnOutOfMemoryError" that will crash on any OutOfMemoryError exception. The cause of the OOME will be logged in the crash file at the following path: /var/solr/logs/jvm_crash_12.log
+2023-11-23 17:22:03.386 INFO  (main) [] o.a.s.s.CoreContainerProvider Solr Home: /var/solr/data (source: system property: solr.solr.home)
+2023-11-23 17:22:03.399 INFO  (main) [] o.a.s.c.SolrXmlConfig solr.xml not found in SOLR_HOME, using built-in default
+2023-11-23 17:22:03.399 INFO  (main) [] o.a.s.c.SolrXmlConfig Loading solr.xml from /usr/share/java/solr/server/solr/solr.xml
+2023-11-23 17:22:03.451 INFO  (main) [] o.a.s.c.SolrResourceLoader Added 1 libs to classloader, from paths: [/usr/share/java/solr/lib]
+2023-11-23 17:22:04.035 INFO  (main) [] o.a.s.u.t.SimplePropagator Always-on trace id generation enabled.
+2023-11-23 17:22:04.268 WARN  (main) [] o.a.s.u.StartupLoggingUtils Jetty request logging enabled. Will retain logs for last 3 days. See chapter "Configuring Logging" in reference guide for how to configure.
+2023-11-23 17:22:04.270 WARN  (main) [] o.a.s.c.CoreContainer Not all security plugins configured!  authentication=disabled authorization=disabled.  Solr is only as secure as you make it. Consider configuring authentication/authorization before exposing Solr to users internal or external.  See https://s.apache.org/solrsecurity for more info
+2023-11-23 17:22:04.458 INFO  (main) [] o.a.s.c.CorePropertiesLocator Found 0 core definitions underneath /var/solr/data
+2023-11-23 17:22:04.582 WARN  (main) [] o.g.j.m.i.MessagingBinders A class javax.activation.DataSource for a default provider MessageBodyWriter<javax.activation.DataSource> was not found. The provider is not available.
+2023-11-23 17:22:04.803 INFO  (main) [] o.a.s.j.SolrRequestAuthorizer Creating a new SolrRequestAuthorizer
+2023-11-23 17:22:04.903 INFO  (main) [] o.e.j.s.h.ContextHandler Started o.e.j.w.WebAppContext@3aee3976{solr-jetty-context.xml,/solr,file:///usr/share/java/solr/server/solr-webapp/webapp/,AVAILABLE}{/usr/share/java/solr/server/solr-webapp/webapp}
+2023-11-23 17:22:04.921 INFO  (main) [] o.e.j.s.RequestLogWriter Opened /var/solr/logs/2023_11_23.request.log
+2023-11-23 17:22:04.931 INFO  (main) [] o.e.j.s.AbstractConnector Started ServerConnector@556d0826{HTTP/1.1, (http/1.1, h2c)}{0.0.0.0:8983}
+2023-11-23 17:22:04.932 INFO  (main) [] o.e.j.s.Server Started Server@2b491fee{STARTING}[10.0.17,sto=0] @3216ms
+```
+
+The admin console should then be available in your browser at [http://localhost:8983](http://localhost:8983).

--- a/images/solr/config/main.tf
+++ b/images/solr/config/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "solr",
+    // Other packages your image needs
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/solr/config/template.apko.yaml
+++ b/images/solr/config/template.apko.yaml
@@ -1,0 +1,65 @@
+contents:
+  packages: [
+    # Package "solr" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+    "solr-oci-compat",
+  ]
+
+accounts:
+  groups:
+    - groupname: solr
+      gid: 8983
+  users:
+    - username: solr
+      uid: 8983
+      gid: 8983
+  run-as: 8983
+
+environment:
+  PATH: /usr/share/java/solr/bin:/usr/share/java/solr/bin:/usr/share/java/solr/docker/scripts:/usr/share/java/solr/prometheus-exporter/bin:/usr/sbin:/sbin:/usr/bin:/bin
+  SOLR_INCLUDE: /etc/default/solr.in.sh
+  SOLR_HOME: /var/solr/data
+  SOLR_PID_DIR: /var/solr
+  SOLR_LOGS_DIR: /var/solr/logs
+  LOG4J_PROPS: /var/solr/log4j2.xml
+  SOLR_JETTY_HOST: "0.0.0.0"
+  SOLR_ZK_EMBEDDED_HOST: "0.0.0.0"
+
+paths:
+  - path: /docker-entrypoint-initdb.d
+    type: directory
+    uid: 8983
+    gid: 8983
+    permissions: 0o770
+  - path: /var/solr
+    type: directory
+    uid: 8983
+    gid: 8983
+    recursive: true
+    permissions: 0o770
+  - path: /var/solr/data
+    type: directory
+    uid: 8983
+    gid: 8983
+    recursive: true
+    permissions: 0o770
+  - path: /var/solr/logs
+    type: directory
+    uid: 8983
+    gid: 8983
+    recursive: true
+    permissions: 0o770
+  - path: /usr/share/java/solr/server/resources
+    type: directory
+    uid: 8983
+    gid: 8983
+    recursive: true
+    permissions: 0o770
+
+work-dir: /usr/share/java/solr
+
+entrypoint:
+  command: /usr/share/java/solr/docker/scripts/docker-entrypoint.sh
+
+cmd: solr-foreground

--- a/images/solr/main.tf
+++ b/images/solr/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "solr" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.solr.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.solr.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.solr.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/solr/tests/main.tf
+++ b/images/solr/tests/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "manifest" {
+  digest      = var.digest
+  script      = "./runs.sh"
+  working_dir = path.module
+}

--- a/images/solr/tests/runs.sh
+++ b/images/solr/tests/runs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+container_name="aws-flb-${RANDOM}"
+docker run --rm -d -p $FREE_PORT:8983 --name="${container_name}" "${IMAGE_NAME}"
+trap "docker rm -f ${container_name}" EXIT
+
+sleep 10
+docker logs "${container_name}" | grep "Server Started"
+
+curl localhost:$FREE_PORT/api | jq .responseHeader.status | grep 0

--- a/main.tf
+++ b/main.tf
@@ -1017,6 +1017,11 @@ module "smarter-device-manager" {
   target_repository = "${var.target_repository}/smarter-device-manager"
 }
 
+module "solr" {
+  source            = "./images/solr"
+  target_repository = "${var.target_repository}/solr"
+}
+
 module "spark-operator" {
   source            = "./images/spark-operator"
   target_repository = "${var.target_repository}/spark-operator"


### PR DESCRIPTION
## New Image Pull Request Template

### Image Size

- [X] The Image is smaller in size than its common public counterpart.
328MB vs. 350MB

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [X] The image is _not_ tagged with version tags.
- [X] The image is tagged with :latest

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)

### Environment Variables

- [X] Environment variables added.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
