### PR TITLE
google-cloud-sdk: fix image build

### DIFF
--- a/images/google-cloud-sdk/config/template.apko.yaml
+++ b/images/google-cloud-sdk/config/template.apko.yaml
@@ -4,9 +4,6 @@ contents:
     - busybox
     - bash
     - google-cloud-sdk
-    # Pin to python 3.11 until issues with 3.12 are resolved.
-    # ref: https://issuetracker.google.com/issues/303737178
-    - python3~3.11
 
 accounts:
   groups:


### PR DESCRIPTION
The package builds with Python 3.12 now, and expresses its own dependency on 3.12, so the image build doesn't need to pin a version.