### PR TITLE
Remove packages which are defined in the package as runtime dependencies

### DIFF
--- a/images/keycloak/config/main.tf
+++ b/images/keycloak/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  default     = ["openjdk-17", "openjdk-17-default-jvm", "keycloak"]
+  default     = ["keycloak"]
 }
 
 data "apko_config" "this" {


### PR DESCRIPTION
Removing packages which are already defined as runtime dependencies in the [keycloak wolfi package](https://github.com/wolfi-dev/os/blob/56be435602874b7aa055a5d16d04d8ba57cad927/keycloak.yaml#L11). Also the JDK was defined here but is not required, so this should reduce the size of the image.