### PR TITLE
Use older cilium cli to test

### DIFF
--- a/images/cilium/tests/cilium-install.sh
+++ b/images/cilium/tests/cilium-install.sh
@@ -72,9 +72,6 @@ $TMPDIR/cilium install --context k3d-$CLUSTER_NAME \
     --helm-set hubble.ui.backend.image.override=$HUBBLE_UI_BACKEND_IMAGE \
     --helm-set operator.image.override=$OPERATOR_IMAGE
 
-# Enable Hubble, as well as UI
-$TMPDIR/cilium hubble enable --ui
-
 $TMPDIR/cilium status --context k3d-$CLUSTER_NAME --wait
 
 QUAY_IMAGES=$($TMPDIR/cilium status --context k3d-$CLUSTER_NAME -o json | grep quay.io || true )

--- a/images/cilium/tests/cilium-install.sh
+++ b/images/cilium/tests/cilium-install.sh
@@ -52,7 +52,7 @@ done
 
 # Download the cilium CLI
 pushd $TMPDIR
-CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
+CILIUM_CLI_VERSION=v0.15.17
 # These use the platform passed into Docker. It's still better to let Go
 # translate that into its format than do any Bash-based translation here.
 GOOS=$(go env GOOS || docker run cgr.dev/chainguard/go env GOOS)

--- a/images/cilium/tests/cilium-install.sh
+++ b/images/cilium/tests/cilium-install.sh
@@ -72,6 +72,9 @@ $TMPDIR/cilium install --context k3d-$CLUSTER_NAME \
     --helm-set hubble.ui.backend.image.override=$HUBBLE_UI_BACKEND_IMAGE \
     --helm-set operator.image.override=$OPERATOR_IMAGE
 
+# Enable Hubble, as well as UI
+$TMPDIR/cilium hubble enable --ui
+
 $TMPDIR/cilium status --context k3d-$CLUSTER_NAME --wait
 
 QUAY_IMAGES=$($TMPDIR/cilium status --context k3d-$CLUSTER_NAME -o json | grep quay.io || true )

--- a/images/cilium/tests/cilium-install.sh
+++ b/images/cilium/tests/cilium-install.sh
@@ -52,6 +52,8 @@ done
 
 # Download the cilium CLI
 pushd $TMPDIR
+
+# Version v0.15.18 has test logic that needs `jq`. Temporarily pin this back to v0.15.17 here.
 CILIUM_CLI_VERSION=v0.15.17
 # These use the platform passed into Docker. It's still better to let Go
 # translate that into its format than do any Bash-based translation here.


### PR DESCRIPTION
Newest stable version of Cilium CLI includes a packet drop calculation logic that needs `jq` in the image, which we don't bundle.

Temporarily pin this back to v0.15.17 to make the test pass again.