### PR TITLE
feat(images): Add Docker Selenium

### DIFF
--- a/images/docker-selenium/README.md
+++ b/images/docker-selenium/README.md
@@ -1,0 +1,28 @@
+<!--monopod:start-->
+# docker-selenium
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/docker-selenium` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/docker-selenium/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Minimal [docker-selenium](https://github.com/SeleniumHQ/docker-selenium) container image with Chromium.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/docker-selenium:latest
+```
+<!--getting:end-->
+
+<!--body:start--><!--body:end-->

--- a/images/docker-selenium/TESTING.md
+++ b/images/docker-selenium/TESTING.md
@@ -1,0 +1,158 @@
+# Testing docker-selenium
+
+This describes how to test our `docker-selenium` image.
+
+Testing the `docker-selenium` is a bit tricky so we need to deep dive into the package itself first.
+
+## 1. Testing the Package
+
+### 1.1. Build
+
+Checkout to `enterprise-packages` repository and build the package:
+
+```shell
+ARCH=amd64 make package/docker-selenium
+```
+
+> [!WARNING]
+> This package doesn't support `arm64` architecture, yet.
+
+### 1.2. Install
+
+To install the package, you need to spin up a container first:
+
+```shell
+docker container run --entrypoint="" -p 4444:4444 -p 7900:7900 --shm-size="2g" --platform linux/x86_64 --rm -it --pull always -v "$PWD":/work --workdir="/work" cgr.dev/chainguard/wolfi-base:latest sh
+```
+
+* `4444`: Selenium port
+* `7900`: VNC port
+
+1. Install the transitive dependencies
+
+```shell
+apk add --allow-untrusted \
+  packages/x86_64/bouncycastle-tls-fips-1.0.18-r0.apk \
+  packages/x86_64/bouncycastle-pkix-fips-1.0.7-r0.apk \
+  packages/x86_64/bouncycastle-fips-1.0.2.4-r0.apk \
+  packages/x86_64/openjdk-11-jre-base-bcfips-11.0.22-r3.apk \
+  packages/x86_64/openjdk-11-jre-bcfips-11.0.22-r3.apk \
+  packages/x86_64/openjdk-11-default-jvm-bcfips-11.0.22-r3.apk \
+  packages/x86_64/openjdk-11-bcfips-11.0.22-r3.apk \
+  packages/x86_64/chromium-122.0.6250.1-r0.apk \
+  packages/x86_64/selenium-server-jre-bcfips-4.17.0-r1.apk \
+  packages/x86_64/selenium-server-jre-bcfips-compat-4.17.0-r1.apk
+```
+
+* Change the version of the packages to the version you have fetched.
+
+> [!TIP]
+> Use `gsutil -m cp -n "gs://chainguard-enterprise-registry-destination/os/x86_64/<PACKAGE>" ./packages/x86_64/` to download the packages from the GCS bucket.
+
+2. Install the package
+
+```shell
+apk add --allow-untrusted \
+  packages/x86_64/docker-selenium-$VERSION.apk \
+  packages/x86_64/docker-selenium-supervisor-config-$VERSION.apk
+```
+
+Set the `VERSION` to the version of the package you have built.
+
+3. Set the required environment variables
+
+```shell
+export TZ=UTC LANG_WHICH=en LANG_WHERE=US ENCODING=UTF-8 LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 SEL_USER=seluser SEL_UID=65532 SEL_GID=65532 HOME=/home/seluser SEL_DOWNLOAD_DIR=/home/Downloads SE_BIND_HOST=false SE_SCREEN_WIDTH=1360 SE_SCREEN_HEIGHT=1020 SE_SCREEN_DEPTH=24 SE_SCREEN_DPI=96 SE_START_XVFB=true SE_START_VNC=true SE_START_NO_VNC=true SE_NO_VNC_PORT=7900 SE_VNC_PORT=5900 DISPLAY=:99.0 DISPLAY_NUM=99 CONFIG_FILE=/opt/selenium/config.toml GENERATE_CONFIG=true SE_DRAIN_AFTER_SESSION_COUNT=0 SE_OFFLINE=true SE_NODE_MAX_SESSIONS=1 SE_NODE_SESSION_TIMEOUT=300 SE_NODE_OVERRIDE_MAX_SESSIONS=false DBUS_SESSION_BUS_ADDRESS=/dev/null SE_RELAX_CHECKS=true LC_CTYPE=en_US FONTCONFIG_PATH=/etc/fonts
+```
+
+### Test
+
+1. Run the entrypoint:
+
+```shell
+/opt/bin/entry_point.sh
+```
+
+* Expect the process to be running after a while.
+* Expect the following core processes should not exit with a non-zero status code:
+  * `xvfb`
+  * `vnc`
+  * `novnc`
+  * `selenium-standalone`
+
+```
+2024-02-05 08:59:35,911 INFO success: xvfb entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
+2024-02-05 08:59:35,914 INFO success: vnc entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
+2024-02-05 08:59:35,914 INFO success: novnc entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
+2024-02-05 08:59:35,915 INFO success: selenium-standalone entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
+```
+
+2. Interrupt the process with <kbd>Ctrl</kbd>+<kbd>C</kbd> and check the logs:
+
+```shell
+cat /var/log/supervisor/*.log
+```
+
+* Expect no critical errors in the logs.
+
+> [!NOTE]
+> `Failed to read: session.NAME` logs are expected, you can ignore them.
+
+3. Check the Selenium server on `http://localhost:4444`:
+
+* Selenium UI should be accessible.
+* `curl -sL http://localhost:4444/status` expects a `200` status code, and the response body should contain `{"value":{"ready":true}}` with 1 `availability: UP` node.
+
+4. Check the VNC server on `http://localhost:7900/vnc.html`:
+
+* VNC UI should be accessible.
+* Login with the password `secret`.
+
+## 2. Testing the Image
+
+In order to use the image, you'll need to install [Docker](https://docs.docker.com/get-docker/). Following Docker's installation, getting up and running with Docker Selenium is as easy as opening a terminal and running:
+
+```
+docker container run -p 4444:4444 -p 7900:7900 --shm-size="2g" --platform linux/x86_64 --name CONTAINER_NAME --rm -it cgr.dev/images-private/docker-selenium:latest
+```
+
+Substitute `CONTAINER_NAME` with the name you'd like to assign to the container.
+
+### 2.1 Retrieving Logs
+
+Docker provides a built in way to retrieve logs from a running container:
+
+```
+docker logs CONTAINER_NAME
+```
+
+Additionally, we can pass `--follow` as an argument to monitor output in real time or `--details` to print additional information that may be helpful.
+
+Furthermore, we can leverage `docker exec` to even more detail than what's available via the standard output of our entrypoint:
+
+```
+docker exec CONTAINER_NAME bash -c "cat /var/log/supervisor/*.log"
+```
+
+This will output the details of every log captured by `supervisor`. We can even choose to be more specific and only print information from error logs:
+
+```
+docker exec CONTAINER_NAME bash -c "cat /var/log/supervisor/*stderr*.log"
+```
+
+### 2.2 Testing Functionality
+
+Like testing the package above, we are utilizing the same ports:
+
+* `4444`: Selenium port
+* `7900`: VNC port
+
+To verify Selenium is operational, check its status:
+
+```
+curl -sL http://localhost:4444/status
+```
+
+Then access it by going to `localhost:4444`.
+
+To verify VNC is operational, go to `localhost:7900` and login with the password `secret`.

--- a/images/docker-selenium/config/main.tf
+++ b/images/docker-selenium/config/main.tf
@@ -1,0 +1,142 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. docker-selenium)."
+  default     = ["docker-selenium"]
+}
+
+variable "environment" {
+  default = {}
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  run-as = 0
+  uid    = 65532
+  gid    = 65532
+  name   = "seluser"
+}
+
+output "config" {
+  value = jsonencode({
+    archs = ["x86_64"]
+    contents = {
+      packages = concat([
+        "docker-selenium-supervisor-config",
+      ], var.extra_packages)
+    }
+    accounts = module.accts.block
+    environment = merge({
+      "PATH" : "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      "DEBIAN_FRONTEND" : "noninteractive"
+      "DEBCONF_NONINTERACTIVE_SEEN" : "true"
+      "TZ" : "UTC"
+      "LANG_WHICH" : "en"
+      "LANG_WHERE" : "US"
+      "ENCODING" : "UTF-8"
+      "LANGUAGE" : "en_US.UTF-8"
+      "LANG" : "en_US.UTF-8"
+      "SEL_USER" : "seluser"
+      "SEL_UID" : "65532"
+      "SEL_GID" : "65532"
+      "HOME" : "/home/seluser"
+      "SEL_DOWNLOAD_DIR" : "/home/seluser/Downloads"
+      "SE_BIND_HOST" : "false"
+      "SE_SCREEN_WIDTH" : "1360"
+      "SE_SCREEN_HEIGHT" : "1020"
+      "SE_SCREEN_DEPTH" : "24"
+      "SE_SCREEN_DPI" : "96"
+      "SE_START_XVFB" : "true"
+      "SE_START_VNC" : "true"
+      "SE_START_NO_VNC" : "true"
+      "SE_NO_VNC_PORT" : "7900"
+      "SE_VNC_PORT" : "5900"
+      "DISPLAY" : ":99.0"
+      "DISPLAY_NUM" : "99"
+      "CONFIG_FILE" : "/opt/selenium/config.toml"
+      "GENERATE_CONFIG" : "true"
+      "SE_DRAIN_AFTER_SESSION_COUNT" : "0"
+      "SE_OFFLINE" : "true"
+      "SE_NODE_MAX_SESSIONS" : "1"
+      "SE_NODE_SESSION_TIMEOUT" : "300"
+      "SE_NODE_OVERRIDE_MAX_SESSIONS" : "false"
+      "DBUS_SESSION_BUS_ADDRESS" : "/dev/null"
+      "SE_RELAX_CHECKS" : "true"
+      "FONTCONFIG_PATH" : "/etc/fonts"
+      "LC_CTYPE" : "en_US"
+      "OPENBLAS_NUM_THREADS" : "1"
+      "SE_SESSION_REQUEST_TIMEOUT" : "300"
+      "SE_SESSION_RETRY_INTERVAL" : "15"
+      "SE_HEALTHCHECK_INTERVAL" : "120"
+      "SE_REJECT_UNSUPPORTED_CAPS" : "false"
+      "SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" : "true"
+      "SE_OTEL_TRACES_EXPORTER" : "otlp"
+      "SE_OTEL_SERVICE_NAME" : "selenium-node-chrome"
+    }, var.environment)
+    entrypoint = {
+      command = "/opt/bin/entry_point.sh"
+    }
+    paths = [{
+      path        = "/opt/bin"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/opt/selenium"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = false
+      }, {
+      path        = "/etc/supervisor"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/etc/supervisor/conf.d"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/var/log/supervisor"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/var/run/supervisor"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/tmp"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/home/seluser"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+    }]
+    }
+  )
+}

--- a/images/docker-selenium/main.tf
+++ b/images/docker-selenium/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  source         = "./config"
+  extra_packages = ["docker-selenium"]
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/docker-selenium/metadata.yaml
+++ b/images/docker-selenium/metadata.yaml
@@ -1,0 +1,12 @@
+name: docker-selenium
+image: cgr.dev/chainguard/docker-selenium
+logo: https://storage.googleapis.com/chainguard-academy/logos/docker-selenium.svg
+endoflife: ""
+console_summary: ""
+short_description: Minimal [docker-selenium](https://github.com/SeleniumHQ/docker-selenium) container image with Chromium.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/SeleniumHQ/docker-selenium
+keywords:
+  - application
+  - tools

--- a/images/docker-selenium/tests/main.tf
+++ b/images/docker-selenium/tests/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "oci_exec_test" "smoke" {
+  digest = var.digest
+  script = "${path.module}/smoke.sh"
+}

--- a/images/docker-selenium/tests/smoke.sh
+++ b/images/docker-selenium/tests/smoke.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+CONTAINER_NAME="docker-selenium-$(uuidgen)"
+
+SELENIUM_PORT="${FREE_PORT}"
+NO_VNC_PORT="$((${SELENIUM_PORT} + 1))"
+VNC_PORT="$((${NO_VNC_PORT} + 1))"
+
+# Start container
+docker run \
+  -d --rm \
+  -p "${SELENIUM_PORT}":4444 \
+  -p "${NO_VNC_PORT}":7900 \
+  -p "${VNC_PORT}":5900 \
+  -e "SE_NO_VNC_PORT=${NO_VNC_PORT}" \
+  -e "SE_VNC_PORT=${VNC_PORT}" \
+  --platform linux/x86_64 \
+  --name "${CONTAINER_NAME}" \
+  "${IMAGE_NAME}"
+
+# Stop container when script exits
+trap "docker stop ${CONTAINER_NAME}" EXIT
+
+# Verify services are available
+echo "Checking if Selenium is ready..."
+if ! curl -vsL --retry-all-errors --retry 10 --retry-max-time 120 http://localhost:"${SELENIUM_PORT}"/status | jq -e '.value.ready == true'; then
+  # Check if container is still running
+  if ! docker ps --filter "name=${CONTAINER_NAME}" --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "FAILED: ${CONTAINER_NAME} is not running."
+  fi
+  exit 1
+fi
+
+echo "Checking if Selenium has 1 available node..."
+curl -vsL http://localhost:"${SELENIUM_PORT}"/status | jq '.value.nodes | length == 1'
+curl -vsL http://localhost:"${SELENIUM_PORT}"/status | jq '.value.nodes[0].avaibility == "UP"'
+
+echo "Checking noVNC availability..."
+nc -zv localhost "${NO_VNC_PORT}"
+
+# netcat may succeed but the noVNC page may not be available
+if ! curl -vsL --retry-all-errors --retry 2 --retry-max-time 10 localhost:"${NO_VNC_PORT}"; then
+  if [[ "$?" -eq "56" ]]; then
+    exit 1
+  fi
+fi
+
+# Check if container is still running
+if ! docker ps --filter "name=${CONTAINER_NAME}" --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+  echo "FAILED: ${CONTAINER_NAME} is not running."
+  exit 1
+fi
+
+function dump_logs_and_exit {
+  echo "Dumping supervisor logs and exiting..."
+  supervisor_logs=$(docker exec "${CONTAINER_NAME}" ls /var/log/supervisor)
+  for log in ${supervisor_logs}; do
+    echo "Dumping supervisor log: ${log}"
+    docker exec "${CONTAINER_NAME}" cat "/var/log/supervisor/${log}" || true
+  done
+  container_logs=$(docker logs "${CONTAINER_NAME}")
+  echo "Dumping container logs: ${container_logs}"
+  exit 1
+}
+
+logs=$(docker logs "${CONTAINER_NAME}" 2>&1)
+
+# Services that started by supervisor should have entered RUNNING state
+true_asserts=("xvfb entered RUNNING state" "vnc entered RUNNING state" "novnc entered RUNNING state" "selenium-standalone entered RUNNING state")
+
+# Services that started by supervisor should NOT have exited unexpectedly
+false_asserts=("WARN exited" "terminated by SIGTRAP", "not expected")
+
+for assert in "${true_asserts[@]}"; do
+  if ! echo "$logs" | grep -q "$assert"; then
+    echo "AssertTrue failed: $assert"
+    dump_logs_and_exit
+  fi
+done
+
+for assert in "${false_asserts[@]}"; do
+  if echo "$logs" | grep -q "$assert"; then
+    echo "AssertFalse failed: $assert"
+    dump_logs_and_exit
+  fi
+done
+
+echo "All assertions passed."

--- a/main.tf
+++ b/main.tf
@@ -347,6 +347,11 @@ module "dive" {
   target_repository = "${var.target_repository}/dive"
 }
 
+module "docker-selenium" {
+  source            = "./images/docker-selenium"
+  target_repository = "${var.target_repository}/docker-selenium"
+}
+
 module "dotnet" {
   source            = "./images/dotnet"
   target_repository = "${var.target_repository}/dotnet"


### PR DESCRIPTION
Adds image for Docker Selenium

## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [ ] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
