### PR TITLE
Jenkins: add git and openssh-client 

### DIFF
--- a/images/jenkins/config/template.apko.yaml
+++ b/images/jenkins/config/template.apko.yaml
@@ -5,6 +5,9 @@ contents:
     - coreutils
     - busybox
     - tzdata
+    - git
+    - git-lfs
+    - openssh-client
     # jenkins and openjdk provided by extra_packages
 
 accounts:


### PR DESCRIPTION
Added git to the Jenkins image. This change is necessary as the GitHub push webhook wasn't functioning without the presence of git in the image.