### PR TITLE
chore: Move pytorch to images

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,16 +2,15 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/chainguard-dev/apko" {
-  version     = "0.14.0"
-  constraints = "0.14.0"
+  version     = "0.15.2"
+  constraints = "0.15.2"
   hashes = [
-    "h1:0tXyqnKrrQ07krTbutG/q63iXPZEatyjCT8RZrkp5OI=",
-    "h1:y149YAHs7JDKK1bAL6/ddNxb07JAOaJWZKGMNp+beA8=",
-    "zh:1771ec64219b8b39af02a4740d0870628cd7704d07b71622931767506ce7081a",
-    "zh:21afab7e9d840754c43609019b92d195a7c5ef2a17b5f666ed7bf76ab54870b0",
-    "zh:720c9b0bc9ab9463326c5feeb1ea5f5243c091563806af99b84fe4f91e066634",
+    "h1:ZAxVcQUI8ZRDiYDd599YQPAyPhb/9Mj28EUjsmEL0oc=",
+    "zh:29d2d68a8c49c216e3f29070bdb2bc259420b6b4074f3c9300540b2add567573",
+    "zh:35b3c7cc68a2a91572c1974660cf5dbf6a1acf907f1468650e256e6c18f193b5",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:8baf671447623f3450879bd84872a75ea969180ee6502d986a1848ebcb14aa12",
+    "zh:a23063b1111045c1ffee258683433777c069d6e8c63dffb1e882818445ad859f",
+    "zh:ec0145598f7bf9c235faea0ffda227bb86432745f20902bbe0f8ed4ce0700c75",
   ]
 }
 

--- a/images/pytorch/README.md
+++ b/images/pytorch/README.md
@@ -1,0 +1,45 @@
+<!--monopod:start-->
+# pytorch
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/pytorch` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/pytorch/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+A minimal, [wolfi](https://github.com/wolfi-dev)-based image for pytorch, a Python package that provides two high-level features: Tensor computation (like NumPy) with strong GPU acceleration and Deep neural networks built on a tape-based autograd system.
+
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/pytorch:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+
+## Running pytorch
+
+Please refer TESTING.md for instructions on how to configure and test pytorch. 
+The below examples are intended as demonstrating how to substitute with the chainguard image, and
+are not comprehensive.
+
+### Docker
+
+```bash
+docker run --rm -i -t \
+    --privileged \
+    --gpus all \
+    cgr.dev/chainguard/pytorch:latest
+```
+<!--body:end-->

--- a/images/pytorch/TESTING.md
+++ b/images/pytorch/TESTING.md
@@ -1,0 +1,77 @@
+Since testing this image requires GPU's, CUDA toolkit and NVidia drivers, this document gives an high level overview of the setup needed to run/test this image. Google Cloud has been used for all our testing setup.
+
+# Installation
+1. Create a VM with GPUs
+
+    
+    ```gcloud compute instances create pytorch-testing \
+    --zone=us-central1-a \
+    --machine-type=n1-standard-4 \
+    --accelerator="type=nvidia-tesla-t4,count=2" \
+    --boot-disk-size=200GB \
+    --boot-disk-type=pd-standard \
+    --image-family=ubuntu-2204-lts \
+    --image-project=ubuntu-os-cloud \
+    --maintenance-policy=TERMINATE \
+    --restart-on-failure```
+    
+
+Verify that NVIDIA card is detected
+    ```lspci -vv | grep -i nvidia```
+    
+    a. Setup docker for future usage
+        https://docs.docker.com/engine/install/ubuntu/
+
+
+2. Installing NVIDIA driver and toolkit
+Install the new cuda-keyring package:
+
+    ```
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+    sudo dpkg -i cuda-keyring_1.1-1_all.deb
+    ```
+
+    Enroll the new signing key manually:
+
+    ```wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-archive-keyring.gpg
+    sudo mv cuda-archive-keyring.gpg /usr/share/keyrings/cuda-archive-keyring.gpg
+    ```
+
+    ```sudo apt-get update
+       sudo apt-get install cuda-12-3
+    ```
+    
+
+        Not needed, should be covered by the cuda-12-3 installation
+        ```
+        sudo apt-get install cuda-toolkit
+        sudo apt-get install nvidia-gds
+        ```
+
+    Reboot the system before proceeding 
+
+    ```sudo reboot```
+
+    Update PATH
+    
+    ```export PATH=/usr/local/cuda/bin:$PATH``` 
+
+3. Run Image
+
+    ```sudo docker run --gpus all -it --rm cgr.dev/chainguard/pytorch:latest```
+
+4. Test scripts to run
+    ```
+    $ python
+    >>> import torch
+    >>> print(torch.cuda.is_available())
+    True
+    ```
+
+Reference:
+https://collabnix.com/introducing-new-docker-cli-api-support-for-nvidia-gpus-under-docker-engine-19-03-0-beta-release/
+
+https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#ubuntu
+
+
+

--- a/images/pytorch/config/main.tf
+++ b/images/pytorch/config/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = ["pytorch-cuda12"]
+}
+
+variable "environment" {
+  default = {}
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    environment = merge({
+      "PATH" : "/usr/share/pytorch/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    }, var.environment)
+    entrypoint = {
+      command = ""
+    }
+    archs = ["x86_64"]
+  })
+}

--- a/images/pytorch/config/main.tf
+++ b/images/pytorch/config/main.tf
@@ -10,6 +10,16 @@ variable "extra_packages" {
   default     = ["pytorch-cuda12"]
 }
 
+variable "extra_repositories" {
+  description = "The additional repositores to install from (e.g. extras)."
+  default     = ["https://packages.cgr.dev/extras"]
+}
+
+variable "extra_keyring" {
+  description = "The additional keys to use (e.g. extras)."
+  default     = ["https://packages.cgr.dev/extras/chainguard-extras.rsa.pub"]
+}
+
 variable "environment" {
   default = {}
 }
@@ -21,7 +31,9 @@ module "accts" {
 output "config" {
   value = jsonencode({
     contents = {
-      packages = var.extra_packages
+      packages     = var.extra_packages
+      repositories = var.extra_repositories
+      keyring      = var.extra_keyring
     }
     accounts = module.accts.block
     environment = merge({

--- a/images/pytorch/main.tf
+++ b/images/pytorch/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+locals {
+  versions = [
+    "pytorch-cuda12",
+  ]
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+
+module "config" {
+  for_each       = toset(local.versions)
+  source         = "./config"
+  extra_packages = [each.key, "busybox", "bash"]
+}
+
+module "versioned" {
+  for_each = toset(local.versions)
+  source   = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config[each.key].config
+  build-dev         = true
+  main_package      = each.key
+}
+
+module "test" {
+  for_each = toset(local.versions)
+  source   = "./tests"
+  digest   = module.versioned[each.key].image_ref
+}
+
+module "tagger" {
+  source     = "../../tflib/tagger"
+  depends_on = [module.test]
+  tags       = merge([for v in local.versions : module.versioned[v].latest_tag_map]...)
+}

--- a/images/pytorch/main.tf
+++ b/images/pytorch/main.tf
@@ -4,42 +4,36 @@ terraform {
   }
 }
 
-locals {
-  versions = [
-    "pytorch-cuda12",
-  ]
-}
-
 variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-
 module "config" {
-  for_each       = toset(local.versions)
   source         = "./config"
-  extra_packages = [each.key, "busybox", "bash"]
+  extra_packages = ["pytorch-cuda12", "busybox", "bash"]
 }
 
-module "versioned" {
-  for_each = toset(local.versions)
-  source   = "../../tflib/publisher"
-
+module "latest" {
+  source            = "../../tflib/publisher"
   name              = basename(path.module)
   target_repository = var.target_repository
-  config            = module.config[each.key].config
+  config            = module.config.config
   build-dev         = true
-  main_package      = each.key
 }
 
 module "test" {
-  for_each = toset(local.versions)
-  source   = "./tests"
-  digest   = module.versioned[each.key].image_ref
+  source = "./tests"
+  digest = module.latest.image_ref
 }
 
-module "tagger" {
-  source     = "../../tflib/tagger"
+resource "oci_tag" "latest" {
   depends_on = [module.test]
-  tags       = merge([for v in local.versions : module.versioned[v].latest_tag_map]...)
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
 }

--- a/images/pytorch/metadata.yaml
+++ b/images/pytorch/metadata.yaml
@@ -1,0 +1,10 @@
+name: pytorch
+image: cgr.dev/chainguard/pytorch
+logo: https://storage.googleapis.com/chainguard-academy/logos/pytorch.svg
+endoflife: ""
+console_summary: ""
+short_description: |
+  A minimal, [wolfi](https://github.com/wolfi-dev)-based image for pytorch, a Python package that provides two high-level features: Tensor computation (like NumPy) with strong GPU acceleration and Deep neural networks built on a tape-based autograd system.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://www.pytorch.org/

--- a/images/pytorch/metadata.yaml
+++ b/images/pytorch/metadata.yaml
@@ -8,3 +8,7 @@ short_description: |
 compatibility_notes: ""
 readme_file: README.md
 upstream_url: https://www.pytorch.org/
+keywords:
+  - ai
+  - library
+  - python

--- a/images/pytorch/tests/main.tf
+++ b/images/pytorch/tests/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "random_pet" "suffix" {}
+
+resource "helm_release" "pytorch" {
+  name             = "pytorch-${random_pet.suffix.id}"
+  namespace        = "pytorch"
+  create_namespace = true
+  repository       = "oci://registry-1.docker.io/bitnamicharts"
+  chart            = "pytorch"
+
+  values = [jsonencode({
+    containerName = "pytorch"
+    image = {
+      registry   = data.oci_string.ref.registry
+      repository = data.oci_string.ref.repo
+      digest     = data.oci_string.ref.digest
+    }
+    containerSecurityContext = {
+      runAsUser                = 0
+      runAsNonRoot             = false
+      allowPrivilegeEscalation = true
+    }
+    persistence = {
+      size = "1Gi"
+    }
+  })]
+}
+
+data "oci_exec_test" "helm-install" {
+  depends_on = [resource.helm_release.pytorch]
+  digest     = var.digest
+  script     = "${path.module}/pytorch-helm-install.sh"
+
+  env = [
+    {
+      name  = "RELEASE_NAME"
+      value = helm_release.pytorch.name
+    },
+    {
+      name  = "RELEASE_NAMESPACE"
+      value = helm_release.pytorch.namespace
+    }
+  ]
+}
+
+module "helm_cleanup" {
+  depends_on = [data.oci_exec_test.helm-install]
+  source     = "../../../tflib/helm-cleanup"
+  name       = helm_release.pytorch.id
+  namespace  = helm_release.pytorch.namespace
+}

--- a/images/pytorch/tests/pytorch-helm-install.sh
+++ b/images/pytorch/tests/pytorch-helm-install.sh
@@ -9,12 +9,13 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
+my_d=$(cd "${0%/*}" && pwd)
 test_script="/home/runner/work/images-private/images-private/images/pytorch/tests/torch_optim.py"
 exit_code=1
 
 run_scripts() {
   pod_name=$(kubectl get pods -n ${RELEASE_NAMESPACE} -l "app.kubernetes.io/instance=${RELEASE_NAME}" -o custom-columns=:metadata.name --no-headers | head -n 1)
-  kubectl cp "$test_script" "$pod_name":/tmp/pytorch.py -n ${RELEASE_NAMESPACE}
+  kubectl cp "${my_d}/torch_optim.py" "$pod_name":/tmp/pytorch.py -n ${RELEASE_NAMESPACE}
   kubectl exec "$pod_name" -n ${RELEASE_NAMESPACE} -- python /tmp/pytorch.py
   exit_code=$?
   if [ $exit_code -eq 0 ]; then

--- a/images/pytorch/tests/pytorch-helm-install.sh
+++ b/images/pytorch/tests/pytorch-helm-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+#
+# Tests pytorch with its helm chart and runs sample scripts to 
+# confirm its functionality
+#
+# This helm installation is intendended to run on devices with only cpu;
+# to test features utilizing GPU, please refer TESTING.md
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+test_script="/home/runner/work/images-private/images-private/images/pytorch/tests/torch_optim.py"
+exit_code=1
+
+run_scripts() {
+  pod_name=$(kubectl get pods -n ${RELEASE_NAMESPACE} -l "app.kubernetes.io/instance=${RELEASE_NAME}" -o custom-columns=:metadata.name --no-headers | head -n 1)
+  kubectl cp "$test_script" "$pod_name":/tmp/pytorch.py -n ${RELEASE_NAMESPACE}
+  kubectl exec "$pod_name" -n ${RELEASE_NAMESPACE} -- python /tmp/pytorch.py
+  exit_code=$?
+  if [ $exit_code -eq 0 ]; then
+      printf "Test ran successfully"
+    return 0
+  fi
+  echo "FAILED: Unable to run test scripts"
+  exit 1
+}
+
+run_scripts
+

--- a/images/pytorch/tests/quickstart.py
+++ b/images/pytorch/tests/quickstart.py
@@ -1,0 +1,110 @@
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets
+from torchvision.transforms import ToTensor
+
+# Download training data from open datasets.
+training_data = datasets.FashionMNIST(
+    root="data",
+    train=True,
+    download=True,
+    transform=ToTensor(),
+)
+
+# Download test data from open datasets.
+test_data = datasets.FashionMNIST(
+    root="data",
+    train=False,
+    download=True,
+    transform=ToTensor(),
+)
+
+batch_size = 64
+
+# Create data loaders.
+train_dataloader = DataLoader(training_data, batch_size=batch_size)
+test_dataloader = DataLoader(test_data, batch_size=batch_size)
+
+for X, y in test_dataloader:
+    print(f"Shape of X [N, C, H, W]: {X.shape}")
+    print(f"Shape of y: {y.shape} {y.dtype}")
+    break
+
+# Get cpu, gpu or mps device for training.
+device = (
+    "cuda"
+    if torch.cuda.is_available()
+    else "mps"
+    if torch.backends.mps.is_available()
+    else "cpu"
+)
+print(f"Using {device} device")
+
+# Define model
+class NeuralNetwork(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.flatten = nn.Flatten()
+        self.linear_relu_stack = nn.Sequential(
+            nn.Linear(28*28, 512),
+            nn.ReLU(),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Linear(512, 10)
+        )
+
+    def forward(self, x):
+        x = self.flatten(x)
+        logits = self.linear_relu_stack(x)
+        return logits
+
+model = NeuralNetwork().to(device)
+print(model)
+
+
+loss_fn = nn.CrossEntropyLoss()
+optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+
+def train(dataloader, model, loss_fn, optimizer):
+    size = len(dataloader.dataset)
+    model.train()
+    for batch, (X, y) in enumerate(dataloader):
+        X, y = X.to(device), y.to(device)
+
+        # Compute prediction error
+        pred = model(X)
+        loss = loss_fn(pred, y)
+
+        # Backpropagation
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+        if batch % 100 == 0:
+            loss, current = loss.item(), (batch + 1) * len(X)
+            print(f"loss: {loss:>7f}  [{current:>5d}/{size:>5d}]")
+
+
+def test(dataloader, model, loss_fn):
+    size = len(dataloader.dataset)
+    num_batches = len(dataloader)
+    model.eval()
+    test_loss, correct = 0, 0
+    with torch.no_grad():
+        for X, y in dataloader:
+            X, y = X.to(device), y.to(device)
+            pred = model(X)
+            test_loss += loss_fn(pred, y).item()
+            correct += (pred.argmax(1) == y).type(torch.float).sum().item()
+    test_loss /= num_batches
+    correct /= size
+    print(f"Test Error: \n Accuracy: {(100*correct):>0.1f}%, Avg loss: {test_loss:>8f} \n")
+
+
+epochs = 3
+for t in range(epochs):
+    print(f"Epoch {t+1}\n-------------------------------")
+    train(train_dataloader, model, loss_fn, optimizer)
+    test(test_dataloader, model, loss_fn)
+print("Done!")

--- a/images/pytorch/tests/torch_optim.py
+++ b/images/pytorch/tests/torch_optim.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import torch
+import math
+
+
+# Create Tensors to hold input and outputs.
+x = torch.linspace(-math.pi, math.pi, 2000)
+y = torch.sin(x)
+
+# Prepare the input tensor (x, x^2, x^3).
+p = torch.tensor([1, 2, 3])
+xx = x.unsqueeze(-1).pow(p)
+
+# Use the nn package to define our model and loss function.
+model = torch.nn.Sequential(
+    torch.nn.Linear(3, 1),
+    torch.nn.Flatten(0, 1)
+)
+loss_fn = torch.nn.MSELoss(reduction='sum')
+
+# Use the optim package to define an Optimizer that will update the weights of
+# the model for us. Here we will use RMSprop; the optim package contains many other
+# optimization algorithms. The first argument to the RMSprop constructor tells the
+# optimizer which Tensors it should update.
+learning_rate = 1e-3
+optimizer = torch.optim.RMSprop(model.parameters(), lr=learning_rate)
+for t in range(2000):
+    # Forward pass: compute predicted y by passing x to the model.
+    y_pred = model(xx)
+
+    # Compute and print loss.
+    loss = loss_fn(y_pred, y)
+    if t % 100 == 99:
+        print(t, loss.item())
+
+    # Before the backward pass, use the optimizer object to zero all of the
+    # gradients for the variables it will update (which are the learnable
+    # weights of the model). This is because by default, gradients are
+    # accumulated in buffers( i.e, not overwritten) whenever .backward()
+    # is called. Checkout docs of torch.autograd.backward for more details.
+    optimizer.zero_grad()
+
+    # Backward pass: compute gradient of the loss with respect to model
+    # parameters
+    loss.backward()
+
+    # Calling the step function on an Optimizer makes an update to its
+    # parameters
+    optimizer.step()
+
+
+linear_layer = model[0]
+print(f'Result: y = {linear_layer.bias.item()} + {linear_layer.weight[:, 0].item()} x + {linear_layer.weight[:, 1].item()} x^2 + {linear_layer.weight[:, 2].item()} x^3')

--- a/main.tf
+++ b/main.tf
@@ -1088,6 +1088,11 @@ module "pulumi" {
   target_repository = "${var.target_repository}/pulumi"
 }
 
+module "pytorch" {
+  source            = "./images/pytorch"
+  target_repository = "${var.target_repository}/pytorch"
+}
+
 module "python" {
   source            = "./images/python"
   target_repository = "${var.target_repository}/python"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [ ] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
