### PR TITLE
Update haproxy image test to use haproxy helm chart

### DIFF
--- a/images/haproxy/tests/main.tf
+++ b/images/haproxy/tests/main.tf
@@ -14,32 +14,27 @@ data "oci_string" "ref" {
 
 resource "random_pet" "suffix" {}
 
-resource "helm_release" "redis-ha" {
-  name             = "haproxy-redis-${random_pet.suffix.id}"
-  namespace        = "haproxy-system-${random_pet.suffix.id}"
-  repository       = "https://dandydeveloper.github.io/charts"
-  chart            = "redis-ha"
+resource "helm_release" "haproxy" {
+  name             = "haproxy-${random_pet.suffix.id}"
+  namespace        = "haproxy-${random_pet.suffix.id}"
+  repository       = "https://haproxytech.github.io/helm-charts"
+  chart            = "haproxy"
   create_namespace = true
   timeout          = 300
 
   values = [
     jsonencode({
       image = {
-        registry = "cgr.dev/chainguard/redis"
-        tag      = "latest"
-      }
-      hardAntiAffinity = false
-      haproxy = {
-        enabled          = true
-        hardAntiAffinity = false
-        image = {
-          repository = data.oci_string.ref.registry_repo
-          tag        = data.oci_string.ref.pseudo_tag
-        }
-        containerSecurityContext = {
-          capabilities = { add = ["NET_BIND_SERVICE"] }
-        }
+        repository = data.oci_string.ref.registry_repo
+        tag      = data.oci_string.ref.pseudo_tag
       }
     })
   ]
+}
+
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.haproxy.id
+  namespace = helm_release.haproxy.namespace
 }

--- a/images/haproxy/tests/main.tf
+++ b/images/haproxy/tests/main.tf
@@ -14,6 +14,7 @@ data "oci_string" "ref" {
 
 resource "random_pet" "suffix" {}
 
+
 resource "helm_release" "haproxy" {
   name             = "haproxy-${random_pet.suffix.id}"
   namespace        = "haproxy-${random_pet.suffix.id}"
@@ -26,15 +27,50 @@ resource "helm_release" "haproxy" {
     jsonencode({
       image = {
         repository = data.oci_string.ref.registry_repo
-        tag      = data.oci_string.ref.pseudo_tag
+        tag        = data.oci_string.ref.pseudo_tag
       }
     })
   ]
 }
 
-
-module "helm_cleanup" {
+module "helm_cleanup_haproxy" {
   source    = "../../../tflib/helm-cleanup"
   name      = helm_release.haproxy.id
   namespace = helm_release.haproxy.namespace
+}
+
+resource "helm_release" "redis-ha" {
+  name             = "haproxy-redis-${random_pet.suffix.id}"
+  namespace        = "haproxy-system-${random_pet.suffix.id}"
+  repository       = "https://dandydeveloper.github.io/charts"
+  chart            = "redis-ha"
+  create_namespace = true
+  timeout          = 300
+
+  values = [
+    jsonencode({
+      image = {
+        registry = "cgr.dev/chainguard/redis"
+        tag      = "latest"
+      }
+      hardAntiAffinity = false
+      haproxy = {
+        enabled          = true
+        hardAntiAffinity = false
+        image = {
+          repository = data.oci_string.ref.registry_repo
+          tag        = data.oci_string.ref.pseudo_tag
+        }
+        containerSecurityContext = {
+          capabilities = { add = ["NET_BIND_SERVICE"] }
+        }
+      }
+    })
+  ]
+}
+
+module "helm_cleanup_redis_ha" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.redis-ha.id
+  namespace = helm_release.redis-ha.namespace
 }


### PR DESCRIPTION
### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [x] The image is _not_ tagged with version tags.
- [ ] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
