### PR TITLE
chore: Add extras to package repositories

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,10 +45,16 @@ variable "archs" {
 }
 
 provider "apko" {
-  extra_repositories = concat(["https://packages.wolfi.dev/os"], var.extra_repositories)
-  extra_keyring      = concat(["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"], var.extra_keyring)
-  extra_packages     = concat(["wolfi-baselayout"], var.extra_packages)
-  default_archs      = length(var.archs) == 0 ? ["x86_64", "aarch64"] : var.archs
+  extra_repositories = concat([
+    "https://packages.wolfi.dev/os",
+    "https://packages.cgr.dev/extras",
+  ], var.extra_repositories)
+  extra_keyring = concat([
+    "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+    "https://packages.cgr.dev/extras/chainguard-extras.rsa.pub",
+  ], var.extra_keyring)
+  extra_packages = concat(["wolfi-baselayout"], var.extra_packages)
+  default_archs  = length(var.archs) == 0 ? ["x86_64", "aarch64"] : var.archs
 }
 
 provider "apko" {


### PR DESCRIPTION
This is needed in order to include pytorch-cuda12 in the public pytorch image