### PR TITLE
create a build job summary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,3 +158,32 @@ jobs:
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ${{ steps.tf-diag.outputs.errors }}
+
+  summary:
+    name: "Build Summary"
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: "Download shard logs"
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+        with:
+          path: /tmp/shard-logs
+          pattern: mega-module-*
+
+      # Cat all the files into one
+      - run: |
+          find /tmp/shard-logs -name 'mega-module.tf.json' -exec cat {} + >> logs.tf.json
+
+      # Build the markdown table
+      - run: |
+          echo "| Status | Image | Summary | Address |" >> $GITHUB_STEP_SUMMARY
+          echo "| :-:    | ----- | ------- | ------- |" >> $GITHUB_STEP_SUMMARY
+
+          # append the rows to the table
+          export rows="$(jq -r 'select(.["@level"]=="error") | ("| ❌ | " + (.diagnostic.address | split(".")[1]) + " | ```" + .diagnostic.summary + "``` | ```" + .diagnostic.address + "``` |")' logs.tf.json)"
+          echo "${rows}"
+
+          cat >> $GITHUB_STEP_SUMMARY <<EOR
+          ${rows}
+          EOR


### PR DESCRIPTION
uses a [gha job summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) to aggregate the test results

this is a primitive table to start, but we can flush this out further with links and details once the initial GHA madness is confirmed to work.

I tested this on a private repo, and kept this small, so I'm hopeful 🤞. either way, this doesn't touch the actual release process so the side effects are negligible, ci is always red nowadays anyways 😮‍💨 