### PR TITLE
Update mode for ingress-nginx geoip directory

### DIFF
--- a/images/ingress-nginx-controller/config/latest.apko.yaml
+++ b/images/ingress-nginx-controller/config/latest.apko.yaml
@@ -28,6 +28,12 @@ paths:
     permissions: 0o755
     uid: 101
     gid: 101
+  - path: /etc/ingress-controller/geoip
+    type: directory
+    permissions: 0o755
+    uid: 101
+    gid: 101
+    recursive: true
   - path: /etc/ingress-controller/ssl
     type: directory
     permissions: 0o755


### PR DESCRIPTION
This is a directory to container the GeoIP2 database which needs to be writable. This directory was updated in 1.9.5 (similar to https://github.com/chainguard-images/images/pull/1986).

See also https://github.com/kubernetes/ingress-nginx/pull/10470

Will follow up with an e2e test for GeoIP2 features to prevent future regression.