### PR TITLE
deconflict postgres_network

### DIFF
--- a/images/postgres/tests/tls.sh
+++ b/images/postgres/tests/tls.sh
@@ -4,7 +4,7 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 
 server_name="postgres_server"
 client_name="postgres_client"
-network_name="postgres_network"
+network_name="postgres_network-${RANDOM}"
 certs_dir="certs"
 postgres_password="secret"
 

--- a/images/postgres/tests/tls.sh
+++ b/images/postgres/tests/tls.sh
@@ -2,8 +2,8 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-server_name="postgres_server"
-client_name="postgres_client"
+server_name="postgres_server-${RANDOM}"
+client_name="postgres_client-${RANDOM}"
 network_name="postgres_network-${RANDOM}"
 certs_dir="certs"
 postgres_password="secret"


### PR DESCRIPTION
If we run multiple tests concurrently they conflict on the network name.

```
  Cleaning up...
  + docker rm -f postgres_server postgres_client
  Error response from daemon: No such container: postgres_server
  Error response from daemon: No such container: postgres_client
  + docker network rm postgres_network
  Error response from daemon: network postgres_network is ambiguous (2 matches found based on name)
```