### PR TITLE
Add k8ssandra-operator

### DIFF
--- a/images/k8ssandra-operator/README.md
+++ b/images/k8ssandra-operator/README.md
@@ -1,0 +1,16 @@
+<!--monopod:start-->
+# k8ssandra-operator
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/k8ssandra-operator` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/k8ssandra-operator/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+k8ssandra-operator is the Kubernetes operator for
+[K8ssandra](https://docs.k8ssandra.io/).

--- a/images/k8ssandra-operator/config/main.tf
+++ b/images/k8ssandra-operator/config/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = [
+    "k8ssandra-operator-compat",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/k8ssandra-operator/config/template.apko.yaml
+++ b/images/k8ssandra-operator/config/template.apko.yaml
@@ -1,0 +1,19 @@
+contents:
+  packages: [
+    # Package "k8ssandra-operator" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/manager

--- a/images/k8ssandra-operator/main.tf
+++ b/images/k8ssandra-operator/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "k8ssandra-operator" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.k8ssandra-operator.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.k8ssandra-operator.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.k8ssandra-operator.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/k8ssandra-operator/tests/main.tf
+++ b/images/k8ssandra-operator/tests/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+resource "random_pet" "suffix" {
+  length = 1
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "helm_release" "cert-manager" {
+  name             = "cert-manager-${random_pet.suffix.id}"
+  namespace        = "cert-manager"
+  repository       = "https://charts.jetstack.io" // TODO
+  chart            = "cert-manager"               // TODO
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+}
+
+resource "helm_release" "helm" {
+  // We use a shortened name to avoid hitting the 63 character limit for cert-manager names.
+  name             = "k8ss-op-${random_pet.suffix.id}"
+  namespace        = "k8ss-op-${random_pet.suffix.id}"
+  repository       = "https://helm.k8ssandra.io/stable" // TODO
+  chart            = "k8ssandra-operator"               // TODO
+  create_namespace = true
+
+  // Requires cert-manager to be installed first.
+  depends_on = [helm_release.cert-manager]
+
+  values = [jsonencode({
+    image = {
+      registry   = data.oci_string.ref.registry
+      repository = data.oci_string.ref.repo
+      tag        = data.oci_string.ref.pseudo_tag
+    }
+  })]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.helm.id
+  namespace = helm_release.helm.namespace
+}
+
+module "helm_cleanup_cert_manager" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.cert-manager.id
+  namespace = helm_release.cert-manager.namespace
+
+  // Uninstall in reverse order so we don't clean this up prematurely.
+  depends_on = [module.helm_cleanup]
+}

--- a/main.tf
+++ b/main.tf
@@ -523,6 +523,11 @@ module "k8sgpt-operator" {
   target_repository = "${var.target_repository}/k8sgpt-operator"
 }
 
+module "k8ssandra-operator" {
+  source            = "./images/k8ssandra-operator"
+  target_repository = "${var.target_repository}/k8ssandra-operator"
+}
+
 module "kafka" {
   source            = "./images/kafka"
   target_repository = "${var.target_repository}/kafka"


### PR DESCRIPTION
## New Image Pull Request Template

Part of https://github.com/chainguard-dev/image-requests/issues/517

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

```sh
$ imgsize k8ssandra/k8ssandra-operator
26M
$ imgsize ttl.sh/wlynch/k8ssandra-operator:latest@sha256:3c6ba79a1c2b39a2cbae529fe99c1f4d43cc277f21e27efdf1bc8e2d4d55e8aa
17M
```

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [x] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
