### PR TITLE
minor updates to a few READMEs

### DIFF
--- a/images/calico/README.md
+++ b/images/calico/README.md
@@ -17,20 +17,20 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
-The image is available on `cgr.dev`:
-
-```
-docker pull cgr.dev/chainguard/calico:latest
-```
 <!--getting:end-->
 
 <!--body:start-->
 ## Installation
 
-There are several ways to install Calico. This document follows the upstream recommended way with the `tigera-operator` ([ref](https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart#install-calico)).
+There are several ways you can install Calico onto a Kubernetes cluster. This document follows method recommended in the [official Calico documentation](https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart#install-calico) which involves using the Tigera Calico operator. 
 
-There are two CRDs involved that work together to use the correct Chainguard Images:
+After setting up and connecting to the Kubernetes cluster where you want to install Calico, install the Tigera Calico operator and custom resource definitions (CRDs).
+
+```shell
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.4/manifests/tigera-operator.yaml
+```
+
+Then apply the following YAML manifest to create two CRDs.
 
 ```yaml
 ---
@@ -72,5 +72,11 @@ spec:
   imagePrefix: calico-
 ```
 
-The above combination of `ImageSet` and `Installation` can be used as a drop in replacement for the [upstream documentation](https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart#install-calico) step 2 (`custom-resources.yaml`) to correctly rename the Calico images to their `cgr.dev` variants.
+The combination of these `ImageSet` and `Installation` CRDs serve as a drop in replacement for [Step 2 of the upstream documentation](https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart#install-calico). Together, these correctly rename the Calico images to their `cgr.dev` variants.
+
+After creating the CRDs, you can ensure that the pods are running with a command like the following.
+
+```shell
+kubectl get pods -n calico-system
+```
 <!--body:end-->

--- a/images/haproxy-ingress/README.md
+++ b/images/haproxy-ingress/README.md
@@ -13,32 +13,44 @@
 <!--monopod:end-->
 
 <!--overview:start-->
-Kubernetes ingress controller implementation for HAProxy
+[HAProxy Ingress](https://haproxy-ingress.github.io/) is a Kubernetes ingress controller implementation for HAProxy.
 <!--overview:end-->
 
 <!--getting:start-->
 ## Get It!
-The image is available on `cgr.dev`:
+The image is available on `cgr.dev`.
 
-```
+```shell
 docker pull cgr.dev/chainguard/haproxy-ingress:latest
 ```
 <!--getting:end-->
 
 <!--body:start-->
-# Usage
+# Use It!
 
-You can use this image with the [Helm Chart](https://artifacthub.io/packages/helm/haproxy-ingress/haproxy-ingress) of the project:
+You can use this image with the `haproxy-ingress` project's [Helm chart](https://artifacthub.io/packages/helm/haproxy-ingress/haproxy-ingress). To begin, add the Helm chart's repository.
 
 ```shell
 helm repo add haproxy-ingress https://haproxy-ingress.github.io/charts
+```
 
+Then run the following command to retrieve the latest information about the charts in the repository you just added.
+
+```shell
 helm repo update
+```
 
+Then install `haproxy-ingress` with the following command. This command directs Helm to install it using Chainguard's `haprox-ingress:latest` image.
+
+```shell
 helm install ingress haproxy-ingress/haproxy-ingress \
   --set controller.image.repository="cgr.dev/chainguard/haproxy-ingress" \
   --set controller.image.tag="latest"
+```
 
+Run the following command to confirm that the the Pod is running and ready to use.
+
+```shell
 kubectl wait --for=condition=ready pod --selector "app.kubernetes.io/name=haproxy-ingress" --timeout=120s
 ```
 <!--body:end-->

--- a/images/helm/README.md
+++ b/images/helm/README.md
@@ -18,7 +18,7 @@ Minimal image with [helm](https://helm.sh) binary. **EXPERIMENTAL**
 
 <!--getting:start-->
 ## Get It!
-The image is available on `cgr.dev`:
+The image is available on `cgr.dev`.
 
 ```
 docker pull cgr.dev/chainguard/helm:latest
@@ -26,23 +26,18 @@ docker pull cgr.dev/chainguard/helm:latest
 <!--getting:end-->
 
 <!--body:start-->
-## Image Variants
 
-Our `latest` tags use the most recent build of the [Wolfi helm](https://github.com/wolfi-dev/os/blob/main/helm.yaml) package. The following tagged variants are available without authentication:
+## Testing the Helm Image
 
-- `latest`: This is a distroless image for running helm to install packages to a kubernetes cluster. It does not include `apk-tools` or `bash`, so no shell will be available.
-- `latest-dev`: This is a development / builder image that includes `bash`, `apk-tools`, and `busybox`. This variant allows you to customize your final image with additional Wolfi packages.
-
-### Helm Version
-This will automatically pull the image to your local system and execute the command `helm version`:
+The following command will pull the image to your local system and automatically execute the `helm version` command:
 
 ```shell
 docker run --rm  cgr.dev/chainguard/helm version
 ```
 
-You should see output similar to this:
+This will return output similar to this.
 
 ```
-version.BuildInfo{Version:"v3.13.1", GitCommit:"3547a4b5bf5edb5478ce352e18858d8a552a4110", GitTreeState:"dirty", GoVersion:"go1.21.3"}
+version.BuildInfo{Version:"v3.13.2", GitCommit:"2a2fb3b98829f1e0be6fb18af2f6599e0f4e8243", GitTreeState:"clean", GoVersion:"go1.21.4"}
 ```
 <!--body:end-->


### PR DESCRIPTION
Another PR with some README updates. These are mostly small formatting improvements to the READMEs for the `calico`, `helm`, and `haproxy-ingress` images. 

As with previous updates, I'd like approval from someone from Dev Enablement before this gets merged. Thanks!

## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
