### PR TITLE
fix(kafka): Use extra packages, grant access to /bitnami

### DIFF
--- a/images/kafka/config/main.tf
+++ b/images/kafka/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. kafka)."
-  default     = ["kafka"]
+  default     = ["kafka", "openjdk-11-default-jvm"]
 }
 
 data "apko_config" "this" {

--- a/images/kafka/config/template.apko.yaml
+++ b/images/kafka/config/template.apko.yaml
@@ -27,6 +27,11 @@ paths:
     permissions: 0o755
     uid: 65532
     gid: 65532
+  - path: /bitnami
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
 
 entrypoint:
   command: /opt/bitnami/scripts/kafka/entrypoint.sh /opt/bitnami/scripts/kafka/run.sh

--- a/images/kafka/config/template.apko.yaml
+++ b/images/kafka/config/template.apko.yaml
@@ -2,10 +2,7 @@ contents:
   packages:
     - bash
     - busybox
-    - kafka
     - kafka-bitnami-compat
-    - openjdk-11-default-jvm
-    - kafka
 
 accounts:
   groups:


### PR DESCRIPTION
This fixes an issue where the kafka user couldn't create a bitnami config as it didn't have access to /bitnami. This also moves Kafka and the JVM to extra packages so that other variants may be used