### PR TITLE
withdraw spire

### DIFF
--- a/withdrawn-repos.txt
+++ b/withdrawn-repos.txt
@@ -2,3 +2,6 @@ crossplane-xfn
 
 # Renamed to kyverno-policy-reporter
 kyverno-policy-reporter-reporter
+
+# Accidentally published in terraform migration
+spire


### PR DESCRIPTION
Looks like the dev tags for spire were accidentally [pushed to the wrong repo](https://github.com/chainguard-images/images/blob/1212ae6c5321b3d167a0dcda735406f4ce6ccfe1/images/spire/main.tf#L29) during the terraform migration. Cleaning it up here so it doesn't show up in our dashboard and as an available image