### PR TITLE
fix: add dependency on k8ssandra-operator to image

### DIFF
--- a/images/k8ssandra-operator/config/main.tf
+++ b/images/k8ssandra-operator/config/main.tf
@@ -7,6 +7,7 @@ terraform {
 variable "extra_packages" {
   description = "The additional packages to install"
   default = [
+    "k8ssandra-operator",
     "k8ssandra-operator-compat",
   ]
 }


### PR DESCRIPTION
Fix the extra packages after the change to the `k8ssandra-operator-compat` package to remove the runtime dependency on `k8ssandra-operator`.