### PR TITLE
feat: add variables for Java version on JDK tests

### DIFF
--- a/images/jdk/tests/main.tf
+++ b/images/jdk/tests/main.tf
@@ -8,13 +8,27 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
+variable "java-source-version" {
+  type        = number
+  description = "The Java source version to use for compilation in this test."
+  default     = 8
+}
+
+variable "java-target-version" {
+  type        = number
+  description = "The Java target version to use for compilation in this test."
+  default     = 8
+}
+
 data "oci_exec_test" "version" {
   digest = var.digest
   script = "docker run --rm $IMAGE_NAME javac -version"
 }
 
 module "jre-test" {
-  source    = "../../jre/tests"
-  digest    = var.digest
-  sdk-image = var.digest
+  source              = "../../jre/tests"
+  digest              = var.digest
+  sdk-image           = var.digest
+  java-source-version = var.java-source-version
+  java-target-version = var.java-target-version
 }


### PR DESCRIPTION
Add variables to the JDK tests for code parity with the JRE tests.