### PR TITLE
fix: opentelemetry-collector-contrib tests after 0.94.0 release

### DIFF
--- a/images/opentelemetry-collector-contrib/tests/custom-deploy-config.yaml
+++ b/images/opentelemetry-collector-contrib/tests/custom-deploy-config.yaml
@@ -1,0 +1,76 @@
+# Configuration adapted from https://github.com/open-telemetry/opentelemetry-helm-charts/blob/07993512215d76b57807468db6bdbf450230e8a6/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+# Removes the logging exporter that seems to not work anymore with v0.94.0 of opentelemetry-collector
+exporters:
+  debug: {}
+
+extensions:
+  health_check:
+    endpoint: ${env:MY_POD_IP}:13133
+
+processors:
+  batch: {}
+  memory_limiter:
+    check_interval: 5s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: ${env:MY_POD_IP}:14250
+      thrift_compact:
+        endpoint: ${env:MY_POD_IP}:6831
+      thrift_http:
+        endpoint: ${env:MY_POD_IP}:14268
+  otlp:
+    protocols:
+      grpc:
+        endpoint: ${env:MY_POD_IP}:4317
+      http:
+        endpoint: ${env:MY_POD_IP}:4318
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: opentelemetry-collector
+          scrape_interval: 10s
+          static_configs:
+            - targets:
+                - ${env:MY_POD_IP}:8888
+  zipkin:
+    endpoint: ${env:MY_POD_IP}:9411
+
+service:
+  extensions:
+    - health_check
+  pipelines:
+    logs:
+      exporters:
+        - debug
+      processors:
+        - memory_limiter
+        - batch
+      receivers:
+        - otlp
+    metrics:
+      exporters:
+        - debug
+      processors:
+        - memory_limiter
+        - batch
+      receivers:
+        - otlp
+        - prometheus
+    traces:
+      exporters:
+        - debug
+      processors:
+        - memory_limiter
+        - batch
+      receivers:
+        - otlp
+        - jaeger
+        - zipkin
+  telemetry:
+    metrics:
+      address: ${env:MY_POD_IP}:8888

--- a/images/opentelemetry-collector-contrib/tests/custom-ds-config.yaml
+++ b/images/opentelemetry-collector-contrib/tests/custom-ds-config.yaml
@@ -45,7 +45,7 @@ exporters:
     const_labels:
       label1: value1
 
-  logging:
+  debug: {}
 
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
@@ -99,7 +99,7 @@ service:
         - k8sattributes
         - batch
       exporters:
-        - logging
+        - debug
         - prometheus
         # - datadog
 
@@ -111,7 +111,7 @@ service:
         - k8sattributes
         - batch
       exporters:
-        - logging
+        - debug
         - zipkin # fails (with warning) without zipkin deployed
         # - datadog
 
@@ -123,6 +123,6 @@ service:
         - k8sattributes
         - batch
       exporters:
-        - logging
+        - debug
         # - datadog
 

--- a/images/opentelemetry-collector-contrib/tests/custom_config.sh
+++ b/images/opentelemetry-collector-contrib/tests/custom_config.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset -o errtrace -o pipefail -x
-
-kubectl create namespace open-telemetry-custom-config
-kubectl create configmap -n open-telemetry-custom-config custom --from-file=${PWD}/images/opentelemetry-collector-contrib/tests/custom-config.yaml


### PR DESCRIPTION
### Changes
* Tests are failing since the release of v0.94.0. Add configuration that works with the new release.
* Migrate tests to the imagetest provider.
