### PR TITLE
use startupProbe since readinessProbe value is locked behind semVer

### DIFF
--- a/images/qdrant/tests/main.tf
+++ b/images/qdrant/tests/main.tf
@@ -26,6 +26,12 @@ resource "helm_release" "helm" {
         repository = data.oci_string.ref.registry_repo
         tag        = data.oci_string.ref.pseudo_tag
       }
+      readinessProbe = {
+        enabled = false
+      }
+      startupProbe = {
+        enabled = true
+      }
     })
   ]
 }


### PR DESCRIPTION
upstream changed the chart to use a `semVer` check for the readiness probe: https://github.com/qdrant/qdrant-helm/blob/main/charts/qdrant/templates/statefulset.yaml#L122

rather than fork the chart to change this to support our psuedo_tag, just leverage the existing `startupProbe` as a ~similar check. while they're not identical, the pod will still block on `Running` until the `startupProbe` succeeds, which is enough of a signal for `helm`