### PR TITLE
filebeat: initial configuration

### DIFF
--- a/images/filebeat/README.md
+++ b/images/filebeat/README.md
@@ -1,0 +1,28 @@
+<!--monopod:start-->
+# filebeat
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/filebeat` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/filebeat/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+[filebeat](https://github.com/elastic/beats/tree/main/filebeat) Tails and ships log files
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/filebeat:latest
+```
+<!--getting:end-->
+
+<!--body:start--><!--body:end-->

--- a/images/filebeat/config/main.tf
+++ b/images/filebeat/config/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "filebeat",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/filebeat/config/template.apko.yaml
+++ b/images/filebeat/config/template.apko.yaml
@@ -1,0 +1,46 @@
+contents:
+  packages: [
+    # Package "filebeat" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+    busybox,
+    bash,
+    curl
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+work-dir: /usr/share/filebeat
+
+entrypoint:
+  command: /sbin/tini -- /usr/local/bin/docker-entrypoint
+
+cmd: "-environment container"
+
+environment:
+  ELASTIC_CONTAINER: true
+  LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE: "/"
+  PATH : "/usr/share/filebeat:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+paths:
+  - path: /usr/share/filebeat/logs/
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true
+
+  - path: /usr/share/filebeat/data/
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+    recursive: true

--- a/images/filebeat/main.tf
+++ b/images/filebeat/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "filebeat" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.filebeat.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.filebeat.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.filebeat.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/filebeat/metadata.yaml
+++ b/images/filebeat/metadata.yaml
@@ -1,0 +1,10 @@
+name: filebeat
+image: cgr.dev/chainguard/filebeat
+logo: https://storage.googleapis.com/chainguard-academy/logos/filebeat.svg
+endoflife: ""
+console_summary: ""
+short_description: "[filebeat](https://github.com/elastic/beats/tree/main/filebeat) Tails and ships log files"
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/elastic/beats
+keywords: []

--- a/images/filebeat/tests/check-filebeat.sh
+++ b/images/filebeat/tests/check-filebeat.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+
+# We just test if the container starts ok. as we don't have any backend tests yet 
+# thi uses an output to file configuration for now  we can check for that file 
+TEST_container_starts_ok() {
+   
+    # Check if the container is running
+    if ! kubectl get pods -n ${FB_NAMESPACE} | grep 'filebeat-'; then
+        echo "FAILED: Pod  is not running."
+        exit 1
+    else
+        echo "Pod is running."
+    fi
+
+  
+}
+
+TEST_container_starts_ok

--- a/images/filebeat/tests/filebeat.yml
+++ b/images/filebeat/tests/filebeat.yml
@@ -1,0 +1,9 @@
+filebeat.inputs:
+- type: log
+  paths:
+    - /var/log/messages
+    - /var/log/*.log
+    - /tmp/*.log
+output.file:
+  path: "/tmp/"
+  filename: foobar

--- a/images/filebeat/tests/main.tf
+++ b/images/filebeat/tests/main.tf
@@ -1,0 +1,58 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "filebeat" {
+  name             = "elastic"
+  namespace        = "filebeat-${random_pet.suffix.id}"
+  repository       = "https://helm.elastic.co"
+  chart            = "filebeat"
+  create_namespace = true
+
+
+  values = [
+    "${file("${path.module}/values.yaml")}"
+  ]
+
+  set {
+    name  = "image"
+    value = data.oci_string.ref.registry_repo
+  }
+
+  set {
+    name  = "imageTag"
+    value = data.oci_string.ref.pseudo_tag
+  }
+}
+
+data "oci_exec_test" "check-filebeat" {
+  digest      = var.digest
+  script      = "./check-filebeat.sh"
+  working_dir = path.module
+  depends_on  = [helm_release.filebeat]
+
+  env = [{
+    name  = "FB_NAMESPACE"
+    value = helm_release.filebeat.namespace
+  }, ]
+}
+
+
+module "helm_cleanup" {
+  depends_on = [data.oci_exec_test.check-filebeat]
+  source     = "../../../tflib/helm-cleanup"
+  name       = helm_release.filebeat.id
+  namespace  = helm_release.filebeat.namespace
+}
+
+

--- a/images/filebeat/tests/test.sh
+++ b/images/filebeat/tests/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+container_name="filebeat-${RANDOM}"
+
+docker run -d \
+  --name=${container_name} \
+  --user=nonroot \
+  --volume="$(pwd)/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro" \
+  --volume="nonroot:/usr/share/filebeat/data:rw" \
+  ${IMAGE_NAME} filebeat -e --strict.perms=false
+
+trap "docker rm -f ${container_name}" EXIT
+# Write a log message and expect the log to be ingested
+docker exec "${container_name}" sh -c 'echo "test chainguard" > /tmp/test.log'
+sleep 60
+docker exec "${container_name}" sh -c 'ls -al /tmp'
+docker cp "${container_name}:/tmp" "${PWD}/localcopy"
+sleep 60
+
+# Get the .ndjson file dynamically from ls output
+ndjson_file=$(find ${PWD}/localcopy/tmp -name "foobar*.ndjson" -print -quit)
+
+
+# Check if any .ndjson file is found
+if [ -n "$ndjson_file" ]; then
+    # Use jq to filter messages containing "test"
+    jq '. | select(.message | contains("test"))' "$ndjson_file"
+else
+    echo "Error: No .ndjson file found"
+fi

--- a/images/filebeat/tests/values.yaml
+++ b/images/filebeat/tests/values.yaml
@@ -1,0 +1,76 @@
+daemonset:
+  filebeatConfig:
+    filebeat.yml: |
+      filebeat.inputs:
+      - type: container
+        paths:
+          - /var/log/containers/*.log
+        processors:
+        - add_kubernetes_metadata:
+            host: ${NODE_NAME}
+            matchers:
+            - logs_path:
+                logs_path: "/var/log/containers/"
+      output.file:
+          path: "/tmp/"
+          filename: foobar
+      setup.ilm.enabled: false
+      setup.template.name: "filebeat"
+      setup.template.pattern: "filebeat-oss-*"
+
+  # Annotations to apply to the daemonset
+  annotations: {}
+  # additionals labels
+  labels: {}
+  affinity: {}
+  # Include the daemonset
+  enabled: true
+  # Extra environment variables for Filebeat container.
+  envFrom: []
+  # - configMapRef:
+  #     name: config-secret
+  extraEnvs: []
+  # Allows you to add any config files in /usr/share/filebeat
+  extraVolumes: []
+  # - name: extras
+  #   emptyDir: {}
+  extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+  hostNetworking: false
+  # Allows you to add any config files in /usr/share/filebeat
+  # such as filebeat.yml for daemonset
+ 
+  # Only used when updateStrategy is set to "RollingUpdate"
+  maxUnavailable: 1
+  nodeSelector: {}
+  # A list of secrets and their paths to mount inside the pod
+  # This is useful for mounting certificates for security other sensitive values
+  secretMounts: []
+
+  #  - name: filebeat-certificates
+  #    secretName: filebeat-certificates
+  #    path: /usr/share/filebeat/certs
+  # Various pod security context settings. Bear in mind that many of these have an impact on Filebeat functioning properly.
+  #
+  # - User that the container will execute as. Typically necessary to run as root (0) in order to properly collect host container logs.
+  # - Whether to execute the Filebeat containers as privileged containers. Typically not necessarily unless running within environments such as OpenShift.
+  securityContext:
+    runAsUser: 0
+    privileged: false
+
+  tolerations: []
+
+readinessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - |
+        #!/usr/bin/env bash -e
+        filebeat version
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5

--- a/main.tf
+++ b/main.tf
@@ -397,6 +397,11 @@ module "ffmpeg" {
   target_repository = "${var.target_repository}/ffmpeg"
 }
 
+module "filebeat" {
+  source            = "./images/filebeat"
+  target_repository = "${var.target_repository}/filebeat"
+}
+
 module "fluent-bit" {
   source            = "./images/fluent-bit"
   target_repository = "${var.target_repository}/fluent-bit"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [ ] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
