### PR TITLE
add wget to -dev variants

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -116,6 +116,7 @@ module "this-dev" {
     "bash",
     "busybox",
     "git",
+    "wget",
   ], var.extra_dev_packages)
 
   check_sbom   = var.check-sbom


### PR DESCRIPTION
This in preparation for removing the `wget` applet from `busybox`, into `busybox-full`: https://github.com/wolfi-dev/os/pull/12631