### PR TITLE
migrate crossplane to imagetest

### DIFF
--- a/images/crossplane-aws/tests/install.sh
+++ b/images/crossplane-aws/tests/install.sh
@@ -2,178 +2,22 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail
 
-trap "kubectl get providers && kubectl describe providers" EXIT
-
-# If the image is on cgr.dev and we have a cred helper for that available, use
-# it to generate creds we can pass to the Crossplane control plane.
-# This is necessary when pushing to a private repo, since the Crossplane
-# control plane needs to pull the image to get configuration from it.
-tmp=$(mktemp -d)
-echo "{}" > ${tmp}/config.json
-if [ -x "$(command -v docker-credential-cgr)" ]; then
-  token=$(echo "cgr.dev" | docker-credential-cgr get)
-  user=$(echo $token | jq -r '.Username')
-  pass=$(echo $token | jq -r '.Secret')
-
-  DOCKER_CONFIG=${tmp} crane auth login -u ${user} -p ${pass} cgr.dev
-  echo "WROTE ${tmp}/config.json"
-fi
-head -c 100 ${tmp}/config.json
-kubectl delete secret regcred -n crossplane-system || true
-kubectl create secret generic regcred \
-  -n crossplane-system \
-  --from-file=.dockerconfigjson=${tmp}/config.json \
-  --type=kubernetes.io/dockerconfigjson
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-cloudfront
-spec:
-  package: ${CLOUDFRONT_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-cloudwatchlogs
-spec:
-  package: ${CLOUDWATCHLOGS_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-dynamodb
-spec:
-  package: ${DYNAMODB_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-ec2
-spec:
-  package: ${EC2_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-eks
-spec:
-  package: ${EKS_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-firehose
-spec:
-  package: ${FIREHOSE_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-iam
-spec:
-  package: ${IAM_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-kms
-spec:
-  package: ${KMS_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-lambda
-spec:
-  package: ${LAMBDA_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-rds
-spec:
-  package: ${RDS_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-s3
-spec:
-  package: ${S3_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-sns
-spec:
-  package: ${SNS_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-sqs
-spec:
-  package: ${SQS_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-for provider in cloudfront cloudwatchlogs dynamodb ec2 eks firehose iam kms lambda rds s3 sns sqs ; do
-  kubectl wait --for=condition=Installed "provider/provider-aws-${provider}" --timeout=3m
-  kubectl wait --for=condition=Healthy   "provider/provider-aws-${provider}" --timeout=5m
-done
-
-# Update the AWS family provider that was installed by the above providers as a dependency, to use our AWS family provider instead.
+declare -A providerDigests=(
+	[aws]=${AWS_DIGEST}
+	[cloudfront]=${CLOUDFRONT_DIGEST}
+	[cloudwatchlogs]=${CLOUDWATCHLOGS_DIGEST}
+	[dynamodb]=${DYNAMODB_DIGEST}
+	[ec2]=${EC2_DIGEST}
+	[eks]=${EKS_DIGEST}
+	[firehose]=${FIREHOSE_DIGEST}
+	[iam]=${IAM_DIGEST}
+	[kms]=${KMS_DIGEST}
+	[lambda]=${LAMBDA_DIGEST}
+	[rds]=${RDS_DIGEST}
+	[s3]=${S3_DIGEST}
+	[sns]=${SNS_DIGEST}
+	[sqs]=${SQS_DIGEST}
+)
 
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -182,9 +26,42 @@ metadata:
   name: upbound-provider-family-aws
 spec:
   package: ${AWS_DIGEST}
+  revisionHistoryLimit: 0
+  ignoreCrossplaneConstraints: true
   packagePullSecrets:
   - name: regcred
 EOF
 
-kubectl wait --for=condition=Installed provider/upbound-provider-family-aws --timeout=3m
-kubectl wait --for=condition=Healthy   provider/upbound-provider-family-aws --timeout=5m
+kubectl wait --for=condition=Installed provider upbound-provider-family-aws --timeout=3m
+kubectl wait --for=condition=Healthy provider upbound-provider-family-aws --timeout=5m
+
+# Install 1 provider at a time, these things are fat
+for provider in cloudfront cloudwatchlogs dynamodb ec2 eks firehose iam kms lambda rds s3 sns sqs; do
+	digest="${providerDigests[$provider]}"
+
+	cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-${provider}
+spec:
+  package: ${digest}
+  # The providers seem to hardcode their dependency on the upstream
+  # upbound-provider-family-aws reference. Since we're using our own, we
+  # disable this check.
+  skipDependencyResolution: true
+  # Delete the revision history to save space
+  revisionHistoryLimit: 0
+  # We use psuedo_tags for the provider images, so we need to ignore the semver
+  # checks.
+  ignoreCrossplaneConstraints: true
+  # When applicable, use the regcred secret to pull the provider images.
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+	kubectl wait --for=condition=Installed "provider/provider-aws-${provider}" --timeout=3m
+	kubectl wait --for=condition=Healthy "provider/provider-aws-${provider}" --timeout=5m
+
+	kubectl delete provider provider-aws-${provider}
+done

--- a/images/crossplane-azure/tests/install.sh
+++ b/images/crossplane-azure/tests/install.sh
@@ -2,79 +2,12 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail
 
-trap "kubectl get providers && kubectl describe providers" EXIT
-
-# If the image is on cgr.dev and we have a cred helper for that available, use
-# it to generate creds we can pass to the Crossplane control plane.
-# This is necessary when pushing to a private repo, since the Crossplane
-# control plane needs to pull the image to get configuration from it.
-tmp=$(mktemp -d)
-echo "{}" > ${tmp}/config.json
-if [ -x "$(command -v docker-credential-cgr)" ]; then
-  token=$(echo "cgr.dev" | docker-credential-cgr get)
-  user=$(echo $token | jq -r '.Username')
-  pass=$(echo $token | jq -r '.Secret')
-
-  DOCKER_CONFIG=${tmp} crane auth login -u ${user} -p ${pass} cgr.dev
-  echo "WROTE ${tmp}/config.json"
-fi
-head -c 100 ${tmp}/config.json
-kubectl delete secret regcred -n crossplane-system || true
-kubectl create secret generic regcred \
-  -n crossplane-system \
-  --from-file=.dockerconfigjson=${tmp}/config.json \
-  --type=kubernetes.io/dockerconfigjson
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-azure-authorization
-spec:
-  package: ${AUTHORIZATION_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-azure-managedidentity
-spec:
-  package: ${MANAGEDIDENTITY_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-azure-sql
-spec:
-  package: ${SQL_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-azure-storage
-spec:
-  package: ${STORAGE_DIGEST}
-  packagePullSecrets:
-  - name: regcred
-EOF
-
-for provider in authorization managedidentity sql storage; do
-  kubectl wait --for=condition=Installed "provider/provider-azure-${provider}" --timeout=3m
-  kubectl wait --for=condition=Healthy   "provider/provider-azure-${provider}" --timeout=5m
-done
-
-# Update the Azure family provider that was installed by the above providers as a dependency, to use our Azure family provider instead.
+declare -A providerDigests=(
+	[authorization]=${AUTHORIZATION_DIGEST}
+	[managedidentity]=${MANAGEDIDENTITY_DIGEST}
+	[sql]=${SQL_DIGEST}
+	[storage]=${STORAGE_DIGEST}
+)
 
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -83,9 +16,39 @@ metadata:
   name: upbound-provider-family-azure
 spec:
   package: ${AZURE_DIGEST}
+  revisionHistoryLimit: 0
+  ignoreCrossplaneConstraints: true
   packagePullSecrets:
   - name: regcred
 EOF
 
 kubectl wait --for=condition=Installed provider/upbound-provider-family-azure --timeout=3m
-kubectl wait --for=condition=Healthy   provider/upbound-provider-family-azure --timeout=5m
+kubectl wait --for=condition=Healthy provider/upbound-provider-family-azure --timeout=5m
+
+for provider in authorization managedidentity sql storage; do
+	digest="${providerDigests[$provider]}"
+
+	cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-azure-${provider}
+spec:
+  package: ${digest}
+  # The providers seem to hardcode their dependency on the upstream
+  # upbound-provider-family-azure reference. Since we're using our own, we
+  # disable this check.
+  skipDependencyResolution: true
+  # Delete the revision history to save space
+  revisionHistoryLimit: 0
+  # We use psuedo_tags for the provider images, so we need to ignore the semver
+  # checks.
+  ignoreCrossplaneConstraints: true
+  # When applicable, use the regcred secret to pull the provider images.
+  packagePullSecrets:
+  - name: regcred
+EOF
+
+	kubectl wait --for=condition=Installed "provider/provider-azure-${provider}" --timeout=3m
+	kubectl wait --for=condition=Healthy "provider/provider-azure-${provider}" --timeout=5m
+done

--- a/images/crossplane-azure/tests/main.tf
+++ b/images/crossplane-azure/tests/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
-    oci  = { source = "chainguard-dev/oci" }
-    helm = { source = "hashicorp/helm" }
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
   }
 }
 
@@ -16,60 +16,57 @@ variable "digests" {
   })
 }
 
-resource "helm_release" "crossplane" {
-  name             = "crossplane"
-  repository       = "https://charts.crossplane.io/stable"
-  chart            = "crossplane"
-  namespace        = "crossplane-system"
-  create_namespace = true
+data "imagetest_inventory" "this" {}
 
-  values = [jsonencode({
-    // Our images have package config in one big layer, which might cause the
-    // Crossplane control plane to have difficulty.
-    resourcesCrossplane = {
-      limits = {
-        cpu    = "1"
-        memory = "1Gi"
+resource "imagetest_harness_k3s" "this" {
+  name      = "crossplane"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
       }
-      requests = {
-        cpu    = "1"
-        memory = "1Gi"
-      }
+    ]
+
+    envs = {
+      "AZURE_DIGEST"           = var.digests.family
+      "AUTHORIZATION_DIGEST"   = var.digests.authorization
+      "MANAGEDIDENTITY_DIGEST" = var.digests.managedidentity
+      "SQL_DIGEST"             = var.digests.sql
+      "STORAGE_DIGEST"         = var.digests.storage
     }
-  })]
-}
-
-data "oci_exec_test" "install" {
-  depends_on = [helm_release.crossplane]
-
-  script = "${path.module}/install.sh"
-  digest = var.digests.family // Unused but required by the data source
-
-  env {
-    name  = "AZURE_DIGEST"
-    value = var.digests.family
-  }
-  env {
-    name  = "AUTHORIZATION_DIGEST"
-    value = var.digests.authorization
-  }
-  env {
-    name  = "MANAGEDIDENTITY_DIGEST"
-    value = var.digests.managedidentity
-  }
-  env {
-    name  = "SQL_DIGEST"
-    value = var.digests.sql
-  }
-  env {
-    name  = "STORAGE_DIGEST"
-    value = var.digests.storage
   }
 }
 
-module "helm_cleanup" {
-  depends_on = [data.oci_exec_test.install]
-  source     = "../../../tflib/helm-cleanup"
-  name       = helm_release.crossplane.id
-  namespace  = helm_release.crossplane.namespace
+module "helm_crossplane" {
+  source = "../../crossplane/tests/install"
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the cert-manager helm chart."
+
+  steps = [
+    {
+      name = "Install crossplane",
+      cmd  = module.helm_crossplane.install_cmd
+    },
+    {
+      name = "Something"
+      cmd  = "/tests/install.sh"
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+
+  timeouts = {
+    # This can take a while since we're working in serial to avoid disk
+    # pressure
+    create = "15m"
+  }
 }

--- a/images/crossplane/tests/install/main.tf
+++ b/images/crossplane/tests/install/main.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_providers {
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "values" {
+  type = any
+  default = {
+    image = {
+      repository = "cgr.dev/chainguard/crossplane"
+      tag        = "latest"
+    }
+  }
+}
+
+module "helm_crossplane" {
+  source = "../../../../tflib/imagetest/helm"
+
+  name      = "crossplane"
+  namespace = "crossplane-system"
+  repo      = "https://charts.crossplane.io/stable"
+  chart     = "crossplane"
+
+  values = merge(var.values, {
+    // Our images have package config in one big layer, which might cause the
+    // Crossplane control plane to have difficulty.
+    resourcesCrossplane = {
+      limits = {
+        cpu    = "1"
+        memory = "1Gi"
+      }
+      requests = {
+        cpu    = "1"
+        memory = "1Gi"
+      }
+    }
+  })
+}
+
+output "install_cmd" {
+  value = <<EOF
+${module.helm_crossplane.install_cmd}
+
+apk add jq yq
+
+yq eval -o=json /k3s-config/registries.yaml | jq '
+{
+  "auths": (
+    .configs | to_entries | map({
+      key: .key,
+      value: { auth: ((.value.auth.username + ":" + .value.auth.password) | @base64) }
+    }) | from_entries
+  )
+}' | kubectl create secret generic regcred \
+  -n crossplane-system \
+  --from-file=.dockerconfigjson=/dev/stdin \
+  --type=kubernetes.io/dockerconfigjson || true
+  EOF
+}

--- a/images/crossplane/tests/main.tf
+++ b/images/crossplane/tests/main.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
-    oci = { source = "chainguard-dev/oci" }
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
   }
 }
 
@@ -16,24 +17,37 @@ data "oci_string" "ref" {
   input    = each.value
 }
 
-resource "helm_release" "crossplane" {
-  name       = "crossplane"
-  repository = "https://charts.crossplane.io/stable"
-  chart      = "crossplane"
+data "imagetest_inventory" "this" {}
 
-  create_namespace = true
-  namespace        = "crossplane-system"
+resource "imagetest_harness_k3s" "this" {
+  name      = "crossplane"
+  inventory = data.imagetest_inventory.this
+}
 
-  values = [jsonencode({
+module "helm_crossplane" {
+  source = "../../crossplane/tests/install"
+
+  values = {
     image = {
       repository = data.oci_string.ref["crossplane"].registry_repo
       tag        = data.oci_string.ref["crossplane"].pseudo_tag
     }
-  })]
+  }
 }
 
-module "helm-cleanup" {
-  source    = "../../../tflib/helm-cleanup"
-  name      = helm_release.crossplane.id
-  namespace = helm_release.crossplane.namespace
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the cert-manager helm chart."
+
+  steps = [
+    {
+      name = "Install crossplane",
+      cmd  = module.helm_crossplane.install_cmd
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
 }


### PR DESCRIPTION
migrate the crossplane suite of images to use `imagetest`.

the auth required for pulling from private sources is handled by rejiggering the `auth` setup that the `imagetest_harness_k3s` sets up.