### PR TITLE
chore(ci): Aggressively free up runner disk space

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -106,6 +106,11 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+    # In some cases, we run out of disk space during tests, so this hack frees up approx 25G.
+    # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+    - name: Free up runner disk space
+      uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
+
     - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3
       with:
         terraform_version: '1.5.7'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,14 +77,10 @@ jobs:
       contents: read
       actions: read
     steps:
-      # In some cases, we runs out of disk space during tests, so this hack frees up approx 10G.
+      # In some cases, we run out of disk space during tests, so this hack frees up approx 25G.
       # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
       - name: Free up runner disk space
-        shell: bash
-        run: |
-          set -x
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
 
       - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3
         with:


### PR DESCRIPTION
Uses ublue-os/remove-unwanted-software to free up additional disk space on runners

Additionally, this has been added to the CI for presubmit