### PR TITLE
fix image and use compat packages

### DIFF
--- a/images/temporal-admin-tools/config/main.tf
+++ b/images/temporal-admin-tools/config/main.tf
@@ -14,7 +14,12 @@ variable "extra_packages" {
     "temporal",
     "temporal-cassandra-tool",
     "temporal-sql-tool",
-    "temporal-server-schema"
+    "temporal-server-schema",
+    "tctl-compat",
+    "tdbg-compat",
+    "temporal-compat",
+    "temporal-cassandra-tool-compat",
+    "temporal-sql-tool-compat"
   ]
 }
 

--- a/images/temporal-admin-tools/config/template.apko.yaml
+++ b/images/temporal-admin-tools/config/template.apko.yaml
@@ -1,19 +1,33 @@
 contents:
-  packages: [
-    # Package "tctl" comes in via var.extra_packages
-    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
-    # Otherwise, just add packages here.
-  ]
+  packages:
+    - busybox
+    - tini
 
 accounts:
   groups:
-    - groupname: nonroot
-      gid: 65532
+    - groupname: temporal
+      gid: 1000
   users:
-    - username: nonroot
-      uid: 65532
-      gid: 65532
-  run-as: 65532
+    - username: temporal
+      uid: 1000
+      gid: 1000
+  run-as: 1000
+
+paths:
+  - path: /etc/temporal
+    type: directory
+    uid: 1000
+    gid: 1000
+    permissions: 0o755
+    recursive: true
+
+environment:
+  TEMPORAL_HOME: /etc/temporal
 
 entrypoint:
-  command: /usr/bin/tctl
+  command: "/sbin/tini --"
+
+# This is what the upstream Dockerfile does, so we're replicating here: https://github.com/temporalio/docker-builds/blob/main/admin-tools.Dockerfile#L49
+cmd: "sleep infinity"
+
+work-dir: /etc/temporal

--- a/images/temporal-admin-tools/tests/run.sh
+++ b/images/temporal-admin-tools/tests/run.sh
@@ -2,4 +2,4 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-docker run --rm ${IMAGE_NAME} --help
+docker run --rm ${IMAGE_NAME} sleep 1


### PR DESCRIPTION
I feel there's missing compat packages which are needed for symlink and apko.yaml is needed to modify to use correct entry point and permissions, the original PR is here https://github.com/chainguard-images/images/pull/1917 
The Dockerfile is here https://github.com/temporalio/docker-builds/blob/main/admin-tools.Dockerfile#L30-L36