### PR TITLE
Add random pet name namespace for sigstore-policy-controller helm tests

### DIFF
--- a/images/sigstore-policy-controller/tests/main.tf
+++ b/images/sigstore-policy-controller/tests/main.tf
@@ -19,7 +19,7 @@ resource "helm_release" "policy-controller" {
   repository = "https://sigstore.github.io/helm-charts"
   chart      = "policy-controller"
 
-  namespace        = "policy-controller"
+  namespace        = "pc-${random_pet.suffix.id}"
   create_namespace = true
 
   set {


### PR DESCRIPTION
When building locally the CRDs, and mutating/validating webhooks from the helm tests get left lying around. Aligning the namespace arguments for the helm resources gets the tests to pass, even if the actual objects don't live in a namespace.

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
