### PR TITLE
temporarily remove sharding randomization

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -53,7 +53,7 @@ jobs:
       shell: bash # bash math foo required
       if: steps.changed.outputs.base_any_changed == 'true'
       run: |
-        images=($(find ./images -maxdepth 1 -type d -not -path "./images/TEMPLATE" | awk -F'/' '{print $3}' | sort -uR)) # randomize
+        images=($(find ./images -maxdepth 1 -type d -not -path "./images/TEMPLATE" | awk -F'/' '{print $3}' | sort -u))
 
         n=50 # buckets to shard into
         total=${#images[@]}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
         name: Shard
         shell: bash # bash math foo required
         run: |
-          images=($(find ./images -maxdepth 1 -type d -not -path "./images/TEMPLATE" | awk -F'/' '{print $3}' | sort -R)) # randomize
+          images=($(find ./images -maxdepth 1 -type d -not -path "./images/TEMPLATE" | awk -F'/' '{print $3}' | sort -u))
 
           # n buckets to shard into
           n=${{ env.TOTAL_SHARDS }}


### PR DESCRIPTION
temporarily removing the shard randomizer since its making it very difficult to debug test flakes.

there's a chance this is forever removed now that `imagetest` exists to properly fix the issues the randomizer was meant to "fix".