### PR TITLE
change the match terms

### DIFF
--- a/images/kubernetes-event-exporter/tests/logs.sh
+++ b/images/kubernetes-event-exporter/tests/logs.sh
@@ -9,8 +9,8 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 
 # Defining log entries we are looking for in the k8s-event-export logs
 declare -a terms=(
-	"Created container event-exporter"
-	"Started container event-exporter"
+	"Received event"
+	"sending event to sink"
 )
 
 declare -a missing_terms=()


### PR DESCRIPTION
the previous terms are too specific to introspecting the same container. in a concurrent environment (like CI) where the checks happen after the event for `event-exporter` has passed, the test will fail.

this changes the test to use a much more broad yet still representative set of matching terms