### PR TITLE
no world-writable dest path when running git container

### DIFF
--- a/images/git/README.md
+++ b/images/git/README.md
@@ -95,4 +95,11 @@ ls -a ~/workspace/
 ```
 .  ..  .github
 ```
+
+If you do not want to make the destination directory world-writable, you can run the git executable inside the container with your UID, thus giving it access to the directory:
+
+```shell
+docker run -it -v ~/workspace:/home/git -u $(id -u) --rm cgr.dev/chainguard/git clone https://github.com/chainguard-images/.github.git
+```
+
 <!--body:end-->


### PR DESCRIPTION
Add info on how to run the container with one's own UID so that making the destinaiton path world-writable becomes unnecessary.

Template does not apply, this is a documentaiton update.