### PR TITLE
remove packages value from caddy apko

### DIFF
--- a/images/caddy/config/template.apko.yaml
+++ b/images/caddy/config/template.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - caddy
 
 accounts:
   groups:


### PR DESCRIPTION
Fixed a build issue for the caddy FIPS image by removing the 'caddy' value from the packages field in `template.apko.yaml`. This resolves the issue where the build process incorrectly selected the **caddy** package over the required **caddy-fips** package.