### PR TITLE
Fix newrelic k8s events forwarder test

### DIFF
--- a/images/newrelic-k8s-events-forwarder/tests/main.tf
+++ b/images/newrelic-k8s-events-forwarder/tests/main.tf
@@ -18,6 +18,11 @@ data "oci_string" "ref" {
 
 resource "random_pet" "suffix" {}
 
+resource "random_integer" "random_port" {
+  min = 1025
+  max = 65534
+}
+
 resource "helm_release" "nri-bundle" {
   name             = "newrelic-kef-${random_pet.suffix.id}"
   namespace        = "newrelic-kef-${random_pet.suffix.id}"
@@ -46,6 +51,11 @@ resource "helm_release" "nri-bundle" {
             }
             name = "var-run-newrelic-infra"
           }]
+        }
+        common = {
+          agentConfig = {
+            http_server_port = random_integer.random_port.result
+          }
         }
         images = {
           forwarder = {

--- a/images/newrelic-k8s-events-forwarder/tests/main.tf
+++ b/images/newrelic-k8s-events-forwarder/tests/main.tf
@@ -54,6 +54,9 @@ resource "helm_release" "nri-bundle" {
         }
         common = {
           agentConfig = {
+            # This agent uses the host network so we were getting port
+            # conflicts. This has the potential to be a flaky test due
+            # to being random and not gauranteed to be a free port.
             http_server_port = random_integer.random_port.result
           }
         }


### PR DESCRIPTION
Newrelic k8s-events-forwarder was hitting port conflicts. I added a random integer for the port to help alleviate the conflicts. Ideally this would make use of FREE_PORT but there's no way to get at it from terraform yet.