### PR TITLE
fix: remove -coredns suffix from CoreDNS tests

### DIFF
--- a/images/coredns/tests/main.tf
+++ b/images/coredns/tests/main.tf
@@ -53,7 +53,7 @@ resource "kubernetes_job_v1" "check_coredns" {
           command = ["/bin/sh", "-c"]
           args = [
             # Check that our Corefile returns what we want, validating that corends is ~functioning
-            "nslookup -q=TXT ping.chainguard.foo ${helm_release.coredns.id}-coredns.${helm_release.coredns.namespace}.svc.cluster.local 2>&1 | grep -q '\\\"pong\\\"' || (echo 'Warning: TXT record for ping.chainguard.foo is not \"pong\"' && exit 1)"
+            "nslookup -q=TXT ping.chainguard.foo ${helm_release.coredns.id}.${helm_release.coredns.namespace}.svc.cluster.local 2>&1 | grep -q '\\\"pong\\\"' || (echo 'Warning: TXT record for ping.chainguard.foo is not \"pong\"' && exit 1)"
           ]
         }
         restart_policy = "Never"


### PR DESCRIPTION
When deploying CoreDNS via Helm chart, it seems the chart isn't adding the suffix `-coredns` any longer to the deployments and services. Remove the references that had that from our tests too so they can successfully pass.