### PR TITLE
ensure Hashi images are built from MPL packages

### DIFF
--- a/images/consul/config/main.tf
+++ b/images/consul/config/main.tf
@@ -5,8 +5,8 @@ terraform {
 }
 
 variable "extra_packages" {
-  description = "The additional packages to install (e.g. consul, consul-1.15)."
-  default     = ["consul", "consul-oci-entrypoint-compat"]
+  description = "The additional packages to install (e.g. consul<1.17)."
+  default     = []
 }
 
 data "apko_config" "this" {

--- a/images/consul/config/template.apko.yaml
+++ b/images/consul/config/template.apko.yaml
@@ -5,6 +5,7 @@ contents:
     # The curl package is required for the upstream chart to work as it uses
     # curl for the readiness probe
     - curl
+    - consul-oci-entrypoint-compat
     # Consul comes via var.extra_packages
 
 accounts:

--- a/images/consul/main.tf
+++ b/images/consul/main.tf
@@ -8,7 +8,10 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-module "latest-config" { source = "./config" }
+module "latest-config" {
+  source         = "./config"
+  extra_packages = ["consul<1.17"]
+}
 
 module "latest" {
   source            = "../../tflib/publisher"

--- a/images/terraform/config/main.tf
+++ b/images/terraform/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. terraform)."
-  default     = ["terraform"]
+  default     = []
 }
 
 data "apko_config" "this" {

--- a/images/terraform/config/template.apko.yaml
+++ b/images/terraform/config/template.apko.yaml
@@ -1,6 +1,6 @@
 contents:
   packages:
-    - terraform
+    # terraform comes in via var.extra_packages
 
 accounts:
   groups:

--- a/images/terraform/main.tf
+++ b/images/terraform/main.tf
@@ -8,7 +8,10 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-module "latest-config" { source = "./config" }
+module "latest-config" {
+  source         = "./config"
+  extra_packages = ["terraform<1.6"]
+}
 
 module "latest" {
   source            = "../../tflib/publisher"

--- a/images/vault/configs/vault/main.tf
+++ b/images/vault/configs/vault/main.tf
@@ -7,7 +7,7 @@ terraform {
 variable "extra_packages" {
   description = "The additional packages to install."
   type        = list(string)
-  default     = ["vault", "vault-entrypoint"]
+  default     = []
 }
 
 data "apko_config" "this" {

--- a/images/vault/configs/vault/template.apko.yaml
+++ b/images/vault/configs/vault/template.apko.yaml
@@ -1,5 +1,7 @@
 contents:
   packages:
+    - vault-entrypoint
+    # vault comes in via var.extra_packages
 
 accounts:
   groups:

--- a/images/vault/vault.tf
+++ b/images/vault/vault.tf
@@ -1,4 +1,7 @@
-module "vault-config" { source = "./configs/vault" }
+module "vault-config" {
+  source         = "./configs/vault"
+  extra_packages = ["vault<1.15"]
+}
 
 module "vault" {
   source            = "../../tflib/publisher"


### PR DESCRIPTION
This ensures that even if these images are built in the presence of BUSL-licensed versions of these packages, they will choose the latest MPL versions.

Vault < 1.15
Consul < 1.17
Terraform < 1.6