### PR TITLE
Drop cni-plugins-main from cilium

### DIFF
--- a/images/cilium/configs/agent/main.tf
+++ b/images/cilium/configs/agent/main.tf
@@ -12,7 +12,6 @@ variable "extra_packages" {
     "cilium",
     "cilium-container-init-compat",
     "gops",
-    "cni-plugins-main",
   ]
 }
 


### PR DESCRIPTION
We just need loopback, which cilium already depends on.