### PR TITLE
feat: add mc to minio image

### DIFF
--- a/images/minio/main.tf
+++ b/images/minio/main.tf
@@ -11,7 +11,7 @@ variable "target_repository" {
 locals {
   packages = {
     "minio" : {
-      extra_packages : ["minio"],
+      extra_packages : ["minio", "mc"],
       entrypoint : "/usr/bin/minio"
       repository = var.target_repository
     },
@@ -65,4 +65,3 @@ resource "oci_tag" "latest-dev" {
   digest_ref = module.latest[each.key].dev_ref
   tag        = "latest-dev"
 }
-


### PR DESCRIPTION
- `mc` is a requirement of the upstream minio image

## Confirmation

```sh
crane export minio/minio:RELEASE.2023-11-11T08-14-41Z - | tar -tvf - | sort | grep mc                                                  
-rwxr-xr-x  0 0      0    26677248 11 Nov 18:36 usr/bin/mc

docker run --rm --entrypoint bash -it minio/minio:RELEASE.2023-11-11T08-14-41Z
bash-5.1# ls -lah /usr/bin/mc
-rwxr-xr-x 1 root root 26M Nov 11 18:36 /usr/bin/mc
```
