### PR TITLE
print the shard index and an error summary step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,19 +172,33 @@ jobs:
           path: /tmp/shard-logs
           pattern: mega-module-*
 
-      # Cat all the files into one
+      # Cat all the files into one, while maintaining their shard
       - run: |
-          find /tmp/shard-logs -name 'mega-module.tf.json' -exec cat {} + >> logs.tf.json
+          find '/tmp/shard-logs' -name 'mega-module.tf.json' | while read file; do
+            shard_index=$(echo "$file" | sed -E 's/.*mega-module-([0-9]+)\.tf\.json.*/\1/')
+            echo $shard_index
+            jq -cr --arg shard_index "$shard_index" '. + {"shard_index":$shard_index}' $file >> logs.tf.json
+          done
+
+      # process the logs
+      - run: |
+          # Create a file just for errors
+          jq -r 'select(.["@level"]=="error")' logs.tf.json > errors.tf.json
 
       # Build the markdown table
       - run: |
-          echo "| Status | Image | Summary | Address |" >> $GITHUB_STEP_SUMMARY
-          echo "| :-:    | ----- | ------- | ------- |" >> $GITHUB_STEP_SUMMARY
+          echo "| Status | Shard | Image | Summary | Address |" >> $GITHUB_STEP_SUMMARY
+          echo "| :-:    | ----- | ----- | ------- | ------- |" >> $GITHUB_STEP_SUMMARY
 
           # append the rows to the table
-          export rows="$(jq -r 'select(.["@level"]=="error") | ("| ❌ | " + (.diagnostic.address | split(".")[1]) + " | ```" + .diagnostic.summary + "``` | ```" + .diagnostic.address + "``` |")' logs.tf.json)"
+          export rows="$(jq -r '"| ❌ | " + .shard_index + " | " + (.diagnostic.address | split(".")[1]) + " | ```" + .diagnostic.summary + "``` | ```" + .diagnostic.address + "``` |"' errors.tf.json)"
           echo "${rows}"
 
           cat >> $GITHUB_STEP_SUMMARY <<EOR
           ${rows}
           EOR
+
+      - name: Error Details
+        run: |
+          # Print the errors as expandable groups
+          jq -r '"::group:: shard: " + .shard_index + " | " + (.diagnostic.address | split(".")[1]) + "\nresource: " + .diagnostic.address + "\n\nsummary: " + .diagnostic.summary + "\n\ndetails:\n\n" + .diagnostic.detail + "\n::endgroup::"' errors.tf.json || true


### PR DESCRIPTION
I wanted to link from the table row to the actual error detail dropdown, but you won't (at least I didn't) believe how difficult it is to get both the job_id, and a deterministic step link from the github api.

this is essentially a state save of what I've got now, which is just:

1. add and expose the shard index in the summary
2. add a step at the end which aggregates all the images summary/detail so we don't have to go clicking around shards