### PR TITLE
pin the consul entrypoint packages as well

### DIFF
--- a/images/consul/config/template.apko.yaml
+++ b/images/consul/config/template.apko.yaml
@@ -5,7 +5,6 @@ contents:
     # The curl package is required for the upstream chart to work as it uses
     # curl for the readiness probe
     - curl
-    - consul-oci-entrypoint-compat
     # Consul comes via var.extra_packages
 
 accounts:

--- a/images/consul/main.tf
+++ b/images/consul/main.tf
@@ -9,8 +9,12 @@ variable "target_repository" {
 }
 
 module "latest-config" {
-  source         = "./config"
-  extra_packages = ["consul<1.17"]
+  source = "./config"
+  extra_packages = [
+    "consul<1.17",
+    "consul-oci-entrypoint<1.17",
+    "consul-oci-entrypoint-compat<1.17",
+  ]
 }
 
 module "latest" {


### PR DESCRIPTION
Follow up to #2025 pinning the entrypoint subpackages below 1.17 as well.