### PR TITLE
Update vector tests to allow them to be invoked from another module

### DIFF
--- a/images/vector/tests/main.tf
+++ b/images/vector/tests/main.tf
@@ -8,25 +8,36 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
+variable "helm_chart_tag" {
+  description = "Whether to pull a specific version of the helm chart for testing."
+  default     = ""
+}
+
 data "oci_string" "ref" { input = var.digest }
 
+resource "random_id" "hex" { byte_length = 4 }
+
 resource "helm_release" "vector" {
-  name       = "vector"
-  repository = "https://helm.vector.dev"
-  chart      = "vector"
+  name              = "vector-${random_id.hex.hex}"
+  repository        = "https://helm.vector.dev"
+  chart             = "vector"
+  create_namespace  = true
+  namespace         = "vector-${random_id.hex.hex}"
+  timeout           = 120
 
   values = [jsonencode({
     localpv = {
       image = {
         registry   = join("", [data.oci_string.ref.registry, "/"])
         repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        tag        = var.helm_chart_tag != "" ? var.helm_chart_tag : data.oci_string.ref.pseudo_tag
       }
     }
   })]
 }
 
 module "helm_cleanup" {
-  source = "../../../tflib/helm-cleanup"
-  name   = helm_release.vector.id
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.vector.id
+  namespace = helm_release.vector.namespace
 }

--- a/images/vector/tests/main.tf
+++ b/images/vector/tests/main.tf
@@ -12,8 +12,6 @@ data "oci_string" "ref" { input = var.digest }
 
 resource "random_id" "hex" { byte_length = 4 }
 
-resource "random_id" "hex" { byte_length = 4 }
-
 resource "helm_release" "vector" {
   name             = "vector-${random_id.hex.hex}"
   repository       = "https://helm.vector.dev"

--- a/images/vector/tests/main.tf
+++ b/images/vector/tests/main.tf
@@ -18,12 +18,12 @@ data "oci_string" "ref" { input = var.digest }
 resource "random_id" "hex" { byte_length = 4 }
 
 resource "helm_release" "vector" {
-  name              = "vector-${random_id.hex.hex}"
-  repository        = "https://helm.vector.dev"
-  chart             = "vector"
-  create_namespace  = true
-  namespace         = "vector-${random_id.hex.hex}"
-  timeout           = 120
+  name             = "vector-${random_id.hex.hex}"
+  repository       = "https://helm.vector.dev"
+  chart            = "vector"
+  create_namespace = true
+  namespace        = "vector-${random_id.hex.hex}"
+  timeout          = 120
 
   values = [jsonencode({
     localpv = {

--- a/images/vector/tests/main.tf
+++ b/images/vector/tests/main.tf
@@ -12,6 +12,8 @@ data "oci_string" "ref" { input = var.digest }
 
 resource "random_id" "hex" { byte_length = 4 }
 
+resource "random_id" "hex" { byte_length = 4 }
+
 resource "helm_release" "vector" {
   name             = "vector-${random_id.hex.hex}"
   repository       = "https://helm.vector.dev"
@@ -21,12 +23,10 @@ resource "helm_release" "vector" {
   timeout          = 120
 
   values = [jsonencode({
-    localpv = {
-      image = {
-        registry   = join("", [data.oci_string.ref.registry, "/"])
-        repository = data.oci_string.ref.repo
-        tag        = trimprefix(data.oci_string.ref.digest, "sha256:")
-      }
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = "latest"
+      sha        = trimprefix(data.oci_string.ref.digest, "sha256:")
     }
   })]
 }
@@ -36,3 +36,4 @@ module "helm_cleanup" {
   name      = helm_release.vector.id
   namespace = helm_release.vector.namespace
 }
+

--- a/images/vector/tests/main.tf
+++ b/images/vector/tests/main.tf
@@ -30,7 +30,7 @@ resource "helm_release" "vector" {
       image = {
         registry   = join("", [data.oci_string.ref.registry, "/"])
         repository = data.oci_string.ref.repo
-        tag        = var.helm_chart_tag != "" ? var.helm_chart_tag : data.oci_string.ref.pseudo_tag
+        tag        = var.helm_chart_tag != "" ? var.helm_chart_tag : trimprefix(data.oci_string.ref.digest, "sha256:")
       }
     }
   })]

--- a/images/vector/tests/main.tf
+++ b/images/vector/tests/main.tf
@@ -8,11 +8,6 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-variable "helm_chart_tag" {
-  description = "Whether to pull a specific version of the helm chart for testing."
-  default     = ""
-}
-
 data "oci_string" "ref" { input = var.digest }
 
 resource "random_id" "hex" { byte_length = 4 }
@@ -30,7 +25,7 @@ resource "helm_release" "vector" {
       image = {
         registry   = join("", [data.oci_string.ref.registry, "/"])
         repository = data.oci_string.ref.repo
-        tag        = var.helm_chart_tag != "" ? var.helm_chart_tag : trimprefix(data.oci_string.ref.digest, "sha256:")
+        tag        = trimprefix(data.oci_string.ref.digest, "sha256:")
       }
     }
   })]


### PR DESCRIPTION
Tweaks to the vector terraform tests - to allow them to be invoked from other modules and be re-used. This includes support for specifying an alternative git tag for the helm tests.