### PR TITLE
Add prometheus-logstash-exporter image

### DIFF
--- a/images/prometheus-logstash-exporter/README.md
+++ b/images/prometheus-logstash-exporter/README.md
@@ -13,7 +13,7 @@
 <!--monopod:end-->
 
 <!--overview:start-->
-Minimalist Wolfi-based Prometheus Logstash Exporter image for exporting various metrics about Logstash.
+Prometheus exporter for Logstash written in Go
 <!--overview:end-->
 
 <!--getting:start-->
@@ -24,5 +24,5 @@ The image is available on `cgr.dev`:
 docker pull cgr.dev/chainguard/prometheus-logstash-exporter:latest
 ```
 <!--getting:end-->
-See the [upstream git repo](https://github.com/kuskoman/logstash-exporter) for more details on deployment methods! Just swap out `cgr.dev/chainguard/prometheus-logstash-exporter:latest`
+
 <!--body:start--><!--body:end-->

--- a/images/prometheus-logstash-exporter/README.md
+++ b/images/prometheus-logstash-exporter/README.md
@@ -1,0 +1,28 @@
+<!--monopod:start-->
+# prometheus-logstash-exporter
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/prometheus-logstash-exporter` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-logstash-exporter/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Minimalist Wolfi-based Prometheus Logstash Exporter image for exporting various metrics about Logstash.
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/prometheus-logstash-exporter:latest
+```
+<!--getting:end-->
+See the [upstream git repo](https://github.com/kuskoman/logstash-exporter) for more details on deployment methods! Just swap out `cgr.dev/chainguard/prometheus-logstash-exporter:latest`
+<!--body:start--><!--body:end-->

--- a/images/prometheus-logstash-exporter/config/main.tf
+++ b/images/prometheus-logstash-exporter/config/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = [
+    "logstash-exporter",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/prometheus-logstash-exporter/config/template.apko.yaml
+++ b/images/prometheus-logstash-exporter/config/template.apko.yaml
@@ -1,0 +1,15 @@
+contents:
+  packages: []
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/logstash-exporter

--- a/images/prometheus-logstash-exporter/main.tf
+++ b/images/prometheus-logstash-exporter/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "prometheus-logstash-exporter" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev         = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.prometheus-logstash-exporter.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.prometheus-logstash-exporter.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.prometheus-logstash-exporter.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/prometheus-logstash-exporter/main.tf
+++ b/images/prometheus-logstash-exporter/main.tf
@@ -16,7 +16,7 @@ module "prometheus-logstash-exporter" {
   target_repository = var.target_repository
   config            = module.config.config
 
-  build-dev         = true
+  build-dev = true
 
 }
 

--- a/images/prometheus-logstash-exporter/metadata.yaml
+++ b/images/prometheus-logstash-exporter/metadata.yaml
@@ -1,0 +1,12 @@
+name: prometheus-logstash-exporter
+image: cgr.dev/chainguard/prometheus-logstash-exporter
+logo: https://storage.googleapis.com/chainguard-academy/logos/prometheus-logstash-exporter.svg
+endoflife: ""
+console_summary: ""
+short_description: Prometheus exporter for Logstash written in Go
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/wolfi-dev/os
+keywords:
+  - analytics
+  - application

--- a/images/prometheus-logstash-exporter/tests/main.tf
+++ b/images/prometheus-logstash-exporter/tests/main.tf
@@ -1,0 +1,132 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    helm      = { source = "hashicorp/helm" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The image digests to run tests over."
+}
+
+data "oci_string" "ref" {
+  input = var.digest
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "prometheus-logstash-exporter"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ]
+  }
+}
+
+module "helm_prometheus" {
+  source = "../../../tflib/imagetest/helm"
+
+  namespace = "default"
+  chart     = "prometheus"
+  repo      = "https://prometheus-community.github.io/helm-charts"
+  name = "prometheus"
+
+  values = {
+    server = {
+      global = {
+        scrape_interval     = "5s",
+        scrape_timeout      = "4s",
+        evaluation_interval = "1m",
+      }
+      persistentVolume = {
+        enabled = false
+      }
+    }
+    serverFiles = {
+      "prometheus.yml" = {
+        scrape_configs = [
+          {
+            job_name        = "logstash-exporter"
+            scrape_interval = "5s"
+            scrape_timeout  = "5s"
+            metrics_path    = "/metrics"
+            scheme          = "http"
+            static_configs = [
+              {
+                targets = ["exporter-logstash-exporter:9198"]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    alertmanager             = { enabled = false }
+    kube-state-metrics       = { enabled = false }
+    prometheus-node-exporter = { enabled = false }
+    prometheus-pushgateway   = { enabled = false }
+  }
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the logstash image."
+
+  steps = [
+    {
+      name = "Helm install prometheus"
+      cmd  = module.helm_prometheus.install_cmd
+    },
+    {
+      name = "Helm install logstash"
+      cmd  = <<EOF
+        apk add helm
+        helm repo add elastic https://helm.elastic.co
+        helm upgrade --install logstash elastic/logstash \
+            --values /tests/values/logstash.values.yaml \
+            --wait \
+            --wait-for-jobs
+      EOF
+    },
+    {
+      name = "Helm install logstash-exporter"
+      cmd  = <<EOF
+        apk add git helm
+        git clone https://github.com/kuskoman/logstash-exporter.git
+        helm upgrade --install exporter ./logstash-exporter/chart \
+          --set logstash.urls[0]="http://logstash-logstash-headless:9600" \
+          --set logstash.logging.level="debug" \
+          --set image.repository="${data.oci_string.ref.registry_repo}" \
+          --set image.tag="${data.oci_string.ref.pseudo_tag}" \
+          --set image.pullPolicy="Always" \
+          --wait \
+          --wait-for-jobs
+      EOF
+    },
+    {
+      name = "Query metrics"
+      cmd  = <<EOF
+        apk add kubectl curl jq
+        kubectl port-forward svc/prometheus-server 9090:80 & 
+
+        # Wait for api to become available
+        until curl http://localhost:9090/api/v1/label/__name__/values; do sleep 1; done
+
+        # Ensure we see logstash metrics
+        curl -L http://localhost:9090/api/v1/label/__name__/values | \
+            jq -r '.data[]' | grep -E '^logstash_'
+      EOF
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+}

--- a/images/prometheus-logstash-exporter/tests/main.tf
+++ b/images/prometheus-logstash-exporter/tests/main.tf
@@ -36,7 +36,7 @@ module "helm_prometheus" {
   namespace = "default"
   chart     = "prometheus"
   repo      = "https://prometheus-community.github.io/helm-charts"
-  name = "prometheus"
+  name      = "prometheus"
 
   values = {
     server = {
@@ -84,6 +84,9 @@ resource "imagetest_feature" "basic" {
       name = "Helm install prometheus"
       cmd  = module.helm_prometheus.install_cmd
     },
+    # logstash has a weird values file that didn't quite work with the helm
+    # module for imagetest
+    # TODO: make it so this can work with imagestest/helm
     {
       name = "Helm install logstash"
       cmd  = <<EOF
@@ -95,6 +98,13 @@ resource "imagetest_feature" "basic" {
             --wait-for-jobs
       EOF
     },
+
+    # The logstash-exporter project does not have an official helm chart. There
+    # was progress on the official prometheus charts repo but that PR has been
+    # stale for a while. This developer has taken over development for the
+    # logstash-exporter and has included a chart but has not published it yet.
+    # There is an issue to publish the chart https://github.com/kuskoman/logstash-exporter/issues/76
+        # For now we just need to clone the repo and use the chart
     {
       name = "Helm install logstash-exporter"
       cmd  = <<EOF

--- a/images/prometheus-logstash-exporter/tests/main.tf
+++ b/images/prometheus-logstash-exporter/tests/main.tf
@@ -104,7 +104,7 @@ resource "imagetest_feature" "basic" {
     # stale for a while. This developer has taken over development for the
     # logstash-exporter and has included a chart but has not published it yet.
     # There is an issue to publish the chart https://github.com/kuskoman/logstash-exporter/issues/76
-        # For now we just need to clone the repo and use the chart
+    # For now we just need to clone the repo and use the chart
     {
       name = "Helm install logstash-exporter"
       cmd  = <<EOF

--- a/images/prometheus-logstash-exporter/tests/values/logstash.values.yaml
+++ b/images/prometheus-logstash-exporter/tests/values/logstash.values.yaml
@@ -1,0 +1,63 @@
+imageTag: "8.9.0"
+logstashConfig:
+  logstash.yml: |
+    http.host: "0.0.0.0"
+    dead_letter_queue.enable: true
+    path.dead_letter_queue: "/usr/share/logstash/data/dead_letter_queue"
+
+
+logstashPipeline: 
+  logstash.conf: |
+    input {
+        generator {
+            type => "dummy"
+            count => -1
+            message => '{"message": "dummy log"}'
+            codec => plain {id => "plain-codec-001"}
+        }
+
+        dead_letter_queue {
+            path => "/usr/share/logstash/data/dead_letter_queue"
+            commit_offsets => true
+            pipeline_id => "main"
+        }
+    }
+
+    filter {
+        ruby {
+            code => "sleep 0.2"
+        }
+
+        json {
+            id => "json-filter"
+            source => "message"
+        }
+        # There are too many of these. Drop 80% of them.
+        if [message][message] == "dummy log" {
+            drop {
+                id => "drop-80-percent"
+                percentage => 80
+            }
+        }
+        if [massage][non_existent] {
+            drop {
+                id => "drop-non-existent"
+            }
+        }
+        mutate {
+            id => "mutate-path-001"
+            gsub => [
+                "[url][path]", "/([^/]+).*", "\1"
+            ]
+            add_field => { "[oject][foo]" => "bar" }
+        }
+
+        # Don't keep this duplicate payload
+        prune {
+            id => "prune-http-input-fields"
+            blacklist_names => [ "event", "host", "http", "url", "user_agent" ]
+        }
+    }
+
+    output { stdout { } }
+

--- a/main.tf
+++ b/main.tf
@@ -1007,6 +1007,11 @@ module "prometheus-elasticsearch-exporter" {
   target_repository = "${var.target_repository}/prometheus-elasticsearch-exporter"
 }
 
+module "prometheus-logstash-exporter" {
+  source            = "./images/prometheus-logstash-exporter"
+  target_repository = "${var.target_repository}/prometheus-logstash-exporter"
+}
+
 module "prometheus-mongodb-exporter" {
   source            = "./images/prometheus-mongodb-exporter"
   target_repository = "${var.target_repository}/prometheus-mongodb-exporter"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
