### PR TITLE
deconflict kyverno{-policy-reporter} using imagetest

### DIFF
--- a/images/kyverno/tests/helm/main.tf
+++ b/images/kyverno/tests/helm/main.tf
@@ -1,0 +1,65 @@
+variable "values" {
+  type = any
+  default = {
+    admissionController = {
+      container = {
+        image = {
+          registry   = "cgr.dev"
+          repository = "chainguard/kyverno"
+          tag        = "latest"
+        }
+      }
+      initContainer = {
+        image = {
+          registry   = "cgr.dev"
+          repository = "chainguard/kyvernopre"
+          tag        = "latest"
+        }
+      }
+    }
+    backgroundController = {
+      container = {
+        image = {
+          registry   = "cgr.dev"
+          repository = "chainguard/kyverno-background-controller"
+          tag        = "latest"
+        }
+      }
+    }
+    cleanupController = {
+      container = {
+        image = {
+          registry   = "cgr.dev"
+          repository = "chainguard/kyverno-cleanup-controller"
+          tag        = "latest"
+        }
+      }
+    }
+    reportsController = {
+      container = {
+        image = {
+          registry   = "cgr.dev"
+          repository = "chainguard/kyverno-reports-controller"
+          tag        = "latest"
+        }
+      }
+    }
+  }
+}
+
+module "helm" {
+  source = "../../../../tflib/imagetest/helm"
+
+  name      = "kyverno"
+  namespace = "kyverno"
+  repo      = "https://kyverno.github.io/kyverno"
+  chart     = "kyverno"
+
+  values = var.values
+}
+
+output "install_cmd" {
+  value = module.helm.install_cmd
+}
+
+

--- a/images/kyverno/tests/main.tf
+++ b/images/kyverno/tests/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
-    oci  = { source = "chainguard-dev/oci" }
-    helm = { source = "hashicorp/helm" }
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
   }
 }
 
@@ -22,64 +22,38 @@ data "oci_string" "ref" {
   input    = each.value
 }
 
-resource "random_pet" "suffix" {}
+data "imagetest_inventory" "this" {}
 
-resource "helm_release" "kyverno" {
-  name             = "kyverno-${random_pet.suffix.id}"
-  namespace        = "kyverno-${random_pet.suffix.id}"
-  repository       = "https://kyverno.github.io/kyverno"
-  chart            = "kyverno"
-  create_namespace = true
-
-  values = [jsonencode({
-    admissionController = {
-      container = {
-        image = {
-          registry   = data.oci_string.ref["admission"].registry
-          repository = data.oci_string.ref["admission"].repo
-          tag        = data.oci_string.ref["admission"].pseudo_tag
-        }
-      }
-      initContainer = {
-        image = {
-          registry   = data.oci_string.ref["init"].registry
-          repository = data.oci_string.ref["init"].repo
-          tag        = data.oci_string.ref["init"].pseudo_tag
-        }
-      }
-    }
-    backgroundController = {
-      container = {
-        image = {
-          registry = data.oci_string.ref["background"].registry
-          registry = data.oci_string.ref["background"].repo
-          tag      = data.oci_string.ref["background"].pseudo_tag
-        }
-      }
-    }
-    cleanupController = {
-      container = {
-        image = {
-          registry = data.oci_string.ref["cleanup"].registry
-          registry = data.oci_string.ref["cleanup"].repo
-          tag      = data.oci_string.ref["cleanup"].pseudo_tag
-        }
-      }
-    }
-    reportsController = {
-      container = {
-        image = {
-          registry = data.oci_string.ref["reports"].registry
-          registry = data.oci_string.ref["reports"].repo
-          tag      = data.oci_string.ref["reports"].pseudo_tag
-        }
-      }
-    }
-  })]
+resource "imagetest_harness_k3s" "this" {
+  name      = "kyverno"
+  inventory = data.imagetest_inventory.this
 }
 
-module "helm_cleanup" {
-  source    = "../../../tflib/helm-cleanup"
-  name      = helm_release.kyverno.id
-  namespace = helm_release.kyverno.namespace
+module "helm" {
+  # Use a separate module because this chart is re-used by
+  # the kyverno-policy-reporter tests
+  source = "./helm"
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the kyverno helm chart."
+
+  steps = [
+    {
+      name = "Helm install"
+      cmd  = module.helm.install_cmd
+    },
+    {
+      # TODO: These aren't exhaustive, but they seem to be pretty
+      # representative outside the full upstream sweep.
+      name = "helm test"
+      cmd  = "helm test -n kyverno kyverno"
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
 }


### PR DESCRIPTION
deconflicts kyverno and kyverno-policy-reporter by isolating them on separate test harnesses. follows the similar model of #2174 