### PR TITLE
Improvements to Go + Node Image READMEs

### DIFF
--- a/images/go/README.md
+++ b/images/go/README.md
@@ -66,7 +66,6 @@ Hello World!
 The following example Dockerfile builds a hello-world program in Go and copies it on top of the `cgr.dev/chainguard/static:latest` base image:
 
 ```dockerfile
-# syntax=docker/dockerfile:1.4
 FROM cgr.dev/chainguard/go:latest as build
 
 WORKDIR /work

--- a/images/go/README.md
+++ b/images/go/README.md
@@ -26,14 +26,24 @@ docker pull cgr.dev/chainguard/go:latest
 <!--getting:end-->
 
 <!--body:start-->
-## Usage
+## Secure-by-default Features
+
+In Go 1.20, we default to using the new `GODEBUG` settings of `tarinsecurepath=0` and `zipinsecurepath=0`. These can be disabled by clearing the `GODEBUG` environment variable, or by setting them to `1`.
+
+Learn more about these settings in the [Go release notes](https://tip.golang.org/doc/go1.20).
+
+## Go Application Examples
+
+This section contains two examples of how you can use the Go Chainguard Image to build an example Go application. For more information on working with this Image, check out our [Getting Started with the Go Chainguard Image](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-go/) guide. 
 
 
+### Host architecture example
 
-## Host architecture example
+Many Image directories in the [public Chainguard Images GitHub repository](https://github.com/chainguard-images/images), including the one for the Go Image, contain examples you can run to test out the given Image. 
 
-To build the Go application in [tests/hello/main.go](https://github.com/chainguard-images/images/blob/main/images/go/tests/hello/main.go)
-using the host architecture:
+You can build the Go application in [tests/hello/main.go](https://github.com/chainguard-images/images/blob/main/images/go/tests/hello/main.go) using the host architecture of your local machine by cloning the GitHub repository and then navigating to the `/images/go/` directory.
+
+From there, run the following command:
 
 ```sh
 docker run --rm -v "${PWD}:/work" -w /work/tests/hello \
@@ -43,19 +53,15 @@ docker run --rm -v "${PWD}:/work" -w /work/tests/hello \
 
 The example application will be built to `./hello`:
 
+```sh
+./hello
 ```
-$ ./hello
+```
 Hello World!
 ```
 
-## Secure-by-default Features
 
-In Go 1.20, we default to using the new `GODEBUG` settings of `tarinsecurepath=0` and `zipinsecurepath=0`.
-These can be disabled by clearing the `GODEBUG` environment variable, or by setting them to `1`.
-
-Learn more about these settings in the [Go release notes](https://tip.golang.org/doc/go1.20).
-
-## Dockerfile example
+### Dockerfile example
 
 The following example Dockerfile builds a hello-world program in Go and copies it on top of the `cgr.dev/chainguard/static:latest` base image:
 
@@ -87,13 +93,13 @@ CMD ["/hello"]
 
 Run the following command to build the demo image and tag it as `go-hello-world`:
 
-```shell
+```sh
 docker build -t go-hello-world  .
 ```
 
 Now you can run the image with:
 
-```shell
+```sh
 docker run go-hello-world
 ```
 
@@ -105,10 +111,9 @@ Hello World!
 
 It’s worth noting how small the resulting image is:
 
-```shell
+```sh
 docker images go-hello-world
 ```
-
 ```
 REPOSITORY       TAG       IMAGE ID       CREATED       SIZE
 go-hello-world   latest    859fedabd532   5 hours ago   3.21MB

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -35,41 +35,41 @@ It specifies `NODE_PORT=3000` by default.
 <!--compatibility:end-->
 
 <!--body:start-->
-## Usage Example
+## Node Application Example
 
-Navigate to the [`example/`](https://github.com/chainguard-images/images/tree/main/images/node/example) directory:
+This brief example is derived from our [Getting Started with Node](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-node/) guide which is itself based on the [Docker Node example](https://docs.docker.com/language/nodejs/containerize/).
 
+Here, we'll assume you have a node app that you want to containerize and run. You can check out [Step 1 of the Getting Started with Node guide](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-node/#step-1-setting-up-a-demo-application) for instructions on setting up an example Node app.
+
+Navigate to your application directory. Ensure your Dockerfile uses the Chainguard `node` base image.
+
+```sh
+nano Dockerfile
 ```
-cd example/
-```
-
-The Dockerfile is based on Docker's [Build your Node image](https://docs.docker.com/language/nodejs/build-images/) tutorial, but uses the Chainguard node base image instead.
-
-Build the application on the node base image.
-
-```
-docker build \
-  --tag node-docker \
-  --platform=linux/amd64 \
-  .
+```Dockerfile
+FROM cgr.dev/chainguard/node:latest
+... 
 ```
 
-Then you can run the image:
+Next, build the application. Note that this example tags the resulting image with `node-docker`.
 
-```
-docker run \
-  --rm -it \
-  -p 8000:8000 \
-  --platform=linux/amd64 \
-  node-docker
+```sh
+docker build . -t node-docker
 ```
 
-...and test to see that it works:
+Then you can run the image. This example runs an image tagged `node-docker`. It also sets up a port redirect to receive requests on `localhost:8000`. Be aware that it will block your terminal, which will show the application waiting for connections on port `8000` from within the container. 
 
+```sh
+docker run --rm -it -p 8000:8000 node-docker
 ```
+
+Run the following `curl` command in another terminal window to test that the container is able to receive requests on `localhost:8000`. 
+
+```sh
 curl --request POST \
   --url http://localhost:8000/test \
   --header 'content-type: application/json' \
   --data '{"msg": "testing" }'
 ```
+
 <!--body:end-->

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -37,39 +37,102 @@ It specifies `NODE_PORT=3000` by default.
 <!--body:start-->
 ## Node Application Example
 
-This brief example is derived from our [Getting Started with Node](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-node/) guide which is itself based on the [Docker Node example](https://docs.docker.com/language/nodejs/containerize/).
+This brief example is derived from our [Getting Started with Node](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-node/) guide which is itself based on the [Docker Node example](https://docs.docker.com/language/nodejs/containerize/). It involves setting up an example Node application, building the application into a container image using the Chainguard Node Image, and then testing the newly-built image.
 
-Here, we'll assume you have a node app that you want to containerize and run. You can check out [Step 1 of the Getting Started with Node guide](https://edu.chainguard.dev/chainguard/chainguard-images/getting-started/getting-started-node/#step-1-setting-up-a-demo-application) for instructions on setting up an example Node app.
+### Setting up an example application
 
-Navigate to your application directory. Ensure your Dockerfile uses the Chainguard `node` base image.
-
-```sh
-nano Dockerfile
-```
-```Dockerfile
-FROM cgr.dev/chainguard/node:latest
-... 
-```
-
-Next, build the application. Note that this example tags the resulting image with `node-docker`.
+You can set up our example Node application by cloning [the `node` directory](https://github.com/chainguard-dev/edu-images-demos/tree/main/node) from our [`edu-images-demos` repository](https://github.com/chainguard-dev/edu-images-demos).
 
 ```sh
-docker build . -t node-docker
+git clone --sparse https://github.com/chainguard-dev/edu-images-demos.git
 ```
 
-Then you can run the image. This example runs an image tagged `node-docker`. It also sets up a port redirect to receive requests on `localhost:8000`. Be aware that it will block your terminal, which will show the application waiting for connections on port `8000` from within the container. 
+Because the Node demo application code is stored in a repository with other examples, we don’t need to pull down every file from this repository. For this reason, this command includes the `--sparse` option. This will initialize a sparse-checkout file, causing the working directory to contain only the files in the root of the repository until the sparse-checkout configuration is modified.
+
+Navigate into the new directory.
 
 ```sh
-docker run --rm -it -p 8000:8000 node-docker
+cd edu-images-demos
 ```
 
-Run the following `curl` command in another terminal window to test that the container is able to receive requests on `localhost:8000`. 
+To retrieve the files you need for this sample application, run the following `git` command.
+
+```sh
+git sparse-checkout set node
+```
+
+This modifies the sparse-checkout configuration initialized in the previous `git clone` command so that the checkout only consists of the repo’s `node` directory.
+
+Navigate into the new `node` directory.
+
+```sh
+cd node/
+```
+
+From within this directory, run the following command to create a new `package.json` file:
+
+```sh
+npm init -y
+```
+
+Next, install the application dependencies. Specifically, you'll need `ronin-server` and `ronin-mocks`. These will create a "mock" server that saves JSON data in memory and returns it in subsequent GET requests to the same endpoint.
+
+```sh
+npm install ronin-server ronin-mocks
+```
+
+### Building the application image
+
+After setting up the application, it can be built into a container image using the Dockerfile included in the example repository.
+
+This Dockerfile will perform the following actions:
+
+1. Start a new image based on the `cgr.dev/chainguard/node:latest` image;
+2. Set the work dir to `/app` inside the container;
+3. Copy application files from the current directory to the `/app` location in the container;
+4. Run `npm install` to install production-only dependencies;
+5. Set up additional arguments to the default entrypoint (`node`), specifying which script to run.
+
+Build the application image with the following command:
+
+```sh
+docker build . -t wolfi-node-server
+```
+
+### Testing the application
+
+Once the build is finished, run the image:
+
+```sh
+docker run --rm -it -p 8000:8000 wolfi-node-server
+```
+
+Although the application is running from within a container, this command will cause it to block your terminal we set up a port redirect to receive requests on `localhost:8000` as the application waits for connections on port `8000`.
+
+From a new terminal window, run the following command. This will make a POST request to your application sending a JSON payload:
 
 ```sh
 curl --request POST \
   --url http://localhost:8000/test \
   --header 'content-type: application/json' \
-  --data '{"msg": "testing" }'
+  --data '{"msg": "testing node wolfi image" }'
 ```
+
+If the connection is successful, you will receive output like this in the terminal where the application is running:
+
+```sh
+2023-02-07T15:48:54:2450  INFO: POST /test
+```
+
+You can now query the same endpoint to receive the data that was stored in memory when you run the previous command:
+
+```sh
+curl http://localhost:8000/test
+```
+```sh
+{"code":"success","meta":{"total":1,"count":1},"payload":[{"msg":"testing node wolfi image","id":"6011f987-b9f8-4442-8253-d54166df5966","createDate":"2023-02-07T15:57:23.520Z"}]}
+```
+
+When you're finished, you can close the application by pressing `CTRL+C` (`CMD+C` if you're using macOS).
 
 <!--body:end-->


### PR DESCRIPTION
This PR contains updates to the READMEs for the `node` and `go` images. Fingers crossed that the new workflow doesn't cause issues with these updates.

Looking for DevEn approval before this should be merged, thank you!