### PR TITLE
re-add version tags for minio

### DIFF
--- a/images/minio/main.tf
+++ b/images/minio/main.tf
@@ -68,8 +68,8 @@ resource "oci_tag" "latest-dev" {
 
 // TODO(jason): Stop version-tagging this public image.
 module "tagger" {
-  for_each = local.packages
-  source   = "../../tflib/tagger"
+  for_each   = local.packages
+  source     = "../../tflib/tagger"
   depends_on = [module.test-latest]
 
   tags = merge(

--- a/images/minio/main.tf
+++ b/images/minio/main.tf
@@ -65,3 +65,15 @@ resource "oci_tag" "latest-dev" {
   digest_ref = module.latest[each.key].dev_ref
   tag        = "latest-dev"
 }
+
+// TODO(jason): Stop version-tagging this public image.
+module "tagger" {
+  for_each = local.packages
+  source   = "../../tflib/tagger"
+  depends_on = [module.test-latest]
+
+  tags = merge(
+    { for t in module.version-tags[each.key].tag_list : t => module.latest[each.key].image_ref },
+    { for t in module.version-tags[each.key].tag_list : "${t}-dev" => module.latest[each.key].dev_ref },
+  )
+}

--- a/images/minio/main.tf
+++ b/images/minio/main.tf
@@ -70,7 +70,7 @@ resource "oci_tag" "latest-dev" {
 module "version-tags" {
   for_each = local.packages
   source   = "../../tflib/version-tags"
-  package  = each.value
+  package  = each.value.extra_packages[0]
   config   = module.latest[each.key].config
 }
 module "tagger" {

--- a/images/minio/main.tf
+++ b/images/minio/main.tf
@@ -67,6 +67,12 @@ resource "oci_tag" "latest-dev" {
 }
 
 // TODO(jason): Stop version-tagging this public image.
+module "version-tags" {
+  for_each = local.packages
+  source   = "../../tflib/version-tags"
+  package  = each.value
+  config   = module.latest[each.key].config
+}
 module "tagger" {
   for_each   = local.packages
   source     = "../../tflib/tagger"


### PR DESCRIPTION
Tagging was removed in https://github.com/chainguard-images/images/pull/1840 after disabling version tags for everything in #1819 

However, https://github.com/chainguard-images/images/pull/1906 re-enabled them for minio, so we need to re-apply those tags again in the TF.