### PR TITLE
scope presubmit imagetest overrides to presubmit ci

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -118,6 +118,34 @@ jobs:
       with:
         k3s-image: cgr.dev/chainguard/k3s:latest@sha256:0ef62d22d89f611f9df50b9cc86d1f23d3d92d39062d4d13e500736f4e29d0d9
 
+    - name: Configure imagetest provider
+      run: |
+        # Run a presubmit scoped global imagetest provider override that
+        # configures the k3s harnesses for the presubmit scoped local registry.
+        # This _could_ be in the `main.tf` with some conditionals, but since
+        # this is striclty for presubmit we take this approach to keep things
+        # simpler.
+        cat >> main_override.tf <<EOF
+        provider "imagetest" {
+          harnesses = {
+            k3s = {
+              networks = {
+                // wire in k3d's default network where the registry lives
+                "k3d-default" = { name = "k3d-k3s-default" }
+              }
+              registries = {
+                # Mirror the var.target_repository host registry to the local registry.
+                # This ensures the images that are pushed from the host registry are
+                # mirrored to the internal hostname:port registry.
+                "registry.local:5000" = {
+                  mirror = { endpoints = ["http://registry.local:5000"] }
+                }
+              }
+            }
+          }
+        }
+        EOF
+
     - name: Build
       timeout-minutes: 60
       run: |

--- a/images/cert-manager/tests/main.tf
+++ b/images/cert-manager/tests/main.tf
@@ -92,13 +92,13 @@ cmctl check api --wait=60s
       name = "Create a SelfSigned Issuer"
       cmd  = <<EOF
 kubectl apply -f /tests/manifests/issuer.yaml
-          EOF
+      EOF
     },
     {
       name = "Create a Certificate"
       cmd  = <<EOF
 kubectl apply -f /tests/manifests/certificate.yaml
-          EOF
+      EOF
     },
     {
       name = "Check the certificate is valid"
@@ -106,7 +106,7 @@ kubectl apply -f /tests/manifests/certificate.yaml
 kubectl wait --for=condition=Ready certificate/test -n sandbox --timeout=60s
 cmctl status certificate -n sandbox test
 cmctl inspect secret -n sandbox test-server-tls
-          EOF
+      EOF
     },
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -13,24 +13,7 @@ terraform {
   backend "inmem" {}
 }
 
-provider "imagetest" {
-  harnesses = {
-    k3s = {
-      networks = {
-        // wire in k3d's default network where the registry lives
-        "k3d-default" = { name = "k3d-k3s-default" }
-      }
-      registries = {
-        # Mirror the var.target_repository host registry to the local registry.
-        # This ensures the images that are pushed from the host registry are
-        # mirrored to the internal hostname:port registry.
-        "${element(split("/", var.target_repository), 0)}" = {
-          mirror = { endpoints = ["http://${element(split(":", var.target_repository), 0)}:5000"] }
-        }
-      }
-    }
-  }
-}
+provider "imagetest" {}
 
 variable "target_repository" {
   type        = string


### PR DESCRIPTION
moving this out of `main.tf` to avoid the complicated terraform conditionals needed to support the presubmit unique local registry (`registry.local:5000`) vs the postsubmit remote (`cgr.dev`) registry.

This also makes it more flexible for local users to configure things based on their own local registry setup.