### PR TITLE
New image: ml-metadata-store-server

### DIFF
--- a/images/ml-metadata-store-server/README.md
+++ b/images/ml-metadata-store-server/README.md
@@ -1,0 +1,32 @@
+<!--monopod:start-->
+# ml-metadata-store-server
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/ml-metadata-store-server` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/ml-metadata-store-server/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Remote gRPC server for ML Metadata
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/ml-metadata-store-server:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+This image is a drop-in replacement for the upstream image. Please refer to the [TensorFlow documentation](https://www.tensorflow.org/tfx/guide/mlmd#use_mlmd_with_a_remote_grpc_server) for more details.
+<!--body:end-->

--- a/images/ml-metadata-store-server/config/main.tf
+++ b/images/ml-metadata-store-server/config/main.tf
@@ -1,0 +1,19 @@
+variable "extra_packages" {
+  description = "The additional packages to install"
+  type        = list(string)
+  default     = ["ml-metadata-store-server"]
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/metadata_store_server"
+    }
+  })
+}

--- a/images/ml-metadata-store-server/main.tf
+++ b/images/ml-metadata-store-server/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "ml-metadata-store-server" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.ml-metadata-store-server.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.ml-metadata-store-server.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.ml-metadata-store-server.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/ml-metadata-store-server/tests/main.tf
+++ b/images/ml-metadata-store-server/tests/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "ml-metadata-test" {
+  digest      = var.digest
+  script      = "./ml-metadata-test.sh"
+  working_dir = path.module
+}

--- a/images/ml-metadata-store-server/tests/ml-metadata-test.py
+++ b/images/ml-metadata-store-server/tests/ml-metadata-test.py
@@ -1,0 +1,38 @@
+import sys
+from grpc import insecure_channel
+from ml_metadata.proto import metadata_store_pb2
+from ml_metadata.proto import metadata_store_service_pb2
+from ml_metadata.proto import metadata_store_service_pb2_grpc
+
+def main():
+	channel = insecure_channel(sys.argv[1])
+	stub = metadata_store_service_pb2_grpc.MetadataStoreServiceStub(channel)
+
+	artifact_type = metadata_store_pb2.ArtifactType(name='MyArtifactType',
+																									properties={'property_1': metadata_store_pb2.INT,
+																															'property_2': metadata_store_pb2.STRING})
+	put_type_request = metadata_store_service_pb2.PutArtifactTypeRequest(artifact_type=artifact_type)
+	print("PutArtifactTypeRequest:")
+	print(put_type_request)
+	artifact_type_id = stub.PutArtifactType(put_type_request).type_id
+	print("Artifact type id:")
+	print(artifact_type_id)
+	print("GetArtifactTypesResponse:")
+	print(stub.GetArtifactTypes(metadata_store_service_pb2.GetArtifactTypesRequest()))
+
+	artifact = metadata_store_pb2.Artifact(type_id=artifact_type_id,
+																				properties={'property_1': metadata_store_pb2.Value(int_value=123),
+																										'property_2': metadata_store_pb2.Value(string_value='example value')})
+	put_artifacts_request = metadata_store_service_pb2.PutArtifactsRequest(artifacts=[artifact])
+	print("PutArtifactsRequest:")
+	print(put_artifacts_request)
+	put_artifacts_response = stub.PutArtifacts(put_artifacts_request)
+	print("PutArtifactsResponse:")
+	print(put_artifacts_response)
+
+	channel.close()
+
+if __name__ == "__main__":
+	main()
+	print("Done")
+

--- a/images/ml-metadata-store-server/tests/ml-metadata-test.sh
+++ b/images/ml-metadata-store-server/tests/ml-metadata-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+docker network create mlmd || true
+
+TMP=$(mktemp -d)
+cat <<EOF > "${TMP}/mlmd-config.yaml"
+connection_config {
+  sqlite {
+    filename_uri: '/tmp/test_db'
+    connection_mode: READWRITE_OPENCREATE
+  }
+}
+EOF
+# Start the server
+ID=$(docker run --rm --net mlmd -v "/tmp/mlmd-config.yaml:/mlmd-config.yaml" -d ${IMAGE_NAME} --metadata_store_server_config_file=/mlmd-config.yaml)
+
+trap "(rm -rf "${TMP}" || sudo rm -rf "${TMP}") && \
+  docker logs $ID && docker rm -f $ID && \
+  docker network rm mlmd" EXIT
+sleep 2
+SERVER_IP=$(docker inspect ${ID} | jq -r '.[0].NetworkSettings.Networks.mlmd.IPAddress')
+
+docker pull cgr.dev/chainguard/python:latest-dev
+docker build -t ml-metadata-tester -f - . <<EOF
+FROM cgr.dev/chainguard/python:latest-dev
+USER root
+RUN apk add py3-ml-metadata py3-protobuf py3-absl-py py3-attrs && pip3 install grpcio
+COPY ./ml-metadata-test.py /home/ml-metadata-test.py
+ENTRYPOINT ["python3", "/home/ml-metadata-test.py"]
+EOF
+
+TESTER_ID=$(docker run --net mlmd -d ml-metadata-tester ${SERVER_IP}:8080)
+docker wait ${TESTER_ID}
+docker logs ${TESTER_ID}
+docker logs ${TESTER_ID} 2>&1 | grep "Done"
+docker rm -f ${TESTER_ID}

--- a/images/ml-metadata-store-server/tests/ml-metadata-test.sh
+++ b/images/ml-metadata-store-server/tests/ml-metadata-test.sh
@@ -16,7 +16,7 @@ connection_config {
 }
 EOF
 # Start the server
-ID=$(docker run --rm --net mlmd -v "/tmp/mlmd-config.yaml:/mlmd-config.yaml" -d ${IMAGE_NAME} --metadata_store_server_config_file=/mlmd-config.yaml)
+ID=$(docker run --rm --net mlmd -v "${TMP}/mlmd-config.yaml:/mlmd-config.yaml" -d ${IMAGE_NAME} --metadata_store_server_config_file=/mlmd-config.yaml)
 
 trap "(rm -rf "${TMP}" || sudo rm -rf "${TMP}") && \
   docker logs $ID && docker rm -f $ID && \

--- a/main.tf
+++ b/main.tf
@@ -758,6 +758,11 @@ module "minio" {
   target_repository = "${var.target_repository}/minio"
 }
 
+module "ml-metadata-store-server" {
+  source            = "./images/ml-metadata-store-server"
+  target_repository = "${var.target_repository}/ml-metadata-store-server"
+}
+
 module "nats" {
   source            = "./images/nats"
   target_repository = "${var.target_repository}/nats"


### PR DESCRIPTION
Needs https://github.com/wolfi-dev/os/pull/9703

## New Image Pull Request Template

### Image Size

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:
12M vs 68M

### Image Vulnerabilities

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging

- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster

N/A

### Basic Testing - Package/Application

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compact package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

See python test

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
