### PR TITLE
ingress-nginx-controller: fix for latest release

### DIFF
--- a/images/ingress-nginx-controller/config/latest.apko.yaml
+++ b/images/ingress-nginx-controller/config/latest.apko.yaml
@@ -34,6 +34,12 @@ paths:
     uid: 101
     gid: 101
     recursive: true
+  - path: /etc/ingress-controller/telemetry
+    type: directory
+    permissions: 0o755
+    uid: 101
+    gid: 101
+    recursive: true
   - path: /etc/ingress-controller/auth
     type: directory
     permissions: 0o755

--- a/images/ingress-nginx-controller/image.yaml
+++ b/images/ingress-nginx-controller/image.yaml
@@ -1,3 +1,0 @@
-versions:
-  - apko:
-      config: configs/latest.apko.yaml


### PR DESCRIPTION
The latest release of ingress-nginx-controller seems to add a dependency on the directory `/etc/ingress-controller/telemetry` existing and being writeable (seemingly https://github.com/kubernetes/ingress-nginx/pull/10470)

This was released last week and picked up in Wolfi here: https://github.com/wolfi-dev/os/pull/10240

This path wasn't defined in our image, so the pod never got ready and the Helm test failed.