### PR TITLE
enforce 5m timeout on temporal-server test

### DIFF
--- a/images/temporal-server/tests/main.tf
+++ b/images/temporal-server/tests/main.tf
@@ -11,8 +11,9 @@ variable "digest" {
 data "oci_string" "ref" { input = var.digest }
 
 data "oci_exec_test" "helm-install" {
-  digest = var.digest
-  script = "${path.module}/helm.sh"
+  digest          = var.digest
+  script          = "${path.module}/helm.sh"
+  timeout_seconds = 5 * 60 // 5 minutes
 
   env {
     name  = "IMAGE_REGISTRY_REPO"


### PR DESCRIPTION
I'm not sure if this is long enough, but it'd be nice to fail fast rather than time out after an hour, like we do now.