### PR TITLE
node: improve Dockerfile test, include dumb-init

### DIFF
--- a/images/node/config/template.apko.yaml
+++ b/images/node/config/template.apko.yaml
@@ -1,7 +1,8 @@
 contents:
   packages:
-    - busybox
+    - busybox # TODO: busybox should be removed from this image.
     - nghttp2
+    - dumb-init
     # Node comes via var.extra_packages
 
 # By convention, Node apps run in an /app directory, which should be owned by

--- a/images/node/example/Dockerfile
+++ b/images/node/example/Dockerfile
@@ -1,16 +1,19 @@
 # syntax=docker/dockerfile:1
 # Based on https://docs.docker.com/language/nodejs/build-images/
 
-ARG BASE=cgr.dev/chainguard/node
+ARG BUILDER=cgr.dev/chainguard/node:latest-dev
+ARG BASE=cgr.dev/chainguard/node:latest
+
+FROM ${BUILDER} AS builder
+WORKDIR /build-stage
+COPY package*.json ./
+ENV NODE_ENV=production
+RUN npm ci --omit=dev
+# Copy the the files you need
+COPY . ./
+# npm run build or whatever you need to do to build your app
 
 FROM ${BASE}
-
-ENV NODE_ENV=production
-
-COPY --chown=node:node ["package.json", "package-lock.json*", "./"]
-
-RUN npm install --production
-
-COPY --chown=node:node . .
-
-CMD [ "server.js" ]
+COPY --from=builder /build-stage/ .
+ENTRYPOINT [""]
+CMD ["dumb-init", "node", "server.js"]

--- a/images/node/example/package.json
+++ b/images/node/example/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "server.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/images/node/example/package.json
+++ b/images/node/example/package.json
@@ -2,7 +2,7 @@
   "name": "example",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This moves our Dockerfile test to use a multi-stage build as described in [docker-node's best practices](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#smaller-images-without-npmyarn).

This proves the image doesn't _need_ a shell (or `npm`) to run basic apps in a best-practice way.

In the future we can use this test to ensure the image works as expected when/if we remove `sh` and `npm` from the image.

cc @bretfisher