### PR TITLE
chore(temporal-server): migrate tests to imagetest

### DIFF
--- a/images/temporal-server/tests/admin-tools-pod.yaml
+++ b/images/temporal-server/tests/admin-tools-pod.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: admin-tools
+  name: admin-tools
+spec:
+  containers:
+    - args:
+        - tail
+        - -f
+        - /dev/null
+      env:
+        - name: TEMPORAL_ADDRESS
+          value: temporaltest-frontend.temporaltest.svc:7233 # TODO(mauren): figure out a better way
+      image: cgr.dev/chainguard/temporal-admin-tools
+      name: admin-tools
+      resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Always

--- a/images/temporal-server/tests/main.tf
+++ b/images/temporal-server/tests/main.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
-    oci = { source = "chainguard-dev/oci" }
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
   }
 }
 
@@ -10,17 +11,87 @@ variable "digest" {
 
 data "oci_string" "ref" { input = var.digest }
 
-data "oci_exec_test" "helm-install" {
-  digest          = var.digest
-  script          = "${path.module}/helm.sh"
-  timeout_seconds = 15 * 60 // 15 minutes, as specified in the helm install command
+data "imagetest_inventory" "this" {}
 
-  env {
-    name  = "IMAGE_REGISTRY_REPO"
-    value = data.oci_string.ref.registry_repo
+resource "imagetest_harness_k3s" "this" {
+  name      = "temporal-server"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ]
   }
-  env {
-    name  = "IMAGE_TAG"
-    value = data.oci_string.ref.pseudo_tag
-  }
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the temporal-server helm chart."
+
+  steps = [
+    {
+      name = "Install Helm CLI"
+      cmd  = "apk add helm"
+    },
+    {
+      name = "Install Helm chart"
+      cmd  = <<EOF
+        export IMAGE_REGISTRY_REPO=${data.oci_string.ref.registry_repo}
+        export IMAGE_TAG=${data.oci_string.ref.pseudo_tag}
+        /tests/helm.sh
+      EOF
+    },
+    {
+      name = "Deploy the admin-tools image to the cluster"
+      cmd  = <<EOF
+        kubectl apply --filename /tests/admin-tools-pod.yaml
+        kubectl wait --for=condition=ready pod --selector run=admin-tools --timeout 5m
+      EOF
+    },
+    {
+      name = "Configure the temporal environment"
+      cmd  = <<EOF
+        kubectl exec admin-tools -- temporal operator namespace create workflow-test
+      EOF
+    },
+    {
+      name = "Create a workflow run"
+      cmd  = <<EOF
+        # This won't do anything because there are no consumers available
+        kubectl exec admin-tools -- \
+          temporal workflow start \
+            --task-queue hello-world \
+            --type MyWorkflow \
+            --workflow-id 123 \
+            --input 456 \
+            --namespace workflow-test
+      EOF
+    },
+    {
+      name = "Cancel the workflow run"
+      cmd  = <<EOF
+        # Just cancels the no-op workflow from the previous step
+        kubectl exec admin-tools -- \
+          temporal workflow cancel \
+            --workflow-id 123 \
+            --namespace workflow-test
+      EOF
+    },
+    {
+      name = "Clean up admin-tools pod"
+      cmd  = <<EOF
+        kubectl delete --filename /tests/admin-tools-pod.yaml
+      EOF
+    },
+    {
+      name = "Uninstall Helm chart"
+      cmd  = <<EOF
+        helm uninstall temporaltest --namespace temporaltest
+      EOF
+    }
+  ]
 }


### PR DESCRIPTION
Migrate the `temporal-server` tests to imagetest to hopefully address some conflict failures that have been happening.