### PR TITLE
fix(docker-selenium): Run Chromium headless without GPU access and sa…

### DIFF
--- a/images/docker-selenium/config/main.tf
+++ b/images/docker-selenium/config/main.tf
@@ -76,6 +76,7 @@ output "config" {
       "SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" : "true"
       "SE_OTEL_TRACES_EXPORTER" : "otlp"
       "SE_OTEL_SERVICE_NAME" : "selenium-node-chrome"
+      "CHROMIUM_USER_FLAGS" : "--headless --disable-gpu --no-sandbox"
     }, var.environment)
     entrypoint = {
       command = "/opt/bin/entry_point.sh"


### PR DESCRIPTION
…ndbox

This runs Chromium in headless mode with GPU access disabled as this will not be ran on systems with GPU access

Additionally, this disables Chromium's sandbox as it is already being ran in a container thus does not have access to unneeded host resources