### PR TITLE
busybox: remove version tags

### DIFF
--- a/images/busybox/alpine.tf
+++ b/images/busybox/alpine.tf
@@ -15,13 +15,6 @@ module "latest-alpine" {
   check-sbom     = false # Alpine-based SBOMs are not conformant because the Alpine baselayout has an invalid license specifier
 }
 
-
-module "version-tags-alpine" {
-  source  = "../../tflib/version-tags"
-  package = "busybox"
-  config  = module.latest-alpine.config
-}
-
 module "test-latest-alpine" {
   source = "./tests"
   digest = module.latest-alpine.image_ref

--- a/images/busybox/main.tf
+++ b/images/busybox/main.tf
@@ -20,8 +20,7 @@ module "tagger" {
   ]
 
   tags = merge(
-    { for t in toset(concat(["latest"], module.version-tags-alpine.tag_list)) : t => module.latest-alpine.image_ref },
-    { for t in toset(module.version-tags-wolfi.tag_list) : "glibc-${t}" => module.latest-wolfi.image_ref },
+    { "latest" = module.latest-alpine.image_ref },
     { "latest-glibc" = module.latest-wolfi.image_ref },
   )
 }

--- a/images/busybox/wolfi.tf
+++ b/images/busybox/wolfi.tf
@@ -10,12 +10,6 @@ module "latest-wolfi" {
   check-sbom        = false # TODO(jason): Temporarily disabled.
 }
 
-module "version-tags-wolfi" {
-  source  = "../../tflib/version-tags"
-  package = "busybox"
-  config  = module.latest-wolfi.config
-}
-
 module "test-latest-wolfi" {
   source = "./tests"
   digest = module.latest-wolfi.image_ref


### PR DESCRIPTION
We don't version-tag these in public anymore, so just remove the cruft and simplify.