### PR TITLE
emit more useful logs from failed imagetest helm installs

### DIFF
--- a/tflib/imagetest/helm/main.tf
+++ b/tflib/imagetest/helm/main.tf
@@ -1,69 +1,45 @@
-variable "name" {
-  description = "The name of the helm release. One will be generated if not provided"
-  default     = ""
-}
-
-variable "namespace" {
-  description = "The namespace to install the helm release into."
-  default     = "default"
-}
-
-variable "chart" {
-  description = "The name of, or path to the helm chart to install."
-}
-
-variable "repo" {
-  description = "The helm repo to install the chart from. When not specified, a local helm chart will be assumed."
-  default     = ""
-}
-
-variable "chart_version" {
-  description = "The version of the helm chart to install. The latest will be used if none is provided."
-  default     = ""
-}
-
-variable "values" {
-  description = "A map of values to pass to the helm chart."
-  type        = any
-  default     = {}
-}
-
-variable "values_files" {
-  description = "Path to values file on the local filesystem."
-  type        = list(string)
-  default     = []
-}
-
-variable "timeout" {
-  description = "The timeout on the helm install."
-  default     = "5m"
+terraform {
+  required_providers {
+    random = { source = "hashicorp/random" }
+  }
 }
 
 locals {
-  install_cmd = <<-EOa
+  name = var.name != "" ? var.name : random_pet.name.id
+}
+
+resource "random_pet" "name" {}
+
+locals {
+  install_cmd = <<-EOinstall
 apk add helm
-helm install ${var.name} ${var.chart} \
+if ! helm install ${local.name} ${var.chart} \
   --namespace ${var.namespace} --create-namespace \
   %{if var.repo != ""}--repo ${var.repo}%{endif} \
-  %{if var.name == ""}--generate-name%{endif} \
   %{if var.chart_version != ""}--version ${var.chart_version}%{endif} \
   --wait --wait-for-jobs \
   --timeout ${var.timeout} \
   %{if length(var.values_files) != 0}--values ${join(",", var.values_files)}%{endif} \
-  --values <(echo '${jsonencode(var.values)}')
-  EOa
+  --values <(echo '${jsonencode(var.values)}'); then
 
-  uninstall_cmd = <<-EOb
+  printf "\\nFailed to install helm chart\\n"
+
+  printf "\\n\\nGet Pods:\\n\\n"
+  kubectl get pods -n ${var.namespace} -l app.kubernetes.io/instance=${local.name} || true
+
+  printf "\\n\\nDescribe Pods:\\n\\n"
+  kubectl describe pods -n ${var.namespace} -l app.kubernetes.io/instance=${local.name} || true
+
+  printf "\\n\\nEvents:\\n\\n"
+  kubectl get events --field-selector type!=Normal --sort-by=.metadata.creationTimestamp -o wide -n ${var.namespace} || true
+
+  exit 1
+fi
+  EOinstall
+
+  uninstall_cmd = <<-EOuninstall
 helm uninstall ${var.name} --namespace ${var.namespace} \
   --wait \
   --timeout ${var.timeout}
-  EOb
-}
-
-output "install_cmd" {
-  value = local.install_cmd
-}
-
-output "uninstall_cmd" {
-  value = local.uninstall_cmd
+  EOuninstall
 }

--- a/tflib/imagetest/helm/outputs.tf
+++ b/tflib/imagetest/helm/outputs.tf
@@ -1,0 +1,11 @@
+output "install_cmd" {
+  value = local.install_cmd
+}
+
+output "uninstall_cmd" {
+  value = local.uninstall_cmd
+}
+
+output "release_name" {
+  value = local.name
+}

--- a/tflib/imagetest/helm/variables.tf
+++ b/tflib/imagetest/helm/variables.tf
@@ -1,0 +1,40 @@
+variable "name" {
+  description = "The name of the helm release. One will be generated if not provided"
+  default     = ""
+}
+
+variable "namespace" {
+  description = "The namespace to install the helm release into."
+  default     = "default"
+}
+
+variable "chart" {
+  description = "The name of, or path to the helm chart to install."
+}
+
+variable "repo" {
+  description = "The helm repo to install the chart from. When not specified, a local helm chart will be assumed."
+  default     = ""
+}
+
+variable "chart_version" {
+  description = "The version of the helm chart to install. The latest will be used if none is provided."
+  default     = ""
+}
+
+variable "values" {
+  description = "A map of values to pass to the helm chart."
+  type        = any
+  default     = {}
+}
+
+variable "values_files" {
+  description = "Path to values file on the local filesystem."
+  type        = list(string)
+  default     = []
+}
+
+variable "timeout" {
+  description = "The timeout on the helm install."
+  default     = "5m"
+}


### PR DESCRIPTION
standard helm emits some pretty useless logs when it errors out:

https://github.com/chainguard-images/images-private/actions/runs/7845026704/job/21411213191#step:15:89

```
INSTALLATION FAILED: client rate limiter Wait returned an error: context deadline exceeded
```

This wraps the install in a block and captures the error, and prints a whole bunch more diagnostics similar to the `k8s-diag` error we use.

these will get captured by the provider and emitted as `diagnostics.details`, which in turn will show up in the CI logs as the `<detail></detail>`
