### PR TITLE
Tflib imagetest/helm values file fix

### DIFF
--- a/tflib/imagetest/helm/main.tf
+++ b/tflib/imagetest/helm/main.tf
@@ -49,7 +49,7 @@ helm install ${var.name} ${var.chart} \
   %{if var.chart_version != ""}--version ${var.chart_version}%{endif} \
   --wait --wait-for-jobs \
   --timeout ${var.timeout} \
-  --values ${join(",", var.values_files)} \
+  %{if length(var.values_files) != 0}--values ${join(",", var.values_files)}%{endif} \
   --values <(echo '${jsonencode(var.values)}')
   EOa
 


### PR DESCRIPTION
An empty `values_file` parameter would generate a bad helm command. This change just ignores the `--values` line corresponding to values files if the `values_file` parameter is omitted.

Converted the prometheus-logstash-exporter image tests over to use the helm module as a test