### PR TITLE
cert-manager: add separate cmctl image

### DIFF
--- a/images/cert-manager/config/main.tf
+++ b/images/cert-manager/config/main.tf
@@ -18,7 +18,9 @@ module "accts" { source = "../../../tflib/accts" }
 output "config" {
   value = jsonencode({
     contents = {
-      packages = concat(["cert-manager${var.suffix}-${var.name}"], var.extra_packages)
+      packages = concat([
+        var.name == "cmctl" ? "${var.name}${var.suffix}" : "cert-manager${var.suffix}-${var.name}",
+      ], var.extra_packages)
     }
     accounts = module.accts.block
     entrypoint = {

--- a/images/cert-manager/main.tf
+++ b/images/cert-manager/main.tf
@@ -9,7 +9,7 @@ variable "target_repository" {
 }
 
 locals {
-  components = toset(["acmesolver", "controller", "cainjector", "webhook"])
+  components = toset(["acmesolver", "controller", "cainjector", "webhook", "cmctl"])
 }
 
 module "config" {


### PR DESCRIPTION
This will produce an image `cgr.dev/chainguard/cert-manager-cmctl` which only contains cmctl, which is included as a dev package in the other CM images.

The dev variant of cmctl will only include cmctl and dev packages (busybox, etc.)