### PR TITLE
Specify subcommands for aws-ebs-csi-driver test

### DIFF
--- a/images/aws-ebs-csi-driver/tests/01-runs.sh
+++ b/images/aws-ebs-csi-driver/tests/01-runs.sh
@@ -4,5 +4,7 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 
 set +o pipefail  # We expect the command to fail, but want its output anyway.
 
-docker run --rm "${IMAGE_NAME}" 2>&1 | grep "unable to load"
+docker run --rm "${IMAGE_NAME}" all 2>&1 | grep "unable to load"
+docker run --rm "${IMAGE_NAME}" node 2>&1 | grep "unable to load"
+docker run --rm "${IMAGE_NAME}" controller 2>&1 | grep "unable to load"
 


### PR DESCRIPTION
The upstream binary regressed and the default mode (`all`) no longer works as it did previously. Specifying the mode on the command-line works around that. I proposed a fix upstream.

Ideally we move tests like these into the package itself and use the imagetest provider to deploy tests on AWS, but we aren't quite there yet so we'll have to do this for now.