### PR TITLE
Drop explicit python3 dep

### DIFF
--- a/images/management-api-for-apache-cassandra/config/template.apko.yaml
+++ b/images/management-api-for-apache-cassandra/config/template.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - python3
     - busybox
     - bash
     - tini


### PR DESCRIPTION
We pull in cassandra which needs python-3.11 specifically.