### PR TITLE
Add a wire image.

### DIFF
--- a/images/wire/README.md
+++ b/images/wire/README.md
@@ -1,0 +1,47 @@
+<!--monopod:start-->
+# wire
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/wire` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/wire/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Minimalist Wolfi-based wire image for Go code generation.
+<!--overview:end-->
+
+<!--getting:start-->
+## Get It!
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/wire:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+Run the wire image:
+
+```
+docker run --rm cgr.dev/chainguard/wire:latest help
+
+Usage: wire <flags> <subcommand> <subcommand args>
+
+Subcommands:
+	check            print any Wire errors found
+	commands         list all command names
+	diff             output a diff between existing wire_gen.go files and what gen would generate
+	flags            describe all known top-level flags
+	gen              generate the wire_gen.go file for each package
+	help             describe subcommands and their syntax
+	show             describe all top-level provider sets
+```
+<!--body:end-->

--- a/images/wire/config/main.tf
+++ b/images/wire/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. wire-go)."
+  default     = ["wire-go"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/wire/config/template.apko.yaml
+++ b/images/wire/config/template.apko.yaml
@@ -1,0 +1,19 @@
+contents:
+  packages:
+    - wire-go
+    - go
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/wire
+
+cmd: help

--- a/images/wire/main.tf
+++ b/images/wire/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/wire/metadata.yaml
+++ b/images/wire/metadata.yaml
@@ -1,0 +1,12 @@
+name: wire
+image: cgr.dev/chainguard/wire
+logo: https://storage.googleapis.com/chainguard-academy/logos/wire.svg
+endoflife: ""
+console_summary: ""
+short_description: Minimalist Wolfi-based wire image for Go code generation.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/google/wire
+keywords:
+  - application
+  - tools

--- a/images/wire/tests/01-run.sh
+++ b/images/wire/tests/01-run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+TMPDIR="$(mktemp -d)"
+chmod go+wrx $TMPDIR
+cd $TMPDIR
+
+
+# This is a bit weird, but it's cribbed from here: https://github.com/google/wire/blob/main/_tutorial/README.md
+cat <<EOF > main.go
+package main
+
+import "fmt"
+
+type Message string
+
+func NewMessage() Message {
+    return Message("Hi there!")
+}
+
+func NewGreeter(m Message) Greeter {
+    return Greeter{Message: m}
+}
+
+type Greeter struct {
+    Message Message
+}
+
+func (g Greeter) Greet() Message {
+    return g.Message
+}
+
+func NewEvent(g Greeter) Event {
+    return Event{Greeter: g}
+}
+
+
+type Event struct {
+    Greeter Greeter
+}
+
+func (e Event) Start() {
+    msg := e.Greeter.Greet()
+    fmt.Println(msg)
+}
+
+func main() {
+    e := InitializeEvent()
+
+    e.Start()
+}
+EOF
+
+cat <<EOF > wire.go
+//+build wireinject
+
+package main
+
+import "github.com/google/wire"
+
+func InitializeEvent() Event {
+    wire.Build(NewEvent, NewGreeter, NewMessage)
+    return Event{}
+}
+EOF
+
+docker run -w /src -v $(pwd):/src --entrypoint=go $IMAGE_NAME mod init example.com/hello
+docker run -w /src -v $(pwd):/src --entrypoint=go $IMAGE_NAME mod tidy
+
+docker run -w /src -v $(pwd):/src $IMAGE_NAME gen
+
+# This file should be generated!
+cat wire_gen.go | grep InitializeEvent

--- a/images/wire/tests/main.tf
+++ b/images/wire/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "help" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME help"
+}

--- a/images/wire/tests/main.tf
+++ b/images/wire/tests/main.tf
@@ -12,3 +12,8 @@ data "oci_exec_test" "help" {
   digest = var.digest
   script = "docker run --rm $IMAGE_NAME help"
 }
+
+data "oci_exec_test" "runs" {
+  digest = var.digest
+  script = "${path.module}/01-run.sh"
+}

--- a/main.tf
+++ b/main.tf
@@ -1373,6 +1373,11 @@ module "weaviate" {
   target_repository = "${var.target_repository}/weaviate"
 }
 
+module "wire" {
+  source            = "./images/wire"
+  target_repository = "${var.target_repository}/wire"
+}
+
 module "wolfi-base" {
   source            = "./images/wolfi-base"
   target_repository = "${var.target_repository}/wolfi-base"


### PR DESCRIPTION
While debugging an issue in wire I saw a github issue requesting one: https://github.com/google/wire/issues/274

We already had it packaged, so why not!

## New Image Pull Request Template

### Image Size

Notes: N/A, no public image.

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Image Tagging

- [X] The image is _not_ tagged with version tags.
- [X] The image is tagged with :latest

Notes:

### Basic Testing - K8s cluster

Notes: N/A

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

Notes: N/A

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default

### ENTRYPOINT

- X ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]

### CMD

- [X] For utilities/tooling bring up help e.g. `–help`

### Environment Variables

- [X] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
