### PR TITLE
Updating 'Get it' language in READMEs

### DIFF
--- a/images/apko/README.md
+++ b/images/apko/README.md
@@ -17,7 +17,7 @@ Container image for running [apko](https://github.com/chainguard-dev/apko) conta
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/argo/README.md
+++ b/images/argo/README.md
@@ -17,7 +17,7 @@ Images for working with [Argo workflows](https://argoproj.github.io/argo-workflo
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/argocd/README.md
+++ b/images/argocd/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/aspnet-runtime/README.md
+++ b/images/aspnet-runtime/README.md
@@ -17,7 +17,7 @@ Container image with the latest ASP.NET runtime.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/atlantis/README.md
+++ b/images/atlantis/README.md
@@ -17,7 +17,7 @@ Terraform Pull Request Automation
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/aws-cli/README.md
+++ b/images/aws-cli/README.md
@@ -17,7 +17,7 @@ Minimal [aws-cli](https://github.com/aws/aws-cli) container image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/aws-ebs-csi-driver/README.md
+++ b/images/aws-ebs-csi-driver/README.md
@@ -17,7 +17,7 @@ Minimal images for [aws-ebs-csi-driver](https://aws.amazon.com/ebs/).
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/aws-efs-csi-driver/README.md
+++ b/images/aws-efs-csi-driver/README.md
@@ -17,7 +17,7 @@ Minimal images for [aws-efs-csi-driver](https://aws.amazon.com/efs/).
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/aws-for-fluent-bit/README.md
+++ b/images/aws-for-fluent-bit/README.md
@@ -17,7 +17,7 @@ Minimal [aws-for-fluent-bit](https://github.com/aws/aws-for-fluent-bit) Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/aws-load-balancer-controller/README.md
+++ b/images/aws-load-balancer-controller/README.md
@@ -17,7 +17,7 @@ Minimal Image for Kubernetes controller for Elastic Load Balancers
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/az/README.md
+++ b/images/az/README.md
@@ -17,7 +17,7 @@ Azure CLI
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/bank-vaults/README.md
+++ b/images/bank-vaults/README.md
@@ -17,7 +17,7 @@ Minimal Image for [Bank Vaults](https://bank-vaults.dev/), a CLI tool to init, u
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/bash/README.md
+++ b/images/bash/README.md
@@ -17,7 +17,7 @@ Container image with only Bash and libc. Suitable for running any small scripts 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/bazel/README.md
+++ b/images/bazel/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/boring-registry/README.md
+++ b/images/boring-registry/README.md
@@ -17,7 +17,7 @@ Minimal image with the `boring-registry` [server application](https://github.com
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/buck2/README.md
+++ b/images/buck2/README.md
@@ -17,7 +17,7 @@ Minimal image with [buck2](https://buck2.build) build system binaries and toolch
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/buildkit/README.md
+++ b/images/buildkit/README.md
@@ -17,7 +17,7 @@ Buildkit is a concurrent, cache-efficient, and Dockerfile-agnostic builder toolk
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/bun/README.md
+++ b/images/bun/README.md
@@ -17,7 +17,7 @@ Minimal image with [bun](https://bun.sh/) tool.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/busybox/README.md
+++ b/images/busybox/README.md
@@ -17,7 +17,7 @@ Container image with only busybox and libc (available in both musl and glibc var
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/caddy/README.md
+++ b/images/caddy/README.md
@@ -17,7 +17,7 @@ Open source web server with automatic HTTPS written in Go
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cadvisor/README.md
+++ b/images/cadvisor/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/calico/README.md
+++ b/images/calico/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cass-config-builder/README.md
+++ b/images/cass-config-builder/README.md
@@ -17,7 +17,7 @@ Minimal [cass-config-builder](https://github.com/datastax/cass-config-builder) c
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cass-operator/README.md
+++ b/images/cass-operator/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cassandra-medusa/README.md
+++ b/images/cassandra-medusa/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cassandra-reaper/README.md
+++ b/images/cassandra-reaper/README.md
@@ -17,7 +17,7 @@ Automated Repair Awesomeness for Apache Cassandra
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cassandra/README.md
+++ b/images/cassandra/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cc-dynamic/README.md
+++ b/images/cc-dynamic/README.md
@@ -17,7 +17,7 @@ Base image with just enough to run arbitrary binaries that may require gcc or cc
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cedar/README.md
+++ b/images/cedar/README.md
@@ -17,7 +17,7 @@ This image contains the CLI for the [Cedar Policy](https://www.cedarpolicy.com/e
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cert-exporter/README.md
+++ b/images/cert-exporter/README.md
@@ -17,7 +17,7 @@ A minimal, wolfi-based image for cert-exporter: an application that exports cert
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cert-manager/README.md
+++ b/images/cert-manager/README.md
@@ -17,7 +17,7 @@ Minimal, wolfi-based images for [Cert Manager](https://cert-manager.io): Provisi
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cfssl/README.md
+++ b/images/cfssl/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cilium/README.md
+++ b/images/cilium/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/clang/README.md
+++ b/images/clang/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cluster-autoscaler/README.md
+++ b/images/cluster-autoscaler/README.md
@@ -17,7 +17,7 @@ Minimal Kubernetes Cluster Autoscaler Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cluster-proportional-autoscaler/README.md
+++ b/images/cluster-proportional-autoscaler/README.md
@@ -17,7 +17,7 @@ Minimal Kubernetes Cluster Proportional Autoscaler Container
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/conda/README.md
+++ b/images/conda/README.md
@@ -17,7 +17,7 @@ This image contains the CLI for the [Conda](https://docs.conda.io/en/latest/) pr
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/configmap-reload/README.md
+++ b/images/configmap-reload/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/consul/README.md
+++ b/images/consul/README.md
@@ -17,7 +17,7 @@ Minimal image with [Consul](https://www.consul.io/). **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/coredns/README.md
+++ b/images/coredns/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/cosign/README.md
+++ b/images/cosign/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Cosign images for signing and verifying images using Sigs
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/crane/README.md
+++ b/images/crane/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based crane image for interacting with registries.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/crossplane-aws/README.md
+++ b/images/crossplane-aws/README.md
@@ -17,7 +17,7 @@ Crossplane lets you build a control plane with Kubernetes-style declarative and 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/crossplane-azure/README.md
+++ b/images/crossplane-azure/README.md
@@ -17,7 +17,7 @@ Crossplane lets you build a control plane with Kubernetes-style declarative and 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/crossplane/README.md
+++ b/images/crossplane/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ctlog/README.md
+++ b/images/ctlog/README.md
@@ -17,7 +17,7 @@ ctlog is deployed as part of the sigstore stack
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/curl/README.md
+++ b/images/curl/README.md
@@ -17,7 +17,7 @@ Minimal [curl](https://curl.se/) image base containing curl and ca-certificates.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/dask-gateway/README.md
+++ b/images/dask-gateway/README.md
@@ -17,7 +17,7 @@ A multi-tenant server for securely deploying and managing [Dask clusters](https:
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/datadog-agent/README.md
+++ b/images/datadog-agent/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Datadog Agent to collect events and metrics from hosts an
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/deno/README.md
+++ b/images/deno/README.md
@@ -17,7 +17,7 @@ Minimal container image for running [Deno](https://deno.com/) apps
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/dependency-track/README.md
+++ b/images/dependency-track/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/dex/README.md
+++ b/images/dex/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/dive/README.md
+++ b/images/dive/README.md
@@ -17,7 +17,7 @@ Minimal [dive](https://github.com/wagoodman/dive) container image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/dotnet/README.md
+++ b/images/dotnet/README.md
@@ -17,7 +17,7 @@ Minimal image for .NET and the .NET Tools.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/dynamic-localpv-provisioner/README.md
+++ b/images/dynamic-localpv-provisioner/README.md
@@ -17,7 +17,7 @@ Dynamic Local Volumes for Kubernetes Stateful workloads.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/envoy-ratelimit/README.md
+++ b/images/envoy-ratelimit/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/envoy/README.md
+++ b/images/envoy/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/erlang/README.md
+++ b/images/erlang/README.md
@@ -17,7 +17,7 @@ Container image for building Erlang applications.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/etcd/README.md
+++ b/images/etcd/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/external-dns/README.md
+++ b/images/external-dns/README.md
@@ -17,7 +17,7 @@ Minimal image to configure external DNS servers (AWS Route53, Google CloudDNS an
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/external-secrets/README.md
+++ b/images/external-secrets/README.md
@@ -17,7 +17,7 @@ Minimal Kubernetes [External Secrets Operator](https://external-secrets.io/) ima
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/falco-no-driver/README.md
+++ b/images/falco-no-driver/README.md
@@ -17,7 +17,7 @@ A minimal, [wolfi](https://github.com/wolfi-dev)-based image for falco-no-driver
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/falcoctl/README.md
+++ b/images/falcoctl/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based image for `falcoctl`.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ffmpeg/README.md
+++ b/images/ffmpeg/README.md
@@ -17,7 +17,7 @@ Minimal image that contains ffmpeg
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/filebeat/README.md
+++ b/images/filebeat/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/fluent-bit/README.md
+++ b/images/fluent-bit/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/fluentd/README.md
+++ b/images/fluentd/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/flux/README.md
+++ b/images/flux/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/fulcio/README.md
+++ b/images/fulcio/README.md
@@ -17,7 +17,7 @@ Minimal Fulcio image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/gatekeeper/README.md
+++ b/images/gatekeeper/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based [Gatekeeper](https://open-policy-agent.github.io/gatekeep
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/gcc-glibc/README.md
+++ b/images/gcc-glibc/README.md
@@ -17,7 +17,7 @@ Minimal container image for building C applications (which require glibc).
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/git/README.md
+++ b/images/git/README.md
@@ -17,7 +17,7 @@ A minimal Git image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/gitlab/README.md
+++ b/images/gitlab/README.md
@@ -17,7 +17,7 @@ GitLab is an open source end-to-end software development platform with built-in 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/gitness/README.md
+++ b/images/gitness/README.md
@@ -17,7 +17,7 @@ Minimal image with the `gitness` [server application](https://github.com/harness
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/glibc-dynamic/README.md
+++ b/images/glibc-dynamic/README.md
@@ -17,7 +17,7 @@ Base image with just enough to run arbitrary glibc binaries.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/go/README.md
+++ b/images/go/README.md
@@ -17,7 +17,7 @@ Container image for building Go applications.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/google-cloud-sdk/README.md
+++ b/images/google-cloud-sdk/README.md
@@ -17,7 +17,7 @@ Minimal image with the [Google Cloud SDK](https://cloud.google.com/sdk/). **EXPE
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/graalvm-native/README.md
+++ b/images/graalvm-native/README.md
@@ -17,7 +17,7 @@ Base image with just enough files to run native [GraalVM](https://www.graalvm.or
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/gradle/README.md
+++ b/images/gradle/README.md
@@ -17,7 +17,7 @@ Minimal image with [Gradle](https://gradle.org/) build system. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/grafana/README.md
+++ b/images/grafana/README.md
@@ -17,7 +17,7 @@ A minimal wolfi-based image for grafana, which is an open-source monitoring and 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/grype/README.md
+++ b/images/grype/README.md
@@ -17,7 +17,7 @@ A vulnerability scanner for container images and filesystems
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/guacamole-server/README.md
+++ b/images/guacamole-server/README.md
@@ -17,7 +17,7 @@ Minimal [Guacamole server](https://guacamole.apache.org/) remote desktop gateway
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/haproxy-ingress/README.md
+++ b/images/haproxy-ingress/README.md
@@ -17,7 +17,7 @@ Kubernetes ingress controller implementation for HAProxy
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/haproxy/README.md
+++ b/images/haproxy/README.md
@@ -17,7 +17,7 @@ A minimal [haproxy](https://www.haproxy.org/) base image rebuilt every night fro
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/helm-chartmuseum/README.md
+++ b/images/helm-chartmuseum/README.md
@@ -17,7 +17,7 @@ Minimal image with [chartmuseum](https://github.com/helm/chartmuseum) binary. **
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/helm/README.md
+++ b/images/helm/README.md
@@ -17,7 +17,7 @@ Minimal image with [helm](https://helm.sh) binary. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/http-echo/README.md
+++ b/images/http-echo/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based http-echo image that echos what you start it with.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/hugo/README.md
+++ b/images/hugo/README.md
@@ -17,7 +17,7 @@ This is a minimal [Hugo](https://gohugo.io/) image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/influxdb/README.md
+++ b/images/influxdb/README.md
@@ -17,7 +17,7 @@ Minimal image with influxdb. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ingress-nginx-controller/README.md
+++ b/images/ingress-nginx-controller/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ip-masq-agent/README.md
+++ b/images/ip-masq-agent/README.md
@@ -17,7 +17,7 @@ Minimal image to manage IP masquerading on Kubernetes nodes
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/istio/README.md
+++ b/images/istio/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/jdk-lts/README.md
+++ b/images/jdk-lts/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Java JDK image using using [OpenJDK](https://openjdk.org/
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/jdk/README.md
+++ b/images/jdk/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Java JDK image using using [OpenJDK](https://openjdk.org/
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/jenkins/README.md
+++ b/images/jenkins/README.md
@@ -17,7 +17,7 @@ Minimal [Jenkins](https://jenkins.io) container image. **Currently experimental.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/jre-lts/README.md
+++ b/images/jre-lts/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Java JRE image using [OpenJDK](https://openjdk.org/projec
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/jre/README.md
+++ b/images/jre/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Java JRE image using [OpenJDK](https://openjdk.org/projec
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/k3s/README.md
+++ b/images/k3s/README.md
@@ -17,7 +17,7 @@ Minimal image of [K3s](https://k3s.io/), a lightweight Kubernetes distribution
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/k8s-sidecar/README.md
+++ b/images/k8s-sidecar/README.md
@@ -17,7 +17,7 @@ Minimal image with the k8s-sidecar app. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/k8sgpt-operator/README.md
+++ b/images/k8sgpt-operator/README.md
@@ -17,7 +17,7 @@ Minimal k8sgpt-operator container image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/k8sgpt/README.md
+++ b/images/k8sgpt/README.md
@@ -17,7 +17,7 @@ Minimal [k8sgpt](https://k8sgpt.ai/) container image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/k8ssandra-operator/README.md
+++ b/images/k8ssandra-operator/README.md
@@ -17,7 +17,7 @@ The Kubernetes operator for K8ssandra
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kafka/README.md
+++ b/images/kafka/README.md
@@ -17,7 +17,7 @@ Minimal image with Kafka. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/karpenter/README.md
+++ b/images/karpenter/README.md
@@ -17,7 +17,7 @@ Minimal image with Karpenter. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/keda/README.md
+++ b/images/keda/README.md
@@ -17,7 +17,7 @@ Minimal image with the Keda binary. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/keycloak/README.md
+++ b/images/keycloak/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based [Keycloak](https://www.keycloak.org/) image for identity 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ko/README.md
+++ b/images/ko/README.md
@@ -17,7 +17,7 @@ Minimal image to build and deploy Go applications using [ko](https://ko.build/)
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kor/README.md
+++ b/images/kor/README.md
@@ -17,7 +17,7 @@ A Golang Tool to discover unused Kubernetes Resources
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kube-bench/README.md
+++ b/images/kube-bench/README.md
@@ -17,7 +17,7 @@ Minimal image with [kube-bench](https://github.com/aquasecurity/kube-bench).
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kube-downscaler/README.md
+++ b/images/kube-downscaler/README.md
@@ -17,7 +17,7 @@ Minimal image with [kube-downscaler](https://codeberg.org/hjacobs/kube-downscale
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kube-fluentd-operator/README.md
+++ b/images/kube-fluentd-operator/README.md
@@ -17,7 +17,7 @@ This image is used for the [Kubernetes Fluentd Operator](https://github.com/vmwa
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kube-logging-operator-fluentd/README.md
+++ b/images/kube-logging-operator-fluentd/README.md
@@ -17,7 +17,7 @@ Kubernetes Logging Operator Fluentd Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kube-logging-operator/README.md
+++ b/images/kube-logging-operator/README.md
@@ -17,7 +17,7 @@ Minimal Logging operator for Kubernetes Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kube-state-metrics/README.md
+++ b/images/kube-state-metrics/README.md
@@ -17,7 +17,7 @@ Minimal Kube State Metrics Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubectl/README.md
+++ b/images/kubectl/README.md
@@ -17,7 +17,7 @@ Minimal image with kubectl binary. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubeflow-centraldashboard/README.md
+++ b/images/kubeflow-centraldashboard/README.md
@@ -20,7 +20,7 @@ For more information, see the [Kubeflow Central Dashboard](https://www.kubeflow.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubeflow-katib/README.md
+++ b/images/kubeflow-katib/README.md
@@ -17,7 +17,7 @@ Minimalist Kubeflow Katib Images
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubeflow-pipelines-visualization-server/README.md
+++ b/images/kubeflow-pipelines-visualization-server/README.md
@@ -17,7 +17,7 @@ Minimal image with [ml-pipeline/visualization-server](https://github.com/kubeflo
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubeflow-pipelines/README.md
+++ b/images/kubeflow-pipelines/README.md
@@ -17,7 +17,7 @@ Minimalist Kubeflow Pipelines Images
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubeflow/README.md
+++ b/images/kubeflow/README.md
@@ -17,7 +17,7 @@ Minimalist Kubeflow Machine Learning Toolkit for Kubernetes Images
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-external-attacher/README.md
+++ b/images/kubernetes-csi-external-attacher/README.md
@@ -17,7 +17,7 @@ Minimal image with [kubernetes-csi/external-attacher](https://github.com/kuberne
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-external-provisioner/README.md
+++ b/images/kubernetes-csi-external-provisioner/README.md
@@ -17,7 +17,7 @@ Minimal image that acts as a drop-in replacement for the `kubernetes-csi/externa
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-external-resizer/README.md
+++ b/images/kubernetes-csi-external-resizer/README.md
@@ -17,7 +17,7 @@ Minimal image with [kubernetes-csi/external-resizer](https://github.com/kubernet
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-external-snapshot-controller/README.md
+++ b/images/kubernetes-csi-external-snapshot-controller/README.md
@@ -17,7 +17,7 @@ A minimal image for Kubernetes CSI external-snapshot-controller.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-external-snapshot-validation-webhook/README.md
+++ b/images/kubernetes-csi-external-snapshot-validation-webhook/README.md
@@ -17,7 +17,7 @@ A minimal image for Kubernetes CSI external-snapshot-validation-webhook.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-external-snapshotter/README.md
+++ b/images/kubernetes-csi-external-snapshotter/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-livenessprobe/README.md
+++ b/images/kubernetes-csi-livenessprobe/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-csi-node-driver-registrar/README.md
+++ b/images/kubernetes-csi-node-driver-registrar/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-dashboard/README.md
+++ b/images/kubernetes-dashboard/README.md
@@ -17,7 +17,7 @@ Minimal image that acts as a drop-in replacement for the `kubernetesui/dashboard
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-dns-node-cache/README.md
+++ b/images/kubernetes-dns-node-cache/README.md
@@ -17,7 +17,7 @@ Minimal image that acts as a drop-in replacement for the [NodeLocal DNSCache](ht
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-event-exporter/README.md
+++ b/images/kubernetes-event-exporter/README.md
@@ -17,7 +17,7 @@ Minimalist [wolfi](https://github.com/wolfi-dev)-based image of [Kubernetes Even
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubernetes-ingress-defaultbackend/README.md
+++ b/images/kubernetes-ingress-defaultbackend/README.md
@@ -17,7 +17,7 @@ Minimal image that acts as a drop-in replacement for the `registry.k8s.io/defaul
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kubewatch/README.md
+++ b/images/kubewatch/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kyverno-policy-reporter/README.md
+++ b/images/kyverno-policy-reporter/README.md
@@ -17,7 +17,7 @@ Monitoring and Observability Tool for the [PolicyReport CRD](https://kyverno.git
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/kyverno/README.md
+++ b/images/kyverno/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/logstash-oss-with-opensearch-output-plugin/README.md
+++ b/images/logstash-oss-with-opensearch-output-plugin/README.md
@@ -17,7 +17,7 @@ An image with the Logstash plugin that sends event data to a OpenSearch clusters
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/loki/README.md
+++ b/images/loki/README.md
@@ -17,7 +17,7 @@ This image contains the `loki` application for log aggregation. `loki` can be us
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/management-api-for-apache-cassandra/README.md
+++ b/images/management-api-for-apache-cassandra/README.md
@@ -17,7 +17,7 @@ RESTful / Secure Management Sidecar for Apache Cassandra
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/mariadb/README.md
+++ b/images/mariadb/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/maven/README.md
+++ b/images/maven/README.md
@@ -17,7 +17,7 @@ Minimal image with Maven build system.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/mdbook/README.md
+++ b/images/mdbook/README.md
@@ -17,7 +17,7 @@ Minimal image that contains [mdbook](https://rust-lang.github.io/mdBook/).
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/meilisearch/README.md
+++ b/images/meilisearch/README.md
@@ -17,7 +17,7 @@ Minimal meilisearch image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/melange/README.md
+++ b/images/melange/README.md
@@ -17,7 +17,7 @@ Container image for running [melange](https://github.com/chainguard-dev/melange)
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/memcached-exporter-bitnami/README.md
+++ b/images/memcached-exporter-bitnami/README.md
@@ -17,7 +17,7 @@ A memcached exporter for Prometheus that is compatible with Bitnami Helm charts.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/memcached-exporter/README.md
+++ b/images/memcached-exporter/README.md
@@ -17,7 +17,7 @@ A memcached exporter for Prometheus.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/memcached/README.md
+++ b/images/memcached/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/metacontroller/README.md
+++ b/images/metacontroller/README.md
@@ -17,7 +17,7 @@ Minimal Metacontroller Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/metrics-server/README.md
+++ b/images/metrics-server/README.md
@@ -17,7 +17,7 @@ Minimal metric-server container image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/minio/README.md
+++ b/images/minio/README.md
@@ -17,7 +17,7 @@ Minimal image with Minio. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ml-metadata-store-server/README.md
+++ b/images/ml-metadata-store-server/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/nats/README.md
+++ b/images/nats/README.md
@@ -17,7 +17,7 @@ Minimal image with NATS. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/netcat/README.md
+++ b/images/netcat/README.md
@@ -17,7 +17,7 @@ Minimal image for Debian port of OpenBSD's netcat. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/newrelic-fluent-bit-output/README.md
+++ b/images/newrelic-fluent-bit-output/README.md
@@ -17,7 +17,7 @@ Minimal [newrelic-fluent-bit-output](https://github.com/newrelic/newrelic-fluent
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/newrelic-infrastructure-bundle/README.md
+++ b/images/newrelic-infrastructure-bundle/README.md
@@ -17,7 +17,7 @@ Minimal [newrelic-infrastructure-bundle](https://github.com/newrelic/infrastruct
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/newrelic-k8s-events-forwarder/README.md
+++ b/images/newrelic-k8s-events-forwarder/README.md
@@ -17,7 +17,7 @@ Minimal [newrelic-k8s-events-forwarder](https://github.com/newrelic/nri-kubernet
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/newrelic-kube-events/README.md
+++ b/images/newrelic-kube-events/README.md
@@ -17,7 +17,7 @@ Minimal [newrelic-kube-events](https://github.com/newrelic/nri-kube-events) cont
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/newrelic-kubernetes/README.md
+++ b/images/newrelic-kubernetes/README.md
@@ -17,7 +17,7 @@ Minimal [newrelic-kubernetes](https://github.com/newrelic/nri-kubernetes) contai
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/newrelic-prometheus-configurator/README.md
+++ b/images/newrelic-prometheus-configurator/README.md
@@ -17,7 +17,7 @@ Minimal [newrelic-prometheus-configurator](https://github.com/newrelic/newrelic-
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/newrelic-prometheus/README.md
+++ b/images/newrelic-prometheus/README.md
@@ -17,7 +17,7 @@ Minimal [newrelic-prometheus](https://github.com/newrelic/nri-prometheus) contai
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/nfs-subdir-external-provisioner/README.md
+++ b/images/nfs-subdir-external-provisioner/README.md
@@ -17,7 +17,7 @@ Dynamic sub-dir volume provisioner on a remote NFS server.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -17,7 +17,7 @@ Minimal Wolfi-based nginx HTTP, reverse proxy, mail proxy, and a generic TCP/UDP
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/node-lts/README.md
+++ b/images/node-lts/README.md
@@ -17,7 +17,7 @@ Minimal Node.js open-source, cross-platform JavaScript runtime environment.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/node-problem-detector/README.md
+++ b/images/node-problem-detector/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -17,7 +17,7 @@ Minimal container image for running NodeJS apps
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/nodetaint/README.md
+++ b/images/nodetaint/README.md
@@ -17,7 +17,7 @@ Minimal [nodetaint](https://github.com/wish/nodetaint) container image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ntia-conformance-checker/README.md
+++ b/images/ntia-conformance-checker/README.md
@@ -17,7 +17,7 @@ Check SPDX SBOM for NTIA minimum elements
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ntpd-rs/README.md
+++ b/images/ntpd-rs/README.md
@@ -17,7 +17,7 @@ Minimal image with [ntpd-rs](https://github.com/pendulum-project/ntpd-rs). **EXP
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/nvidia-device-plugin/README.md
+++ b/images/nvidia-device-plugin/README.md
@@ -17,7 +17,7 @@ Minimal [nvidia-device-plugin](https://github.com/NVIDIA/k8s-device-plugin) cont
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/oauth2-proxy/README.md
+++ b/images/oauth2-proxy/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/openai/README.md
+++ b/images/openai/README.md
@@ -17,7 +17,7 @@ Minimal image with the OpenAI CLI.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/opensearch/README.md
+++ b/images/opensearch/README.md
@@ -17,7 +17,7 @@ Minimal image with Opensearch. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/opentelemetry-collector-contrib/README.md
+++ b/images/opentelemetry-collector-contrib/README.md
@@ -17,7 +17,7 @@ Minimal image with [opentelemetry-collector-contrib](https://github.com/open-tel
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/opentofu/README.md
+++ b/images/opentofu/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/paranoia/README.md
+++ b/images/paranoia/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based paranoia image for inspecting certificate authorities in 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/pgbouncer/README.md
+++ b/images/pgbouncer/README.md
@@ -17,7 +17,7 @@ This image contains the CLI for the [pgbouncer](https://www.pgbouncer.org/) conn
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/php-fpm_exporter/README.md
+++ b/images/php-fpm_exporter/README.md
@@ -17,7 +17,7 @@ Minimal php-fpm_exporter Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/php/README.md
+++ b/images/php/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based PHP images for building and running PHP applications. Inc
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/postgres-helm-compat/README.md
+++ b/images/postgres-helm-compat/README.md
@@ -17,7 +17,7 @@ PostgreSQL image compatible with helm charts.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/postgres/README.md
+++ b/images/postgres/README.md
@@ -17,7 +17,7 @@ Minimal PostgreSQL image. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/powershell/README.md
+++ b/images/powershell/README.md
@@ -17,7 +17,7 @@ Minimal Wolfi image with Powershell
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-adapter/README.md
+++ b/images/prometheus-adapter/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-alertmanager/README.md
+++ b/images/prometheus-alertmanager/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based image for Prometheus Alertmanager. Handles alerts sent by
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-cloudwatch-exporter/README.md
+++ b/images/prometheus-cloudwatch-exporter/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Prometheus CloudWatch Exporter image for exporting metric
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-config-reloader/README.md
+++ b/images/prometheus-config-reloader/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based image for Prometheus Config Reloader. It helps with confi
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-elasticsearch-exporter/README.md
+++ b/images/prometheus-elasticsearch-exporter/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Prometheus Elasticsearch Exporter image for exporting var
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-logstash-exporter/README.md
+++ b/images/prometheus-logstash-exporter/README.md
@@ -17,7 +17,7 @@ Prometheus exporter for Logstash written in Go
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-mongodb-exporter/README.md
+++ b/images/prometheus-mongodb-exporter/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Prometheus MongoDB Exporter image for exporting various m
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-node-exporter/README.md
+++ b/images/prometheus-node-exporter/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Prometheus Node Exporter image for exporting node metrics
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-operator/README.md
+++ b/images/prometheus-operator/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based image for Prometheus Operator. Prometheus Operator create
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-postgres-exporter/README.md
+++ b/images/prometheus-postgres-exporter/README.md
@@ -17,7 +17,7 @@ A PostgreSQL metric exporter for Prometheus
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-pushgateway-bitnami/README.md
+++ b/images/prometheus-pushgateway-bitnami/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based [prometheus-pushgateway-bitnami](https://github.com/prome
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-redis-exporter/README.md
+++ b/images/prometheus-redis-exporter/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Prometheus Redis Exporter image for exporting metrics to 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus-statsd-exporter/README.md
+++ b/images/prometheus-statsd-exporter/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based Prometheus StatsD Exporter image for exporting metrics to
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/prometheus/README.md
+++ b/images/prometheus/README.md
@@ -17,7 +17,7 @@ Minimal Prometheus Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/promtail/README.md
+++ b/images/promtail/README.md
@@ -17,7 +17,7 @@ This image contains the `promtail` application for log aggregation. `promtail` i
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/proxysql/README.md
+++ b/images/proxysql/README.md
@@ -17,7 +17,7 @@ Minimal image with [proxysql](https://github.com/sysown/proxysql).
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/pulumi/README.md
+++ b/images/pulumi/README.md
@@ -17,7 +17,7 @@ Minimal Pulumi Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/python/README.md
+++ b/images/python/README.md
@@ -17,7 +17,7 @@ Minimal Python image based on Wolfi.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/qdrant/README.md
+++ b/images/qdrant/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/r-base/README.md
+++ b/images/r-base/README.md
@@ -17,7 +17,7 @@ This image contains the R programming language and environment.It can be used fo
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/rabbitmq-cluster-operator/README.md
+++ b/images/rabbitmq-cluster-operator/README.md
@@ -17,7 +17,7 @@ RabbitMQ Cluster Kubernetes Operator
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/rabbitmq-messaging-topology-operator/README.md
+++ b/images/rabbitmq-messaging-topology-operator/README.md
@@ -17,7 +17,7 @@ RabbitMQ messaging topology operator
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/rabbitmq/README.md
+++ b/images/rabbitmq/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/redis-bitnami/README.md
+++ b/images/redis-bitnami/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based [Redis-Bitnami](https://github.com/redis/redis) image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/redis-sentinel/README.md
+++ b/images/redis-sentinel/README.md
@@ -17,7 +17,7 @@ Minimal [redis-sentinel](https://redis.io/docs/management/sentinel/) Image which
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/redis/README.md
+++ b/images/redis/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based [Redis](https://github.com/redis/redis) image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/rekor/README.md
+++ b/images/rekor/README.md
@@ -17,7 +17,7 @@ Rekor is one of the core components of the sigstore stack.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/rqlite/README.md
+++ b/images/rqlite/README.md
@@ -17,7 +17,7 @@ Minimal image with rqlite. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/ruby/README.md
+++ b/images/ruby/README.md
@@ -17,7 +17,7 @@ Minimal Ruby base image.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/rust/README.md
+++ b/images/rust/README.md
@@ -17,7 +17,7 @@ Minimal Wolfi-based Rust image for building Rust applications. **EXPERIMENTAL**.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/secrets-store-csi-driver-provider-gcp/README.md
+++ b/images/secrets-store-csi-driver-provider-gcp/README.md
@@ -17,7 +17,7 @@ Minimal image with the Kubernetes Secrets Store CSI Driver GCP Plugin. **EXPERIM
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/secrets-store-csi-driver/README.md
+++ b/images/secrets-store-csi-driver/README.md
@@ -17,7 +17,7 @@ Minimal image with Kubernetes Secrets Store CSI Driver. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/semgrep/README.md
+++ b/images/semgrep/README.md
@@ -17,7 +17,7 @@ CLI for the [Semgrep](https://semgrep.dev) static analysis tool. Semgrep is a li
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/sigstore-policy-controller/README.md
+++ b/images/sigstore-policy-controller/README.md
@@ -17,7 +17,7 @@ Policy Controller image that is part of the Sigstore stack
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/sigstore-scaffolding/README.md
+++ b/images/sigstore-scaffolding/README.md
@@ -17,7 +17,7 @@ Minimal Wolfi-based [Sigstore](https://sigstore.dev) images.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/skaffold/README.md
+++ b/images/skaffold/README.md
@@ -17,7 +17,7 @@ Minimal container image for running skaffold apps
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/slim-toolkit-debug/README.md
+++ b/images/slim-toolkit-debug/README.md
@@ -17,7 +17,7 @@ Wolfi container image with some debugging utilies included. Suitable for using a
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/smarter-device-manager/README.md
+++ b/images/smarter-device-manager/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based image for smarter device manager.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/solr/README.md
+++ b/images/solr/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/spark-operator/README.md
+++ b/images/spark-operator/README.md
@@ -17,7 +17,7 @@ A minimal, Wolfi-based image for Spark Operator. Facilitates the deployment and 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/spire/README.md
+++ b/images/spire/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based `spire` images.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/sqlpad/README.md
+++ b/images/sqlpad/README.md
@@ -17,7 +17,7 @@ A minimal Wolfi-based image for sqlpad, which is a web application for generatin
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/stakater-reloader/README.md
+++ b/images/stakater-reloader/README.md
@@ -17,7 +17,7 @@ Minimal image with Keda, a Kubernetes-based Event Driven Autoscaler. **EXPERIMEN
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/static/README.md
+++ b/images/static/README.md
@@ -17,7 +17,7 @@ Base images with the minimum contents needed to run static binaries.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/statsd/README.md
+++ b/images/statsd/README.md
@@ -17,7 +17,7 @@ Daemon for easy but powerful stats aggregation
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/stunnel/README.md
+++ b/images/stunnel/README.md
@@ -17,7 +17,7 @@ This image contains the CLI for the [stunnel](https://www.stunnel.org/) networki
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/tekton/README.md
+++ b/images/tekton/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/telegraf/README.md
+++ b/images/telegraf/README.md
@@ -17,7 +17,7 @@ Minimal image with Telegraf agent for collecting, processing, aggregating, and w
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/temporal-admin-tools/README.md
+++ b/images/temporal-admin-tools/README.md
@@ -17,7 +17,7 @@ Golang Server for [https://github.com/temporalio/ui](https://github.com/temporal
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/temporal-server/README.md
+++ b/images/temporal-server/README.md
@@ -17,7 +17,7 @@ Minimal image for [Temporal](https://docs.temporal.io/), a durable execution pla
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/temporal-ui-server/README.md
+++ b/images/temporal-ui-server/README.md
@@ -17,7 +17,7 @@ Golang Server for https://github.com/temporalio/ui
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/terraform/README.md
+++ b/images/terraform/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/thanos-operator/README.md
+++ b/images/thanos-operator/README.md
@@ -17,7 +17,7 @@ Minimal image with the [thanos-operator](https://github.com/banzaicloud/thanos-o
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/thanos/README.md
+++ b/images/thanos/README.md
@@ -17,7 +17,7 @@ Minimal Thanos Image, a highly available Prometheus setup with long term storage
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/tigera-operator/README.md
+++ b/images/tigera-operator/README.md
@@ -17,7 +17,7 @@ Minimal Project Calico Tigera Operator Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/timestamp-authority/README.md
+++ b/images/timestamp-authority/README.md
@@ -17,7 +17,7 @@ timestamp-authority is an RFC3161 Timestamp Authority, a core component of the s
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/timoni/README.md
+++ b/images/timoni/README.md
@@ -17,7 +17,7 @@ Minimal image with `timoni` binary. `timoni` is a package manager for Kubernetes
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/tomcat/README.md
+++ b/images/tomcat/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/traefik/README.md
+++ b/images/traefik/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/trillian/README.md
+++ b/images/trillian/README.md
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/trino/README.md
+++ b/images/trino/README.md
@@ -17,7 +17,7 @@ Fast distributed SQL query engine for big data analytics that helps you explore 
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/trust-manager/README.md
+++ b/images/trust-manager/README.md
@@ -17,7 +17,7 @@ Minimalist Wolfi-based trust-manager operator for distributing trust bundles acr
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/vault/README.md
+++ b/images/vault/README.md
@@ -17,7 +17,7 @@ Vault Server Image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/vector/README.md
+++ b/images/vector/README.md
@@ -17,7 +17,7 @@ Minimal image with [Vector](https://vector.dev/), a high-performance, end-to-end
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/vela-cli/README.md
+++ b/images/vela-cli/README.md
@@ -17,7 +17,7 @@ Vela is a Pipeline Automation (CI/CD) framework built on Linux container technol
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/vertical-pod-autoscaler/README.md
+++ b/images/vertical-pod-autoscaler/README.md
@@ -17,7 +17,7 @@ Image to automatically adjust the amount of CPU and memory requested by pods run
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/vt/README.md
+++ b/images/vt/README.md
@@ -17,7 +17,7 @@ Minimal image with the Virus Total CLI - `vt-cli`.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/wait-for-it/README.md
+++ b/images/wait-for-it/README.md
@@ -17,7 +17,7 @@ Container image for testing whether a service is listening on an address/port co
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/wasmer/README.md
+++ b/images/wasmer/README.md
@@ -17,7 +17,7 @@ This image contains the `wasmer` tool which can be used to compile or run wasm b
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/wasmtime/README.md
+++ b/images/wasmtime/README.md
@@ -17,7 +17,7 @@ This image contains the `wasmtime` tool which can be used to compile or run wasm
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/wavefront-proxy/README.md
+++ b/images/wavefront-proxy/README.md
@@ -17,7 +17,7 @@ Minimal wavefront-proxy image
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/wazero/README.md
+++ b/images/wazero/README.md
@@ -17,7 +17,7 @@ This image contains the `wazero` tool which can be used to compile or run wasm b
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/weaviate/README.md
+++ b/images/weaviate/README.md
@@ -17,7 +17,7 @@ Minimal container image for running the weaviate vector database.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/wolfi-base/README.md
+++ b/images/wolfi-base/README.md
@@ -17,7 +17,7 @@ Base image for the [Wolfi Linux Distribution](https://wolfi.dev).
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/zig/README.md
+++ b/images/zig/README.md
@@ -17,7 +17,7 @@ Minimal image with zig binary.
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/zookeeper/README.md
+++ b/images/zookeeper/README.md
@@ -17,7 +17,7 @@ Minimal image with Apache Zookeeper. **EXPERIMENTAL**
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/images/zot/README.md
+++ b/images/zot/README.md
@@ -17,7 +17,7 @@ Minimal image with [zot](https://github.com/project-zot/zot) binary. **EXPERIMEN
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```

--- a/monopod/pkg/commands/templates/README.md.tpl
+++ b/monopod/pkg/commands/templates/README.md.tpl
@@ -17,7 +17,7 @@
 <!--overview:end-->
 
 <!--getting:start-->
-## Get It!
+## Download this Image
 The image is available on `cgr.dev`:
 
 ```


### PR DESCRIPTION
This PR updates the `Get it!` language in our READMEs to a more formal/descriptive `Download this Image`. This PR updates each Image individually and also changes the monpod template (at /images/monopod/pkg/commands/templates/README.md.tpl) so this changes will be preserved in the future. 

cc @julienv3 

This PR resolves [#3546](https://github.com/chainguard-dev/internal/issues/3546)