### PR TITLE
Create Clickhouse Image

### DIFF
--- a/images/clickhouse/README.md
+++ b/images/clickhouse/README.md
@@ -1,0 +1,99 @@
+<!--monopod:start-->
+# clickhouse
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/clickhouse` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/clickhouse/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+[Clickhouse](https://clickhouse.com) is the fastest and most resource efficient open-source database for real-time apps and analytics.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/clickhouse:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Using Clickhouse
+
+The default Clickhouse listen_host is `127.0.0.1` and port is `8123`.
+
+### start server instance
+
+To run with Docker and allow empty passwords:
+
+```
+docker run -d --ulimit nofile=262144:262144 cgr.dev/chainguard/clickhouse:latest
+```
+
+By default, ClickHouse will be accessible only via the Docker network. See the networking section below.
+
+By default, starting above server instance will be run as the default user without password.
+
+## Users and Directories
+
+By default, this image runs as a non-root user named `clickhouse` with a uid of `101` and a home directory of `/home/clickhouse`.
+
+### Volumes
+
+Typically you may want to mount the following folders inside your container to achieve persistency:
+
+* /var/lib/clickhouse/ - main folder where ClickHouse stores the data
+* /var/log/clickhouse-server/ - logs
+
+```
+docker run -d \
+    -v $(realpath ./ch_data):/var/lib/clickhouse/ \
+    -v $(realpath ./ch_logs):/var/log/clickhouse-server/ \
+    --ulimit nofile=262144:262144 cgr.dev/chainguard/clickhouse:latest
+```
+
+You may also want to mount:
+
+* /etc/clickhouse-server/config.d/*.xml - files with server configuration adjustmenets
+* /etc/clickhouse-server/users.d/*.xml - files with user settings adjustmenets
+* /docker-entrypoint-initdb.d/ - folder with database initialization scripts (see below).
+
+
+## Docker Compose Example
+
+This `docker-compose.yaml` sets up a Clickhouse database with a default database and user.
+
+```yaml
+version: "3.7"
+services:
+  clickhouse:
+    image: ttl.sh/steve/clickhouse@sha256:8717f81f80aa851d53dcf3355e1eb728e84932dd59d42333e6b42b0b9f354fc3
+    restart: unless-stopped
+    entrypoint: /usr/bin/clickhouse-server -- --listen_host 0.0.0.0
+    working_dir: /home/clickhouse
+    ports:
+      - 8123:8123
+    volumes:
+      - ./data/clickhouse:/var/lib/clickhouse
+      - ./logs/clickhouse:/var/log/clickhouse-server
+    networks:
+      - wolfi
+
+networks:
+  wolfi:
+    driver: bridge
+```
+
+## Advanced Configuration
+
+Please refer to [Clickhouse's documentation](https://clickhouse.com/docs/en/operations/configuration-files#configuration_files) for more advanced configuration.
+
+<!--body:end-->

--- a/images/clickhouse/config/latest.apko.yaml
+++ b/images/clickhouse/config/latest.apko.yaml
@@ -1,0 +1,58 @@
+contents:
+  packages:
+    # clickhouse comes in via var.extra_packages.
+    - clickhouse-compat
+
+accounts:
+  groups:
+    - groupname: clickhouse
+      gid: 101
+    - groupname: clickhouse-bridge
+      gid: 999
+  users:
+    - username: clickhouse
+      uid: 101
+      gid: 101
+    - username: clickhouse-bridge
+      uid: 999
+      gid: 999
+  run-as: 101
+
+entrypoint:
+  command: /usr/bin/clickhouse
+
+work-dir: /home/clickhouse
+
+cmd: "help"
+
+environment:
+  CLICKHOUSE_CONFIG: /etc/clickhouse-server/config.xml
+  CLICKHOUSE_DB: default
+  CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+  CLICKHOUSE_LOG: /var/log/clickhouse-server/clickhouse-server.log
+  CLICKHOUSE_USER: default
+  CLICKHOUSE_PASSWORD: ""
+  CLICKHOUSE_UID: 101
+  CLICKHOUSE_GID: 101
+
+paths:
+  - path: /var/lib/clickhouse
+    type: directory
+    permissions: 0o755
+    uid: 101
+    gid: 101
+  - path: /var/log/clickhouse-server
+    type: directory
+    permissions: 0o755
+    uid: 101
+    gid: 101
+  - path: /home/clickhouse
+    type: directory
+    permissions: 0o755
+    uid: 101
+    gid: 101
+  - path: /docker-entrypoint-initdb.d
+    type: directory
+    permissions: 0o755
+    uid: 101
+    gid: 101

--- a/images/clickhouse/config/main.tf
+++ b/images/clickhouse/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install "
+  default     = ["clickhouse"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/latest.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/clickhouse/main.tf
+++ b/images/clickhouse/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "latest" {
+  source = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/clickhouse/metadata.yaml
+++ b/images/clickhouse/metadata.yaml
@@ -1,0 +1,13 @@
+name: clickhouse
+image: cgr.dev/chainguard/clickhouse
+logo: https://clickhouse.com/images/media/ch_logo_mx_md_vert.svg
+endoflife: ""
+console_summary: ""
+short_description: '[Clickhouse](https://clickhouse.com) is the fastest and most resource efficient open-source database for real-time apps and analytics.'
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://clickhouse.com
+keywords:
+  - application
+  - databases
+  - featured

--- a/images/clickhouse/tests/02-runs.sh
+++ b/images/clickhouse/tests/02-runs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Start up the clickhouse server container in the background
+name=clickhouse-${RANDOM}
+docker run --rm -d --name $name -u101:101 -p8123:8123/tcp "${IMAGE_NAME}" server -- --listen_host 0.0.0.0
+
+sleep 5
+
+# Run curl container and run command to check version, greps for 200 OK status code from curl
+echo 'SELECT version()' | docker run -i --rm --link $name cgr.dev/chainguard/curl "http://${name}:8123/?query=" -s -w '%{http_code}' --data-binary @- | grep 200
+
+docker kill $name

--- a/images/clickhouse/tests/main.tf
+++ b/images/clickhouse/tests/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME --version"
+}
+
+data "oci_exec_test" "runs" {
+  digest = var.digest
+  script = "${path.module}/02-runs.sh"
+}

--- a/main.tf
+++ b/main.tf
@@ -247,6 +247,11 @@ module "clang" {
   target_repository = "${var.target_repository}/clang"
 }
 
+module "clickhouse" {
+  source            = "./images/clickhouse/"
+  target_repository = "${var.target_repository}/clickhouse"
+}
+
 module "cluster-autoscaler" {
   source            = "./images/cluster-autoscaler"
   target_repository = "${var.target_repository}/cluster-autoscaler"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

```
$ docker images
REPOSITORY                     TAG       IMAGE ID       CREATED       SIZE
ttl.sh/steve/clickhouse        <none>    5b54ae7f4a63   2 days ago    904MB
clickhouse/clickhouse-server   latest    1d846b541abd   4 days ago    938MB
```

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

```
$ grype clickhouse/clickhouse-server:latest
 ✔ Vulnerability DB                [no update available]
 ✔ Parsed image                                                                                                                                                                       sha256:1d846b541abd6acaf1230d2d0a42e8f6ebe1c479bd73fcafa8a4e312365c1dd9
 ✔ Cataloged contents                                                                                                                                                                        9b9a5710180dcd610f9f9344603b9bbcf2ee846c985980c278c98b20264c5063
   ├── ✔ Packages                        [153 packages]
   ├── ✔ File digests                    [4,123 files]
   ├── ✔ File metadata                   [4,123 locations]
   └── ✔ Executables                     [737 executables]
 ✔ Scanned for vulnerabilities     [32 vulnerability matches]
   ├── by severity: 0 critical, 4 high, 7 medium, 17 low, 4 negligible
   └── by status:   2 fixed, 30 not-fixed, 0 ignored
NAME          INSTALLED                 FIXED-IN                  TYPE       VULNERABILITY   SEVERITY
coreutils     8.30-3ubuntu2                                       deb        CVE-2016-2781   Low
gpgv          2.2.19-3ubuntu2.2                                   deb        CVE-2022-3219   Low
libc-bin      2.31-0ubuntu9.14                                    deb        CVE-2016-20013  Negligible
libc6         2.31-0ubuntu9.14                                    deb        CVE-2016-20013  Negligible
liblzma5      5.2.4-1ubuntu1.1                                    deb        CVE-2020-22916  Medium
libncurses6   6.2-0ubuntu2.1                                      deb        CVE-2023-50495  Low
libncursesw6  6.2-0ubuntu2.1                                      deb        CVE-2023-50495  Low
libpcre3      2:8.39-12ubuntu0.1                                  deb        CVE-2017-11164  Negligible
libsystemd0   245.4-4ubuntu3.23                                   deb        CVE-2023-7008   Low
libsystemd0   245.4-4ubuntu3.23                                   deb        CVE-2023-26604  Low
libtinfo6     6.2-0ubuntu2.1                                      deb        CVE-2023-50495  Low
libudev1      245.4-4ubuntu3.23                                   deb        CVE-2023-7008   Low
libudev1      245.4-4ubuntu3.23                                   deb        CVE-2023-26604  Low
locales       2.31-0ubuntu9.14                                    deb        CVE-2016-20013  Negligible
login         1:4.8.1-1ubuntu5.20.04.4  1:4.8.1-1ubuntu5.20.04.5  deb        CVE-2023-4641   Low
login         1:4.8.1-1ubuntu5.20.04.4                            deb        CVE-2023-29383  Low
login         1:4.8.1-1ubuntu5.20.04.4                            deb        CVE-2013-4235   Low
ncurses-base  6.2-0ubuntu2.1                                      deb        CVE-2023-50495  Low
ncurses-bin   6.2-0ubuntu2.1                                      deb        CVE-2023-50495  Low
passwd        1:4.8.1-1ubuntu5.20.04.4  1:4.8.1-1ubuntu5.20.04.5  deb        CVE-2023-4641   Low
passwd        1:4.8.1-1ubuntu5.20.04.4                            deb        CVE-2023-29383  Low
passwd        1:4.8.1-1ubuntu5.20.04.4                            deb        CVE-2013-4235   Low
stdlib        go1.19.10                                           go-module  CVE-2023-45287  High
stdlib        go1.19.10                                           go-module  CVE-2023-45285  High
stdlib        go1.19.10                                           go-module  CVE-2023-44487  High
stdlib        go1.19.10                                           go-module  CVE-2023-39323  High
stdlib        go1.19.10                                           go-module  CVE-2023-39326  Medium
stdlib        go1.19.10                                           go-module  CVE-2023-39319  Medium
stdlib        go1.19.10                                           go-module  CVE-2023-39318  Medium
stdlib        go1.19.10                                           go-module  CVE-2023-29409  Medium
stdlib        go1.19.10                                           go-module  CVE-2023-29406  Medium
wget          1.20.3-1ubuntu2                                     deb        CVE-2021-31879  Medium

$ grype ttl.sh/steve/clickhouse:latest-dev@sha256:09c57c70cea58b43b0daa73367c035d59ffb1b7f8ceb85996c34852d43300c1c
 ✔ Vulnerability DB                [no update available]
 ✔ Parsed image                                                                                                                                                                       sha256:5b54ae7f4a63820ae4e8392e0fce6168a49b87b17dc3dd6d309ebccc90cde16f
 ✔ Cataloged contents                                                                                                                                                                        cb7e6485bd3ff69ba96b591b963371f19297f2f8b69c8bab1d5bcdc1e68bfaf6
   ├── ✔ Packages                        [27 packages]
   ├── ✔ File digests                    [592 files]
   ├── ✔ File metadata                   [592 locations]
   └── ✔ Executables                     [95 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: clickhouse
  labels:
    app: clickhouse
spec:
  containers:
  - name: clickhouse
    image: ttl.sh/steve/clickhouse:latest-dev@sha256:09c57c70cea58b43b0daa73367c035d59ffb1b7f8ceb85996c34852d43300c1c
    ports:
    - containerPort: 8123
    command: ["/usr/bin/clickhouse"]
    args: ["server", "--", "--listen_host", "0.0.0.0"]
    workingDir: /home/clickhouse
```

```
$ pbpaste | kubectl apply -f -
pod/clickhouse created

$ k get pod
NAME         READY   STATUS    RESTARTS   AGE
clickhouse   1/1     Running   0          39s
```

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

```
$ k expose pod/clickhouse
service/clickhouse exposed

$ kgs
NAME         TYPE        CLUSTER-IP        EXTERNAL-IP   PORT(S)    AGE
kubernetes   ClusterIP   192.168.194.129   <none>        443/TCP    19d
clickhouse   ClusterIP   192.168.194.221   <none>        8123/TCP   2s

$ echo 'SELECT version()' | curl -s --data-binary @- http://192.168.194.221:8123
24.1.5.1
```

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

I tried to test this but I wasn't able to get it running with the bitnami helm chart due to permission errors in the cwd un lack of ability to specify it.

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

As best I could, I based the image on the [upstream documentation here](https://github.com/ClickHouse/ClickHouse/blob/master/docker/server/README.md).

I wrote a test that will curl the clickhouse image to get the version from the server if it is running properly. It checks for a 200 response from curl.

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [x] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

I didn't have an easy way to test it this way.

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [x] The package version is the not the latest version of the package (please explain in the notes).

Notes:

This is only the latest version that's available in Wolfi. We can bump that version.

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

Notes:

Run as `clickhouse`, uid `101`, gid `101`, same as upstream.

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [x] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
