### PR TITLE
remove lint check for archs in YAMLs

### DIFF
--- a/monopod/pkg/lint/rules.go
+++ b/monopod/pkg/lint/rules.go
@@ -42,9 +42,6 @@ var AllRules = func(l *Linter) Rules {
 				if len(c.Contents.Repositories) != 0 {
 					errs = append(errs, errors.New("repositories is not empty"))
 				}
-				if len(c.Archs) != 0 {
-					errs = append(errs, errors.New("archs is not empty"))
-				}
 				if slices.Contains(c.Contents.Packages, "wolfi-baselayout") {
 					errs = append(errs, errors.New("wolfi-baselayout is in packages"))
 				}


### PR DESCRIPTION
This check is not as necessary now that we're setting archs in TF

If a YAML specifies an unknown arch, the build will fail loudly.

Specifying `archs` at all is weird enough reviewers should catch it (🤞).

In some cases we _want_ to specify `archs` to limit the image to one arch (e.g., #2094)

So let's just remove the lint check.