### PR TITLE
chore: add option for `--create-namespace` in imagetest

### DIFF
--- a/tflib/imagetest/helm/main.tf
+++ b/tflib/imagetest/helm/main.tf
@@ -14,7 +14,8 @@ locals {
   install_cmd = <<-EOinstall
 apk add helm
 if ! helm install ${local.name} ${var.chart} \
-  --namespace ${var.namespace} --create-namespace \
+  --namespace ${var.namespace} \
+  %{if var.create_namespace}--create-namespace%{endif} \
   %{if var.repo != ""}--repo ${var.repo}%{endif} \
   %{if var.chart_version != ""}--version ${var.chart_version}%{endif} \
   --wait --wait-for-jobs \

--- a/tflib/imagetest/helm/variables.tf
+++ b/tflib/imagetest/helm/variables.tf
@@ -38,3 +38,8 @@ variable "timeout" {
   description = "The timeout on the helm install."
   default     = "5m"
 }
+
+variable "create_namespace" {
+  description = "Indicates whether Helm should use --create-namespace."
+  default     = true
+}


### PR DESCRIPTION
Include an option for specifying `--create-namespace` in imagetest. Default is kept as true.