### PR TITLE
postgres: set entrypoint to /usr/bin

### DIFF
--- a/images/postgres/config/main.tf
+++ b/images/postgres/config/main.tf
@@ -34,7 +34,7 @@ output "config" {
       "LANG" : "en_US.UTF-8"
     }, var.environment)
     entrypoint = {
-      command = "/var/lib/postgres/initdb/postgresql-entrypoint.sh postgres"
+      command = "/usr/bin/postgresql-entrypoint.sh postgres"
     }
     work-dir = "/home/postgres"
     paths = [{


### PR DESCRIPTION
Point to new entrypoint location in /usr/bin


Context: https://github.com/wolfi-dev/os/issues/9903
Blocked on: https://github.com/wolfi-dev/os/pull/9905 (or another fix)
