### PR TITLE
updating JDK + JRE READMEs

### DIFF
--- a/images/jdk/README.md
+++ b/images/jdk/README.md
@@ -17,6 +17,15 @@ Minimalist Wolfi-based Java JDK image using using [OpenJDK](https://openjdk.org/
 <!--overview:end-->
 
 <!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/jdk:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
 ## Java Application Example
 
 This section outlines how you can build a Java application with the Chainguard JDK Image.

--- a/images/jdk/README.md
+++ b/images/jdk/README.md
@@ -17,18 +17,11 @@ Minimalist Wolfi-based Java JDK image using using [OpenJDK](https://openjdk.org/
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
-The image is available on `cgr.dev`:
+## Java Application Example
 
-```
-docker pull cgr.dev/chainguard/jdk:latest
-```
-<!--getting:end-->
+This section outlines how you can build a Java application with the Chainguard JDK Image.
 
-<!--body:start-->
-## Use it
-
-Create a simple Java class
+Start by creating a sample Java class named `HelloWolfi.java`:
 
 ```sh
 cat >HelloWolfi.java <<EOL
@@ -42,7 +35,7 @@ class HelloWolfi
 EOL
 ```
 
-Next create a multistage Dockerfile and add the Java class
+Then create a multistage Dockerfile, adding the Java class you just created:
 
 ```sh
 cat >Dockerfile <<EOL
@@ -58,14 +51,18 @@ CMD ["HelloWolfi"]
 EOL
 ```
 
-Build the image
+Following that, you can build the image:
 
 ```sh
-docker build -t my-simple-java-app .
+docker build -t my-java-app .
 ```
 
-Run the image
+Note that this example tags the image with `my-java-app`. You can now run the image by referencing this tag, as in the following command:
+
 ```sh
-docker run my-simple-java-app
+docker run my-java-app
+```
+```
+Hello Wolfi users!
 ```
 <!--body:end-->

--- a/images/jre/README.md
+++ b/images/jre/README.md
@@ -26,9 +26,11 @@ docker pull cgr.dev/chainguard/jre:latest
 <!--getting:end-->
 
 <!--body:start-->
-## Use it
+## Java Application Example
 
-Create a simple Java class
+This section outlines how you can build a Java application with the Chainguard JRE Image.
+
+Start by creating a sample Java class named `HelloWolfi.java`:
 
 ```sh
 cat >HelloWolfi.java <<EOL
@@ -42,7 +44,7 @@ class HelloWolfi
 EOL
 ```
 
-Next create a multistage Dockerfile and add the Java class
+Then create a multistage Dockerfile, adding the Java class you just created:
 
 ```sh
 cat >Dockerfile <<EOL
@@ -58,14 +60,18 @@ CMD ["HelloWolfi"]
 EOL
 ```
 
-Build the image
+Following that, you can build the image:
 
 ```sh
-docker build -t my-simple-java-app .
+docker build -t my-java-app .
 ```
 
-Run the image
+Note that this example tags the image with `my-java-app`. You can now run the image by referencing this tag, as in the following command:
+
 ```sh
-docker run my-simple-java-app
+docker run my-java-app
+```
+```
+Hello Wolfi users!
 ```
 <!--body:end-->


### PR DESCRIPTION
Quick update to improve the content of the JDK and JRE READMEs. Both READMEs follow the same example, so other than one sentenace calling out the specific Image these two READMEs should be identical.