### PR TITLE
Allow JDK packages to be overridden when module is invoked

### DIFF
--- a/images/prometheus-cloudwatch-exporter/config/latest.apko.yaml
+++ b/images/prometheus-cloudwatch-exporter/config/latest.apko.yaml
@@ -1,9 +1,7 @@
 contents:
   packages:
     - busybox
-    - openjdk-17-jre
-    - openjdk-17-default-jvm
-    # cloudwatch-exporter comes in via var.extra_packages
+    # The other packages are defined in via var.extra_packages.
 
 accounts:
   groups:

--- a/images/prometheus-cloudwatch-exporter/config/main.tf
+++ b/images/prometheus-cloudwatch-exporter/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  default     = ["cloudwatch-exporter"]
+  default     = ["openjdk-17-jre", "openjdk-17-default-jvm", "cloudwatch-exporter"]
 }
 
 data "apko_config" "this" {


### PR DESCRIPTION
This is a small terraform tweak to allow the DK packages to be overridden when module is invoked