### PR TITLE
migrate memcached to config module

### DIFF
--- a/images/memcached/config/main.tf
+++ b/images/memcached/config/main.tf
@@ -8,7 +8,7 @@ module "accts" { source = "../../../tflib/accts" }
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. memcached)."
-  default     = [""]
+  default     = ["memcached"]
 }
 
 variable "entrypoint" {


### PR DESCRIPTION
This is mostly just renaming `configs` to `config`, since it already had a `main.tf` in it.