### PR TITLE
Fix test for kubeflow

### DIFF
--- a/images/kubeflow/tests/main.tf
+++ b/images/kubeflow/tests/main.tf
@@ -45,7 +45,7 @@ resource "imagetest_feature" "basic" {
     {
       name  = "Wait for Kubeflow to be ready",
       cmd   = "kubectl wait --for=condition=Ready --timeout=300s -n kubeflow --all pods"
-      retry = { attempts = 4, delay = "1s", factor = 2 }
+      retry = { attempts = 4, delay = "5s", factor = 2 }
     },
   ]
 


### PR DESCRIPTION
The delay seems a bit too short. When running: `kubectl wait --for=condition=Ready --timeout=300s -n kubeflow --all pods`, there's a risk the command will fail right away with `error: no matching resources found`. I think increasing the delay of the retry helps here