### PR TITLE
alpine: drop 386 and arm/v6 archs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,9 @@ provider "apko" {
   extra_repositories = ["https://dl-cdn.alpinelinux.org/alpine/edge/main"]
   # These packages match chainguard-images/static
   extra_packages = ["alpine-baselayout-data", "alpine-release", "ca-certificates-bundle"]
-  default_archs  = length(var.archs) == 0 ? ["386", "amd64", "arm/v6", "arm/v7", "arm64", "ppc64le", "s390x"] : var.archs // All arches *except* riscv64
+  // Don't build for riscv64, 386, arm/v6
+  // Only build for: amd64, arm/v7, arm64, ppc64le, s390x
+  default_archs = length(var.archs) == 0 ? ["amd64", "arm/v7", "arm64", "ppc64le", "s390x"] : var.archs
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
We believe there are no users of these platforms. If you're finding this PR because you use them, please reach out to tell us how!