### PR TITLE
consolidate where providers are pinned to main.tf

### DIFF
--- a/images/cassandra/tests/main.tf
+++ b/images/cassandra/tests/main.tf
@@ -1,10 +1,7 @@
 terraform {
   required_providers {
-    oci = { source = "chainguard-dev/oci" }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.24.0"
-    }
+    oci        = { source = "chainguard-dev/oci" }
+    kubernetes = { source = "hashicorp/kubernetes" }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,33 @@
 terraform {
   required_providers {
-    apko = { source = "chainguard-dev/apko" }
+    cosign = {
+      source  = "chainguard-dev/cosign"
+      version = "0.0.17"
+    }
+    apko = {
+      source  = "chainguard-dev/apko"
+      version = "0.13.1"
+    }
+    oci = {
+      source  = "chainguard-dev/oci"
+      version = "0.0.10"
+    }
+    chainguard = {
+      source  = "chainguard-dev/chainguard"
+      version = "0.1.5"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "1.14.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
   }
 
   # We don't take advantage of terraform.tfstate, so we don't need to save state anywhere.

--- a/policies/main.tf
+++ b/policies/main.tf
@@ -5,9 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 terraform {
   required_providers {
-    cosign = {
-      source = "chainguard-dev/cosign"
-    }
+    cosign = { source = "chainguard-dev/cosign" }
   }
 }
 

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -1,21 +1,9 @@
 terraform {
   required_providers {
-    cosign = {
-      source  = "chainguard-dev/cosign"
-      version = "0.0.17"
-    }
-    apko = {
-      source  = "chainguard-dev/apko"
-      version = "0.13.1"
-    }
-    oci = {
-      source  = "chainguard-dev/oci"
-      version = "0.0.10"
-    }
-    chainguard = {
-      source  = "chainguard-dev/chainguard"
-      version = "0.1.5"
-    }
+    cosign     = { source = "chainguard-dev/cosign" }
+    apko       = { source = "chainguard-dev/apko" }
+    oci        = { source = "chainguard-dev/oci" }
+    chainguard = { source = "chainguard-dev/chainguard" }
   }
 }
 


### PR DESCRIPTION
This should be a noop.

Consolidates where we version pin our providers to the top level `main.tf`.

Previously they were "hidden" within the `tflib/publisher` module. This was ok since this module is used by everything, but it is a little confusing if you don't know where to look.