### PR TITLE
always build the summary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,7 @@ jobs:
   summary:
     name: "Build Summary"
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     needs: build
 
     steps:


### PR DESCRIPTION
prevents the summary job from getting skipped if/when there are errors in the build