### PR TITLE
Move vault-entrypoint to extra_packages

### DIFF
--- a/images/vault/configs/vault/template.apko.yaml
+++ b/images/vault/configs/vault/template.apko.yaml
@@ -1,7 +1,7 @@
 contents:
   packages:
-    - vault-entrypoint
-    # vault comes in via var.extra_packages
+    # - vault-entrypoint comes in via var.extra_packages
+    # - vault comes in via var.extra_packages
 
 accounts:
   groups:

--- a/images/vault/vault.tf
+++ b/images/vault/vault.tf
@@ -1,6 +1,6 @@
 module "vault-config" {
   source         = "./configs/vault"
-  extra_packages = ["vault<1.15"]
+  extra_packages = ["vault<1.15", "vault-entrypoint"]
 }
 
 module "vault" {


### PR DESCRIPTION
When we fix the apko solver, this would cause a conflict with other images that override the entrypoint.
