### PR TITLE
Add script to cleanup CRDs

### DIFF
--- a/images/prometheus-config-reloader/tests/cleanup.sh
+++ b/images/prometheus-config-reloader/tests/cleanup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+crds=(
+  "alertmanagerconfigs.monitoring.coreos.com"
+  "alertmanagers.monitoring.coreos.com"
+  "podmonitors.monitoring.coreos.com"
+  "probes.monitoring.coreos.com"
+  "prometheusagents.monitoring.coreos.com"
+  "prometheuses.monitoring.coreos.com"
+  "prometheusrules.monitoring.coreos.com"
+  "scrapeconfigs.monitoring.coreos.com"
+  "servicemonitors.monitoring.coreos.com"
+  "thanosrulers.monitoring.coreos.com"
+)
+
+cleanup() {
+    helm uninstall ${CHART_NAME} -n ${NAMESPACE} --wait --cascade=foreground --timeout=10m
+    kubectl delete pods -n ${NAMESPACE} --all --wait=true
+    kubectl delete ns ${NAMESPACE} --wait=true
+
+    for crd in "${crds[@]}"; do
+        kubectl delete crd $crd
+    done
+}
+trap cleanup EXIT
+

--- a/images/prometheus-config-reloader/tests/main.tf
+++ b/images/prometheus-config-reloader/tests/main.tf
@@ -38,9 +38,24 @@ resource "helm_release" "kube-prometheus-stack" {
   }
 }
 
-module "helm_cleanup" {
+data "oci_exec_test" "helm_cleanup" {
+  digest = var.digest
+  script = "${path.module}/cleanup.sh"
+
+  env {
+    name  = "CHART_NAME"
+    value = helm_release.kube-prometheus-stack.name
+  }
+  env {
+    name  = "NAMESPACE"
+    value = helm_release.kube-prometheus-stack.namespace
+  }
+}
+
+
+/* module "helm_cleanup" {
   source    = "../../../tflib/helm-cleanup"
   name      = helm_release.kube-prometheus-stack.id
   namespace = helm_release.kube-prometheus-stack.namespace
-}
+} */
 

--- a/images/prometheus-config-reloader/tests/main.tf
+++ b/images/prometheus-config-reloader/tests/main.tf
@@ -23,7 +23,6 @@ resource "helm_release" "kube-prometheus-stack" {
   namespace        = "prometheus-config-reloader-${random_pet.suffix.id}"
   create_namespace = true
 
-  // config-reloader
   set {
     name  = "prometheusOperator.prometheusConfigReloader.image.registry"
     value = data.oci_string.ref.registry
@@ -41,7 +40,17 @@ resource "helm_release" "kube-prometheus-stack" {
 data "oci_exec_test" "helm_cleanup" {
   depends_on = [resource.helm_release.kube-prometheus-stack]
   digest     = var.digest
-  script     = "${path.module}/cleanup.sh"
+  script     = <<EOF
+set -e
+
+if ! command -v flock; then
+  echo "flock not installed; please install it."
+  exit 1
+fi
+
+# Run with `flock` to ensure that only one cleanup process runs at a time.
+flock -e -w 1200 /tmp/prometheus-config-reloader ${path.module}/cleanup.sh
+EOF
 
   env {
     name  = "CHART_NAME"

--- a/images/prometheus-config-reloader/tests/main.tf
+++ b/images/prometheus-config-reloader/tests/main.tf
@@ -39,8 +39,9 @@ resource "helm_release" "kube-prometheus-stack" {
 }
 
 data "oci_exec_test" "helm_cleanup" {
-  digest = var.digest
-  script = "${path.module}/cleanup.sh"
+  depends_on = [resource.helm_release.kube-prometheus-stack]
+  digest     = var.digest
+  script     = "${path.module}/cleanup.sh"
 
   env {
     name  = "CHART_NAME"
@@ -51,11 +52,3 @@ data "oci_exec_test" "helm_cleanup" {
     value = helm_release.kube-prometheus-stack.namespace
   }
 }
-
-
-/* module "helm_cleanup" {
-  source    = "../../../tflib/helm-cleanup"
-  name      = helm_release.kube-prometheus-stack.id
-  namespace = helm_release.kube-prometheus-stack.namespace
-} */
-


### PR DESCRIPTION
Helm was leaving behind CRDs created as part of a test. Adding cleanup script to ensure no data is left behind when the test concludes