### PR TITLE
temporarily disable check-sbom where it's enabled

### DIFF
--- a/images/busybox/wolfi.tf
+++ b/images/busybox/wolfi.tf
@@ -5,7 +5,7 @@ module "latest-wolfi" {
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/latest.wolfi.apko.yaml")
-  check-sbom        = true
+  check-sbom        = false # TODO(jason): Temporarily disabled.
 }
 
 module "one-tirtysix-wolfi" {

--- a/images/static/wolfi.tf
+++ b/images/static/wolfi.tf
@@ -5,7 +5,7 @@ module "wolfi" {
 
   target_repository = var.target_repository
   config            = file("${path.module}/configs/wolfi.apko.yaml")
-  check-sbom        = true
+  check-sbom        = false # TODO(jason): Temporarily disabled.
 }
 
 module "test-wolfi" {


### PR DESCRIPTION
This blocks some downstream checks where the SBOMs we're producing aren't fully valid yet.