### PR TITLE
fix(pytorch-cuda12): Increase helm timeout from 5m to 10m

### DIFF
--- a/images/pytorch-cuda12/tests/main.tf
+++ b/images/pytorch-cuda12/tests/main.tf
@@ -19,6 +19,7 @@ resource "helm_release" "pytorch" {
   create_namespace = true
   repository       = "oci://registry-1.docker.io/bitnamicharts"
   chart            = "pytorch"
+  timeout          = 600
 
   values = [jsonencode({
     containerName = "pytorch"


### PR DESCRIPTION
On release, the timeout was exceeded causing this test to fail. Increase the timeout from the default 5m to 10m.