### PR TITLE
terraform: move latest to BUSL version, add :1.5.7 for last pre-BUSL version

### DIFF
--- a/images/terraform/config/main.tf
+++ b/images/terraform/config/main.tf
@@ -9,9 +9,31 @@ variable "extra_packages" {
   default     = []
 }
 
+variable "extra_repositories" {
+  description = "The additional repositores to install from (e.g. extras)."
+  default     = []
+}
+
+variable "extra_keyring" {
+  description = "The additional keys to use (e.g. extras)."
+  default     = []
+}
+
+locals { base_config = yamldecode(file("${path.module}/template.apko.yaml")) }
+
 data "apko_config" "this" {
-  config_contents = file("${path.module}/template.apko.yaml")
-  extra_packages  = var.extra_packages
+  config_contents = yamlencode(merge(
+    local.base_config,
+    {
+      // Allow injecting extra repositories and keyrings.
+      contents = {
+        repositories = var.extra_repositories
+        keyring      = var.extra_keyring
+        packages     = local.base_config.contents.packages
+      }
+    },
+  ))
+  extra_packages = var.extra_packages
 }
 
 output "config" {

--- a/images/terraform/main.tf
+++ b/images/terraform/main.tf
@@ -56,7 +56,7 @@ resource "oci_tag" "latest-busl-dev" {
   tag        = "latest-dev"
 }
 
-locals { pre_busl_tags = toset(["1.5.7", "1.5"]) }
+locals { pre_busl_tags = toset(["1.5.7", "1.5", "latest-mpl"]) }
 
 resource "oci_tag" "pre-busl" {
   for_each   = local.pre_busl_tags

--- a/images/terraform/main.tf
+++ b/images/terraform/main.tf
@@ -8,32 +8,66 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-module "latest-config" {
+module "pre-busl-config" {
   source         = "./config"
   extra_packages = ["terraform<1.6"]
 }
 
-module "latest" {
+module "latest-busl-config" {
+  source         = "./config"
+  extra_packages = ["terraform"]
+}
+
+module "pre-busl" {
   source            = "../../tflib/publisher"
   name              = basename(path.module)
   target_repository = var.target_repository
-  config            = module.latest-config.config
+  config            = module.pre-busl-config.config
   build-dev         = true
 }
 
-module "test-latest" {
+module "test-pre-busl" {
   source = "./tests"
-  digest = module.latest.image_ref
+  digest = module.pre-busl.image_ref
 }
 
-resource "oci_tag" "latest" {
-  depends_on = [module.test-latest]
-  digest_ref = module.latest.image_ref
+module "latest-busl" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-busl-config.config
+  build-dev         = true
+}
+
+module "test-latest-busl" {
+  source = "./tests"
+  digest = module.latest-busl.image_ref
+}
+
+resource "oci_tag" "latest-busl" {
+  depends_on = [module.test-latest-busl]
+  digest_ref = module.latest-busl.image_ref
   tag        = "latest"
 }
 
-resource "oci_tag" "latest-dev" {
-  depends_on = [module.test-latest]
-  digest_ref = module.latest.dev_ref
+resource "oci_tag" "latest-busl-dev" {
+  depends_on = [module.test-latest-busl]
+  digest_ref = module.latest-busl.dev_ref
   tag        = "latest-dev"
+}
+
+locals { pre_busl_tags = toset(["1.5.7", "1.5"]) }
+
+resource "oci_tag" "pre-busl" {
+  for_each   = local.pre_busl_tags
+  depends_on = [module.test-pre-busl]
+  digest_ref = module.pre-busl.image_ref
+  tag        = each.key
+}
+
+resource "oci_tag" "pre-busl-dev" {
+  for_each   = local.pre_busl_tags
+  depends_on = [module.test-pre-busl]
+  digest_ref = module.pre-busl.dev_ref
+  tag        = "${each.key}-dev"
 }


### PR DESCRIPTION
Ran locally

```
module.terraform.oci_tag.latest-busl: Creation complete after 1s [id=ttl.sh/jason/terraform:latest@sha256:2964ce66f290c759abda053b343d297df39555bfc6fcf8cc09de32d2e5c03acb]
module.terraform.oci_tag.latest-busl-dev: Creation complete after 1s [id=ttl.sh/jason/terraform:latest-dev@sha256:f5e69646e91c6db07a1976435faa0f66e8351749aabcd4266b6dde712a69bd75]
module.terraform.oci_tag.pre-busl-dev["1.5"]: Creation complete after 2s [id=ttl.sh/jason/terraform:1.5-dev@sha256:f5e69646e91c6db07a1976435faa0f66e8351749aabcd4266b6dde712a69bd75]
module.terraform.oci_tag.pre-busl["1.5.7"]: Creation complete after 2s [id=ttl.sh/jason/terraform:1.5.7@sha256:2964ce66f290c759abda053b343d297df39555bfc6fcf8cc09de32d2e5c03acb]
module.terraform.oci_tag.pre-busl-dev["1.5.7"]: Creation complete after 2s [id=ttl.sh/jason/terraform:1.5.7-dev@sha256:f5e69646e91c6db07a1976435faa0f66e8351749aabcd4266b6dde712a69bd75]
module.terraform.oci_tag.pre-busl["1.5"]: Creation complete after 3s [id=ttl.sh/jason/terraform:1.5@sha256:2964ce66f290c759abda053b343d297df39555bfc6fcf8cc09de32d2e5c03acb]
```