### PR TITLE
unpin scaffold dependency on python 3.11

### DIFF
--- a/images/skaffold/config/template.apko.yaml
+++ b/images/skaffold/config/template.apko.yaml
@@ -5,9 +5,7 @@ contents:
     - helm
     - kustomize
     - kpt
-    # Pin to python 3.11 until issues with 3.12 are resolved.
-    # ref: https://issuetracker.google.com/issues/303737178
-    - python3~3.11
+    - python3
 
 paths:
   - path: /app


### PR DESCRIPTION
this appears to have been fixed upstream: https://issuetracker.google.com/issues/303280713

and removing the pin fixes the error in image building: https://github.com/chainguard-images/images/actions/runs/7640386534/job/20815953387#step:11:462