### PR TITLE
Add helm cleanup module for kubernetes-event-exporter

### DIFF
--- a/images/kubernetes-event-exporter/tests/main.tf
+++ b/images/kubernetes-event-exporter/tests/main.tf
@@ -24,6 +24,12 @@ resource "helm_release" "kubernetes-event-exporter" {
   })]
 }
 
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.kubernetes-event-exporter.id
+  namespace = helm_release.kubernetes-event-exporter.namespace
+}
+
 data "oci_exec_test" "log-review-test" {
   digest = var.digest
   script = "${path.module}/logs.sh"


### PR DESCRIPTION
This is a small tweak to the terraform for an existing image, to ensure that it cleans up the previous terraform test after completion.