### PR TITLE
powershell: remove unused version-tags module invocation

### DIFF
--- a/images/powershell/root.tf
+++ b/images/powershell/root.tf
@@ -7,12 +7,6 @@ module "root" {
   config            = file("${path.module}/configs/latest-root.apko.yaml")
 }
 
-module "version-tags-root" {
-  source  = "../../tflib/version-tags"
-  package = "powershell"
-  config  = module.root.config
-}
-
 module "test-root" {
   source = "./tests"
   digest = module.root.image_ref


### PR DESCRIPTION
This was unused, since we only tagged `:latest` and `:latest-dev`.