### PR TITLE
Add a Dependency Track image.

### DIFF
--- a/images/dependency-track/README.md
+++ b/images/dependency-track/README.md
@@ -1,0 +1,130 @@
+<!--monopod:start-->
+# dependency-track
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/dependency-track` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/dependency-track/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+
+[Dependency Track](https://github.com/DependencyTrack/dependency-track) Dependency-Track is an intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/dependency-track
+```
+
+## Using Dependency Track
+
+This image should be a drop-in replacement for the `bundled` variant of the upstream image.
+Documentation is available there: https://hub.docker.com/r/dependencytrack/bundled
+
+You can run it locally with:
+
+```shell
+$ docker run -p 8080:8080 cgr.dev/chainguard/dependency-track
+2023-11-24 19:01:49,201 INFO [EmbeddedJettyServer] alpine-executable-war v2.2.3 (3aff068a-a1af-4e38-85dc-3a5ee66ee121) built on: 2023-09-21T16:07:30Z
+2023-11-24 19:01:56,221 INFO [Config] --------------------------------------------------------------------------------
+2023-11-24 19:01:56,223 INFO [Config] OS Name:      Linux
+2023-11-24 19:01:56,223 INFO [Config] OS Version:   6.4.16-linuxkit
+2023-11-24 19:01:56,224 INFO [Config] OS Arch:      aarch64
+2023-11-24 19:01:56,224 INFO [Config] CPU Cores:    12
+2023-11-24 19:01:56,228 INFO [Config] Max Memory:   18.9 GB (20,347,092,992.0 bytes)
+2023-11-24 19:01:56,228 INFO [Config] Java Vendor:  wolfi
+2023-11-24 19:01:56,229 INFO [Config] Java Version: 17.0.10+1-wolfi-r0
+2023-11-24 19:01:56,230 INFO [Config] Java Home:    /usr/lib/jvm/java-17-openjdk
+2023-11-24 19:01:56,230 INFO [Config] Java Temp:    /tmp
+2023-11-24 19:01:56,230 INFO [Config] User:         dtrack
+2023-11-24 19:01:56,230 INFO [Config] User Home:    /home/dtrack
+2023-11-24 19:01:56,230 INFO [Config] --------------------------------------------------------------------------------
+2023-11-24 19:01:56,230 INFO [Config] Initializing Configuration
+2023-11-24 19:01:56,231 INFO [Config] System property alpine.application.properties not specified
+2023-11-24 19:01:56,232 INFO [Config] Loading application.properties from classpath
+2023-11-24 19:01:56,244 INFO [Config] --------------------------------------------------------------------------------
+2023-11-24 19:01:56,244 INFO [Config] Application:  Dependency-Track
+2023-11-24 19:01:56,244 INFO [Config] Version:      4.9.1
+2023-11-24 19:01:56,244 INFO [Config] Built-on:     2023-11-24T16:33:29Z
+2023-11-24 19:01:56,245 INFO [Config] --------------------------------------------------------------------------------
+2023-11-24 19:01:56,245 INFO [Config] Framework:    Alpine
+2023-11-24 19:01:56,245 INFO [Config] Version :     2.2.3
+2023-11-24 19:01:56,245 INFO [Config] Built-on:     2023-09-21T16:07:30Z
+2023-11-24 19:01:56,245 INFO [Config] --------------------------------------------------------------------------------
+2023-11-24 19:01:56,389 INFO [RequirementsVerifier] Initializing requirements verifier
+2023-11-24 19:01:56,389 INFO [UpgradeInitializer] Initializing upgrade framework
+2023-11-24 19:01:58,102 INFO [PersistenceManagerFactory] Initializing persistence framework
+2023-11-24 19:01:58,106 INFO [PersistenceManagerFactory] Creating transactional connection pool
+2023-11-24 19:01:58,191 INFO [PersistenceManagerFactory] Creating non-transactional connection pool
+2023-11-24 19:01:58,400 INFO [HealthCheckInitializer] Registering health checks
+2023-11-24 19:01:58,403 INFO [DefaultObjectGenerator] Initializing default object generator
+2023-11-24 19:01:58,405 INFO [DefaultObjectGenerator] Synchronizing permissions to datastore
+2023-11-24 19:01:58,660 INFO [DefaultObjectGenerator] Adding default users and teams to datastore
+2023-11-24 19:02:00,276 INFO [DefaultObjectGenerator] Synchronizing SPDX license definitions to datastore
+2023-11-24 19:02:02,714 INFO [DefaultObjectGenerator] Adding default license group definitions to datastore
+2023-11-24 19:02:03,137 INFO [DefaultObjectGenerator] Synchronizing default repositories to datastore
+2023-11-24 19:02:03,192 INFO [DefaultObjectGenerator] Synchronizing config properties to datastore
+2023-11-24 19:02:03,276 INFO [DefaultObjectGenerator] Synchronizing notification publishers to datastore
+2023-11-24 19:02:03,458 INFO [CweImporter] Synchronizing CWEs with datastore
+2023-11-24 19:02:05,447 INFO [CweImporter] CWE synchronization complete
+2023-11-24 19:02:05,449 INFO [EventSubsystemInitializer] Initializing asynchronous event subsystem
+2023-11-24 19:02:05,504 INFO [NotificationSubsystemInitializer] Initializing notification service
+2023-11-24 19:02:05,507 INFO [IndexSubsystemInitializer] Building lucene indexes if required
+2023-11-24 19:02:05,521 INFO [IndexManager] Checking the health of index PROJECT
+2023-11-24 19:02:05,523 WARN [IndexManager] The index PROJECT does not exist
+2023-11-24 19:02:05,523 INFO [IndexManager] (Re)Building index project
+2023-11-24 19:02:05,536 INFO [IndexManager] Checking the health of index COMPONENT
+2023-11-24 19:02:05,537 WARN [IndexManager] The index COMPONENT does not exist
+2023-11-24 19:02:05,537 INFO [IndexManager] (Re)Building index component
+2023-11-24 19:02:05,537 INFO [IndexManager] Checking the health of index SERVICECOMPONENT
+2023-11-24 19:02:05,537 WARN [IndexManager] The index SERVICECOMPONENT does not exist
+2023-11-24 19:02:05,537 INFO [IndexManager] (Re)Building index servicecomponent
+2023-11-24 19:02:05,538 INFO [IndexManager] Checking the health of index VULNERABILITY
+2023-11-24 19:02:05,538 WARN [IndexManager] The index VULNERABILITY does not exist
+2023-11-24 19:02:05,538 INFO [IndexManager] (Re)Building index vulnerability
+2023-11-24 19:02:05,538 INFO [IndexManager] Checking the health of index LICENSE
+2023-11-24 19:02:05,538 WARN [IndexManager] The index LICENSE does not exist
+2023-11-24 19:02:05,539 INFO [IndexManager] (Re)Building index license
+2023-11-24 19:02:05,539 INFO [IndexManager] Checking the health of index CPE
+2023-11-24 19:02:05,539 WARN [IndexManager] The index CPE does not exist
+2023-11-24 19:02:05,540 INFO [IndexManager] (Re)Building index cpe
+2023-11-24 19:02:05,540 INFO [IndexManager] Checking the health of index VULNERABLESOFTWARE
+2023-11-24 19:02:05,541 WARN [IndexManager] The index VULNERABLESOFTWARE does not exist
+2023-11-24 19:02:05,541 INFO [IndexManager] (Re)Building index vulnerablesoftware
+2023-11-24 19:02:05,546 INFO [ProjectIndexer] Starting reindex task. This may take some time.
+2023-11-24 19:02:05,546 INFO [IndexManager] Deleting project index
+2023-11-24 19:02:05,594 INFO [AlpineServlet] Starting Dependency-Track
+2023-11-24 19:02:05,758 INFO [ProjectIndexer] Reindexing complete
+2023-11-24 19:02:05,762 INFO [ComponentIndexer] Starting reindex task. This may take some time.
+2023-11-24 19:02:05,762 INFO [IndexManager] Deleting component index
+2023-11-24 19:02:05,779 INFO [ComponentIndexer] Reindexing complete
+2023-11-24 19:02:05,781 INFO [ServiceComponentIndexer] Starting reindex task. This may take some time.
+2023-11-24 19:02:05,781 INFO [IndexManager] Deleting servicecomponent index
+2023-11-24 19:02:05,794 INFO [ServiceComponentIndexer] Reindexing complete
+2023-11-24 19:02:05,795 INFO [VulnerabilityIndexer] Starting reindex task. This may take some time.
+2023-11-24 19:02:05,795 INFO [IndexManager] Deleting vulnerability index
+2023-11-24 19:02:05,811 INFO [VulnerabilityIndexer] Reindexing complete
+2023-11-24 19:02:05,812 INFO [LicenseIndexer] Starting reindex task. This may take some time.
+2023-11-24 19:02:05,813 INFO [IndexManager] Deleting license index
+2023-11-24 19:02:06,587 INFO [LicenseIndexer] Reindexing complete
+2023-11-24 19:02:06,589 INFO [CpeIndexer] Starting reindex task. This may take some time.
+2023-11-24 19:02:06,590 INFO [IndexManager] Deleting cpe index
+2023-11-24 19:02:06,601 INFO [CpeIndexer] Reindexing complete
+2023-11-24 19:02:06,603 INFO [VulnerableSoftwareIndexer] Starting reindex task. This may take some time.
+2023-11-24 19:02:06,603 INFO [IndexManager] Deleting vulnerablesoftware index
+2023-11-24 19:02:06,613 INFO [VulnerableSoftwareIndexer] Reindexing complete
+2023-11-24 19:02:08,402 INFO [KeyManager] Generating new key pair
+2023-11-24 19:02:09,478 INFO [KeyManager] Saving key pair
+2023-11-24 19:02:09,548 INFO [AlpineServlet] Dependency-Track is ready
+2023-11-24 19:02:09,554 INFO [NvdMirrorServlet] Initializing NVD mirror
+2023-11-24 19:02:09,554 INFO [FileSystemResourceServlet] Initializing filesystem resource servlet
+```
+
+The admin console should then be available in your browser at [http://localhost:8080](http://localhost:8080).

--- a/images/dependency-track/config/main.tf
+++ b/images/dependency-track/config/main.tf
@@ -6,8 +6,6 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  // TODO: Add any other packages here you want to conditionally include,
-  // or update this default to [] if this isn't a version stream image.
   default = [
     "dependency-track-bundled",
     // Other packages your image needs

--- a/images/dependency-track/config/main.tf
+++ b/images/dependency-track/config/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "dependency-track-bundled",
+    // Other packages your image needs
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/dependency-track/config/template.apko.yaml
+++ b/images/dependency-track/config/template.apko.yaml
@@ -1,0 +1,48 @@
+contents:
+  packages: [
+    # Package "dependency-track" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+    openjdk-17-default-jvm,
+    busybox
+  ]
+
+accounts:
+  groups:
+    - groupname: dtrack
+      gid: 1000
+  users:
+    - username: dtrack
+      uid: 1000
+      gid: 1000
+  run-as: 1000
+
+environment:
+  JAVA_OPTIONS: "-XX:+UseParallelGC -XX:MaxRAMPercentage=90.0"
+  EXTRA_JAVA_OPTIONS: ""
+  TZ: Etc/UTC
+  # Dependency-Track's default logging level
+  LOGGING_LEVEL: INFO
+  # JVM Options that are passed at runtime by default
+  # JVM Options that can be passed at runtime, while maintaining also those set in JAVA_OPTIONS
+  # The web context defaults to the root. To override, supply an alternative context which starts with a / but does not end with one
+  # Example: /dtrack
+  CONTEXT: "/"
+  LANG: C.UTF-8
+  # Default notification publisher templates override environment variables
+  DEFAULT_TEMPLATES_OVERRIDE_ENABLED: false
+  DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY: /data
+  LOGGING_CONFIG_PATH: "logback.xml"
+
+work-dir: /usr/share/java/dependency-track
+
+paths:
+  - path: /data
+    type: directory
+    permissions: 0o755
+    uid: 1000
+    gid: 1000
+    recursive: true
+
+cmd: |
+  sh -c "exec java ${JAVA_OPTIONS} ${EXTRA_JAVA_OPTIONS} --add-opens java.base/java.util.concurrent=ALL-UNNAMED -Dlogback.configurationFile=${LOGGING_CONFIG_PATH} -DdependencyTrack.logging.level=${LOGGING_LEVEL} -jar /usr/share/java/dependency-track/dependency-track-bundled.jar -context ${CONTEXT}"

--- a/images/dependency-track/main.tf
+++ b/images/dependency-track/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "dependency-track" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.dependency-track.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.dependency-track.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.dependency-track.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/dependency-track/tests/main.tf
+++ b/images/dependency-track/tests/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "manifest" {
+  digest      = var.digest
+  script      = "./runs.sh"
+  working_dir = path.module
+}

--- a/images/dependency-track/tests/runs.sh
+++ b/images/dependency-track/tests/runs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+container_name="dependency-track-${RANDOM}"
+docker run --rm -d -p $FREE_PORT:8080 --name="${container_name}" "${IMAGE_NAME}"
+trap "docker rm -f ${container_name}" EXIT
+
+sleep 10
+
+curl localhost:$FREE_PORT/api/version | jq .application | grep Dependency-Track

--- a/main.tf
+++ b/main.tf
@@ -284,6 +284,11 @@ module "deno" {
   target_repository = "${var.target_repository}/deno"
 }
 
+module "dependency-track" {
+  source            = "./images/dependency-track"
+  target_repository = "${var.target_repository}/dependency-track"
+}
+
 module "dex" {
   source            = "./images/dex"
   target_repository = "${var.target_repository}/dex"


### PR DESCRIPTION
## New Image Pull Request Template

### Image Size

- [X] The Image is smaller in size than its common public counterpart.

293MB vs. 310MB

Notes:

### Image Vulnerabilities

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [X] The image is _not_ tagged with version tags.
- [X] The image is tagged with :latest

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)

### Environment Variables

- [X] Environment variables added.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
