### PR TITLE
adds sqlpad image

### DIFF
--- a/images/sqlpad/README.md
+++ b/images/sqlpad/README.md
@@ -1,0 +1,10 @@
+# Chainguard Images Template
+
+This is a template README.md for new images.
+
+1. Include a brief description of the image here, and instructions about how to use it.
+1. Run `monopod readme`, which will update the top section of this file and the root README.md file.
+1. Update your new `config/template.apko.yaml` file to specify packages you want the image to include, and any other necessary image config.
+1. Call this module from the `main.tf` in the root of this repo, in alphabetical order. (`lint.sh` will yell at you if you don't)
+
+If you need to support version streams, you can leave `packages` empty in `latest.apko.yaml`, and instead add packages to the images using the `extra_packages` TF variable in `config/main.tf`.

--- a/images/sqlpad/README.md
+++ b/images/sqlpad/README.md
@@ -22,3 +22,25 @@ The image is available on `cgr.dev`:
 docker pull cgr.dev/chainguard/sqlpad:latest
 ```
 
+## Important note about data and docker
+
+Unless data volumes are mapped outside the containers, you will lose data inside SQLPad and various database when the containers are shutdown and removed.
+
+If you are using these examples as a starter for something you are working on, you may want to ensure your data is safe before getting into any serious work.
+
+## Running from command line
+
+```sh
+# The most minimal example, mapping port 3000 to local docker host
+docker run -p 3000:3000 cgr.dev/chainguard/sqlpad:latest
+
+# volume and env vars being set and run in background
+# directory `~/docker-volumes` must be shared with docker to work
+docker run --name sqlpad -p 127.0.0.1:3000:3000 --volume ~/docker-volumes/sqlpad-postgres:/var/lib/sqlpad --detach cgr.dev/chainguard/sqlpad:latest
+
+# To list running docker images
+docker ps
+
+# To stop running docker image by name. (otherwise use container id from `docker ps`)
+docker stop sqlpad
+```

--- a/images/sqlpad/README.md
+++ b/images/sqlpad/README.md
@@ -12,7 +12,7 @@
 ---
 <!--monopod:end-->
 
-Minimalist Wolfi-based `sqlpad` images.
+A minimal wolf-based image for sqlpad, which is a web application for generating and running SQL queries and visualizing the results. For more information, please refer to the [applications documentation](https://github.com/sqlpad/sqlpad) on github.
 
 ## Get It!
 
@@ -43,4 +43,18 @@ docker ps
 
 # To stop running docker image by name. (otherwise use container id from `docker ps`)
 docker stop sqlpad
+```
+
+## Deploying via helm
+A helm chart is provided for deploying sqlpad in Kubernetes. This can be found in the applications [GitHub repository](https://github.com/sqlpad/sqlpad/tree/master/sqlpad-charts).
+Below is an example, using the chainguard image with the vendors helm chart:
+```bash
+git clone https://github.com/sqlpad/sqlpad.git && cd sqlpad/sqlpad-charts
+helm dependency update
+helm -n sqlpad install sqlpad  \
+    --namespace sqlpad \
+    --create-namespace \
+    --set image.repository=cgr.dev/chainguard/sqlpad\
+    --set image.tag=latest \
+    ./
 ```

--- a/images/sqlpad/README.md
+++ b/images/sqlpad/README.md
@@ -12,7 +12,7 @@
 ---
 <!--monopod:end-->
 
-A minimal wolf-based image for sqlpad, which is a web application for generating and running SQL queries and visualizing the results. For more information, please refer to the [applications documentation](https://github.com/sqlpad/sqlpad) on github.
+A minimal Wolfi-based image for sqlpad, which is a web application for generating and running SQL queries and visualizing the results. For more information, please refer to the [applications documentation](https://github.com/sqlpad/sqlpad) on github.
 
 ## Get It!
 
@@ -45,9 +45,9 @@ docker ps
 docker stop sqlpad
 ```
 
-## Deploying via helm
-A helm chart is provided for deploying sqlpad in Kubernetes. This can be found in the applications [GitHub repository](https://github.com/sqlpad/sqlpad/tree/master/sqlpad-charts).
-Below is an example, using the chainguard image with the vendors helm chart:
+## Deploying via Helm
+A Helm chart is provided for deploying sqlpad in Kubernetes. This can be found in the applications [GitHub repository](https://github.com/sqlpad/sqlpad/tree/master/sqlpad-charts).
+Below is an example, using the Chainguard image with the vendor's Helm chart:
 ```bash
 git clone https://github.com/sqlpad/sqlpad.git && cd sqlpad/sqlpad-charts
 helm dependency update

--- a/images/sqlpad/README.md
+++ b/images/sqlpad/README.md
@@ -1,10 +1,24 @@
-# Chainguard Images Template
+<!--monopod:start-->
+# sqlpad
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/sqlpad` |
 
-This is a template README.md for new images.
 
-1. Include a brief description of the image here, and instructions about how to use it.
-1. Run `monopod readme`, which will update the top section of this file and the root README.md file.
-1. Update your new `config/template.apko.yaml` file to specify packages you want the image to include, and any other necessary image config.
-1. Call this module from the `main.tf` in the root of this repo, in alphabetical order. (`lint.sh` will yell at you if you don't)
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/sqlpad/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
 
-If you need to support version streams, you can leave `packages` empty in `latest.apko.yaml`, and instead add packages to the images using the `extra_packages` TF variable in `config/main.tf`.
+---
+<!--monopod:end-->
+
+Minimalist Wolfi-based `sqlpad` images.
+
+## Get It!
+
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/sqlpad:latest
+```
+

--- a/images/sqlpad/config/main.tf
+++ b/images/sqlpad/config/main.tf
@@ -10,6 +10,7 @@ variable "extra_packages" {
   // or update this default to [] if this isn't a version stream image.
   default = [
     "sqlpad",
+    "sqlpad-compat"
     // Other packages your image needs
   ]
 }

--- a/images/sqlpad/config/main.tf
+++ b/images/sqlpad/config/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "sqlpad",
+    // Other packages your image needs
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/sqlpad/config/main.tf
+++ b/images/sqlpad/config/main.tf
@@ -6,12 +6,9 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  // TODO: Add any other packages here you want to conditionally include,
-  // or update this default to [] if this isn't a version stream image.
   default = [
     "sqlpad",
     "sqlpad-compat"
-    // Other packages your image needs
   ]
 }
 

--- a/images/sqlpad/config/template.apko.yaml
+++ b/images/sqlpad/config/template.apko.yaml
@@ -33,4 +33,4 @@ paths:
 work-dir: /usr/app/sqlpad-server
 
 entrypoint:
-  command:  node server.js --config ./config.dev.env
+  command: node server.js --config ./config.dev.env

--- a/images/sqlpad/config/template.apko.yaml
+++ b/images/sqlpad/config/template.apko.yaml
@@ -1,9 +1,5 @@
 contents:
-  packages: [
-    # Package "sqlpad" comes in via var.extra_packages
-    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
-    # Otherwise, just add packages here.
-  ]
+  packages: 
 
 accounts:
   groups:

--- a/images/sqlpad/config/template.apko.yaml
+++ b/images/sqlpad/config/template.apko.yaml
@@ -1,0 +1,34 @@
+contents:
+  packages: [
+    # Package "sqlpad" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  SQLPAD_DB_PATH: /var/lib/sqlpad
+  NODE_ENV: production
+  SQLPAD_PORT: 3000
+
+paths:
+  - path: /usr/bin/sqlpad-server
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
+
+entrypoint:
+  command:  /usr/bin/sqlpad-server
+
+cmd: node server.js --config ./config.dev.env

--- a/images/sqlpad/config/template.apko.yaml
+++ b/images/sqlpad/config/template.apko.yaml
@@ -21,14 +21,20 @@ environment:
   SQLPAD_PORT: 3000
 
 paths:
-  - path: /usr/bin/sqlpad-server
+  - path: /var/lib/sqlpad
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
+  - path: /usr/app/sqlpad-server
     type: directory
     permissions: 0o777
     uid: 65532
     gid: 65532
     recursive: true
 
-entrypoint:
-  command:  /usr/bin/sqlpad-server
+work-dir: /usr/app/sqlpad-server
 
-cmd: node server.js --config ./config.dev.env
+entrypoint:
+  command:  node server.js --config ./config.dev.env

--- a/images/sqlpad/main.tf
+++ b/images/sqlpad/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "sqlpad" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev         = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.sqlpad.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.sqlpad.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.sqlpad.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/sqlpad/main.tf
+++ b/images/sqlpad/main.tf
@@ -16,7 +16,7 @@ module "sqlpad" {
   target_repository = var.target_repository
   config            = module.config.config
 
-  build-dev         = true
+  build-dev = true
 
 }
 

--- a/images/sqlpad/main.tf
+++ b/images/sqlpad/main.tf
@@ -10,30 +10,29 @@ variable "target_repository" {
 
 module "config" { source = "./config" }
 
-module "sqlpad" {
+module "latest" {
   source            = "../../tflib/publisher"
   name              = basename(path.module)
   target_repository = var.target_repository
   config            = module.config.config
-
-  build-dev = true
+  build-dev         = true
 
 }
 
 module "test" {
   source = "./tests"
-  digest = module.sqlpad.image_ref
+  digest = module.latest.image_ref
 }
 
 resource "oci_tag" "latest" {
   depends_on = [module.test]
-  digest_ref = module.sqlpad.image_ref
+  digest_ref = module.latest.image_ref
   tag        = "latest"
 }
 
 resource "oci_tag" "latest-dev" {
   depends_on = [module.test]
-  digest_ref = module.sqlpad.dev_ref
+  digest_ref = module.latest.dev_ref
   tag        = "latest-dev"
 }
 

--- a/images/sqlpad/patches/helm.patch
+++ b/images/sqlpad/patches/helm.patch
@@ -1,0 +1,26 @@
+diff --git a/sqlpad-charts/Chart.lock b/sqlpad-charts/Chart.lock
+index b1199c7d6..b29841b89 100644
+--- a/sqlpad-charts/Chart.lock
++++ b/sqlpad-charts/Chart.lock
+@@ -1,6 +1,6 @@
+ dependencies:
+ - name: postgresql
+   repository: https://charts.bitnami.com/bitnami
+-  version: 10.14.0
+-digest: sha256:a75f2f59bcb26bbc8c9efc006acec8c8d1c249d5d6c0fb7905b9e8a11a763852
+-generated: "2021-12-29T16:43:16.781465+08:00"
++  version: 13.2.24
++digest: sha256:abd6c1b2305d088b2cf67813783cc5e9aefd40e7cfcf7273300c00172753b754
++generated: "2023-12-06T17:07:26.781465+05:30"
+diff --git a/sqlpad-charts/requirements.yaml b/sqlpad-charts/requirements.yaml
+index ec52d2dde..39573f652 100644
+--- a/sqlpad-charts/requirements.yaml
++++ b/sqlpad-charts/requirements.yaml
+@@ -1,5 +1,5 @@
+ dependencies:
+   - name: postgresql
+-    version: 10.14.0
++    version: 13.2.24
+     repository: https://charts.bitnami.com/bitnami
+     condition: postgresql.enabled
+\ No newline at end of file

--- a/images/sqlpad/tests/02-curl-test.sh
+++ b/images/sqlpad/tests/02-curl-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+uid="sqlpad-$FREE_PORT"
+
+docker run -d \
+  -p $FREE_PORT:3000 \
+  --name $uid \
+  ${IMAGE_NAME}
+
+# The server takes some time to startup
+sleep 15
+
+docker logs $uid
+
+trap "docker logs $uid; docker kill $uid" EXIT
+
+# The healthcheck endpoint requires auth, so just hit the normal URL.
+curl -L localhost:$FREE_PORT/sqlpad | grep "SQLPad"

--- a/images/sqlpad/tests/03-helm-test.sh
+++ b/images/sqlpad/tests/03-helm-test.sh
@@ -7,7 +7,8 @@ git clone https://github.com/sqlpad/sqlpad.git && cd sqlpad/sqlpad-charts
 # Set up a trap to remove the directory on script exit
 cleanup() {
     echo "Cleaning up..."
-    rm -rf sqlpad
+    rm -rf ../../sqlpad
+    cd ../../
     helm uninstall sqlpad -n sqlpad
     echo "Cleanup complete."
 }

--- a/images/sqlpad/tests/03-helm-test.sh
+++ b/images/sqlpad/tests/03-helm-test.sh
@@ -2,13 +2,13 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-git clone https://github.com/sqlpad/sqlpad.git && cd sqlpad/sqlpad-charts
+TMPDIR="$(mktemp -d)"
+
+git clone https://github.com/sqlpad/sqlpad.git "${TMPDIR}/sqlpad"
 
 # Set up a trap to remove the directory on script exit
 cleanup() {
     echo "Cleaning up..."
-    rm -rf ../../sqlpad
-    cd ../../
     helm uninstall sqlpad -n sqlpad
     echo "Cleanup complete."
 }
@@ -19,12 +19,11 @@ trap cleanup EXIT
 # Will work only when we use updated version postgresql in upstream charts
 helm dependency update
 
-helm -n sqlpad install sqlpad  \
-    --namespace sqlpad \
+helm upgrade --install --namespace sqlpad sqlpad \
     --create-namespace \
     --set image.repository=$IMAGE_REGISTRY_REPO \
     --set image.tag=$IMAGE_TAG \
-    ./
+    "${TMPDIR}/sqlpad/sqlpad-charts"
 
 # check that sqlpad is up and running app=sqlpad label
 kubectl wait --for=condition=ready pod -l app=sqlpad -n sqlpad --timeout=300s

--- a/images/sqlpad/tests/03-helm-test.sh
+++ b/images/sqlpad/tests/03-helm-test.sh
@@ -2,10 +2,18 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}/../"
+
 TMPDIR="$(mktemp -d)"
 
 git clone https://github.com/sqlpad/sqlpad.git "${TMPDIR}/sqlpad"
 
+# Using local patch till postgresql 13.2.24 gets fixed in upstream charts https://github.com/sqlpad/sqlpad/blob/f42ce1a84e1327e69178f38e7b3a2462dcaeeb7c/sqlpad-charts/requirements.yaml#L3
+# A PR is also up for that https://github.com/sqlpad/sqlpad/pull/1212
+cp patches/helm.patch "${TMPDIR}/sqlpad"
+
+cd "${TMPDIR}/sqlpad" && git apply helm.patch
 # Set up a trap to remove the directory on script exit
 cleanup() {
     echo "Cleaning up..."
@@ -16,14 +24,13 @@ cleanup() {
 # Register the cleanup function to be called on script exit (EXIT signal)
 trap cleanup EXIT
 
-# Will work only when we use updated version postgresql in upstream charts
+cd sqlpad-charts
 helm dependency update
-
 helm upgrade --install --namespace sqlpad sqlpad \
     --create-namespace \
     --set image.repository=$IMAGE_REGISTRY_REPO \
     --set image.tag=$IMAGE_TAG \
-    "${TMPDIR}/sqlpad/sqlpad-charts"
+    ./
 
 # check that sqlpad is up and running app=sqlpad label
 kubectl wait --for=condition=ready pod -l app=sqlpad -n sqlpad --timeout=300s

--- a/images/sqlpad/tests/03-helm-test.sh
+++ b/images/sqlpad/tests/03-helm-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+git clone https://github.com/sqlpad/sqlpad.git && cd sqlpad/sqlpad-charts
+
+# Set up a trap to remove the directory on script exit
+cleanup() {
+    echo "Cleaning up..."
+    rm -rf sqlpad
+    helm uninstall sqlpad -n sqlpad
+    echo "Cleanup complete."
+}
+
+# Register the cleanup function to be called on script exit (EXIT signal)
+trap cleanup EXIT
+
+# Will work only when we use updated version postgresql in upstream charts
+helm dependency update
+
+helm -n sqlpad install sqlpad  \
+    --namespace sqlpad \
+    --create-namespace \
+    --set image.repository=$IMAGE_REGISTRY_REPO \
+    --set image.tag=$IMAGE_TAG \
+    ./
+
+# check that sqlpad is up and running app=sqlpad label
+kubectl wait --for=condition=ready pod -l app=sqlpad -n sqlpad --timeout=300s

--- a/images/sqlpad/tests/EXAMPLE_TEST.sh
+++ b/images/sqlpad/tests/EXAMPLE_TEST.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# TODO: Implement this test.

--- a/images/sqlpad/tests/EXAMPLE_TEST.sh
+++ b/images/sqlpad/tests/EXAMPLE_TEST.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset -o errtrace -o pipefail -x
-
-# TODO: Implement this test.

--- a/images/sqlpad/tests/main.tf
+++ b/images/sqlpad/tests/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+// Invoke a script with the test.
+// $IMAGE_NAME is populated with the image name by digest.
+// TODO: Update or remove this test as appropriate.
+data "oci_exec_test" "manifest" {
+  digest      = var.digest
+  script      = "./EXAMPLE_TEST.sh"
+  working_dir = path.module
+}
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "helm" {
+  name             = "{{.ModuleName}}-${random_pet.suffix.id}"
+  namespace        = "{{.ModuleName}}-${random_pet.suffix.id}"
+  repository       = "" // TODO
+  chart            = "" // TODO
+  create_namespace = true
+
+  values = [
+    jsonencode({
+      // TODO:
+    })
+  ]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.helm.id
+  namespace = helm_release.helm.namespace
+}

--- a/images/sqlpad/tests/main.tf
+++ b/images/sqlpad/tests/main.tf
@@ -13,3 +13,17 @@ data "oci_exec_test" "manifest" {
   script      = "./02-curl-test.sh"
   working_dir = path.module
 }
+# Will work only when we use updated version postgresql 13.2.23 in upstream charts https://github.com/sqlpad/sqlpad/blob/f42ce1a84e1327e69178f38e7b3a2462dcaeeb7c/sqlpad-charts/requirements.yaml#L3
+# data "oci_exec_test" "helm-install" {
+#   digest = var.digest
+#   script = "${path.module}/03-helm-test.sh"
+
+#   env {
+#     name  = "IMAGE_REGISTRY_REPO"
+#     value = data.oci_string.ref.registry_repo
+#   }
+#   env {
+#     name  = "IMAGE_TAG"
+#     value = data.oci_string.ref.pseudo_tag
+#   }
+# }

--- a/images/sqlpad/tests/main.tf
+++ b/images/sqlpad/tests/main.tf
@@ -13,7 +13,10 @@ data "oci_exec_test" "manifest" {
   script      = "./02-curl-test.sh"
   working_dir = path.module
 }
+
+data "oci_string" "ref" { input = var.digest }
 # Will work only when we use updated version postgresql 13.2.23 in upstream charts https://github.com/sqlpad/sqlpad/blob/f42ce1a84e1327e69178f38e7b3a2462dcaeeb7c/sqlpad-charts/requirements.yaml#L3
+# Have created PR for this in upstream https://github.com/sqlpad/sqlpad/pull/1212
 # data "oci_exec_test" "helm-install" {
 #   digest = var.digest
 #   script = "${path.module}/03-helm-test.sh"

--- a/images/sqlpad/tests/main.tf
+++ b/images/sqlpad/tests/main.tf
@@ -17,16 +17,16 @@ data "oci_exec_test" "manifest" {
 data "oci_string" "ref" { input = var.digest }
 # Will work only when we use updated version postgresql 13.2.23 in upstream charts https://github.com/sqlpad/sqlpad/blob/f42ce1a84e1327e69178f38e7b3a2462dcaeeb7c/sqlpad-charts/requirements.yaml#L3
 # Have created PR for this in upstream https://github.com/sqlpad/sqlpad/pull/1212
-# data "oci_exec_test" "helm-install" {
-#   digest = var.digest
-#   script = "${path.module}/03-helm-test.sh"
+data "oci_exec_test" "helm-install" {
+  digest = var.digest
+  script = "${path.module}/03-helm-test.sh"
 
-#   env {
-#     name  = "IMAGE_REGISTRY_REPO"
-#     value = data.oci_string.ref.registry_repo
-#   }
-#   env {
-#     name  = "IMAGE_TAG"
-#     value = data.oci_string.ref.pseudo_tag
-#   }
-# }
+  env {
+    name  = "IMAGE_REGISTRY_REPO"
+    value = data.oci_string.ref.registry_repo
+  }
+  env {
+    name  = "IMAGE_TAG"
+    value = data.oci_string.ref.pseudo_tag
+  }
+}

--- a/images/sqlpad/tests/main.tf
+++ b/images/sqlpad/tests/main.tf
@@ -8,33 +8,8 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-// Invoke a script with the test.
-// $IMAGE_NAME is populated with the image name by digest.
-// TODO: Update or remove this test as appropriate.
 data "oci_exec_test" "manifest" {
   digest      = var.digest
-  script      = "./EXAMPLE_TEST.sh"
+  script      = "./02-curl-test.sh"
   working_dir = path.module
-}
-
-resource "random_pet" "suffix" {}
-
-resource "helm_release" "helm" {
-  name             = "{{.ModuleName}}-${random_pet.suffix.id}"
-  namespace        = "{{.ModuleName}}-${random_pet.suffix.id}"
-  repository       = "" // TODO
-  chart            = "" // TODO
-  create_namespace = true
-
-  values = [
-    jsonencode({
-      // TODO:
-    })
-  ]
-}
-
-module "helm_cleanup" {
-  source    = "../../../tflib/helm-cleanup"
-  name      = helm_release.helm.id
-  namespace = helm_release.helm.namespace
 }

--- a/main.tf
+++ b/main.tf
@@ -1045,6 +1045,11 @@ module "spire-again-for-testing" {
   target_repository = "${var.target_repository}/spire"
 }
 
+module "sqlpad" {
+  source            = "./images/sqlpad"
+  target_repository = "${var.target_repository}/sqlpad"
+}
+
 module "stakater-reloader" {
   source            = "./images/stakater-reloader"
   target_repository = "${var.target_repository}/stakater-reloader"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes: **Reduced from 110 CVEs to 0 CVEs**

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes: 

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes: N/A

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes: The upstream helm chart has an outdated version of `postgresql` chart as dep. Will work only when we use updated version `postgresql 13.2.23` in upstream charts https://github.com/sqlpad/sqlpad/blob/f42ce1a84e1327e69178f38e7b3a2462dcaeeb7c/sqlpad-charts/requirements.yaml#L313.2.23

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
