### PR TITLE
chore: migrate tests to imagetest

### DIFF
--- a/images/argo/tests/check-argo-workflow.sh
+++ b/images/argo/tests/check-argo-workflow.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-kubectl -n argo-workflows apply -f - <<EOF
+cat <<EOF | kubectl --namespace argo-workflows apply --filename -
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -17,9 +17,9 @@ spec:
       args: [ "hello world" ]
 EOF
 
-sleep 3
+kubectl wait --for=condition=Completed workflows/hello \
+  --namespace argo-workflows \
+  --timeout 2m
 
-kubectl -n argo-workflows wait workflows/hello --for condition=Completed --timeout 2m
-
-kubectl logs -n argo-workflows pod/hello
-trap "kubectl -n argo-workflows delete workflows/hello" EXIT
+kubectl logs --namespace argo-workflows pod/hello
+trap "kubectl --namespace argo-workflows delete workflows/hello" EXIT

--- a/images/aws-for-fluent-bit/tests/main.tf
+++ b/images/aws-for-fluent-bit/tests/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
-    oci  = { source = "chainguard-dev/oci" }
-    helm = { source = "hashicorp/helm" }
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
   }
 }
 
@@ -16,23 +16,43 @@ data "oci_exec_test" "startup" {
   script = "${path.module}/startup.sh"
 }
 
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "aws-for-fluent-bit"
+  inventory = data.imagetest_inventory.this
+}
+
 resource "random_pet" "suffix" {}
 
-resource "helm_release" "fluent-bit" {
-  name = "fluent-bit-${random_pet.suffix.id}"
+module "helm" {
+  source = "../../../tflib/imagetest/helm"
 
-  repository = "https://fluent.github.io/helm-charts"
-  chart      = "fluent-bit"
+  name  = "fluent-bit-${random_pet.suffix.id}"
+  repo  = "https://fluent.github.io/helm-charts"
+  chart = "fluent-bit"
 
-  values = [jsonencode({
+  values = {
     image = {
       repository = data.oci_string.ref.registry_repo
       tag        = data.oci_string.ref.pseudo_tag
     }
-  })]
+  }
 }
 
-module "helm_cleanup" {
-  source = "../../../tflib/helm-cleanup"
-  name   = helm_release.fluent-bit.id
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "basic"
+  description = "Basic functionality of AWS for Fluent Bit installed in a Kubernetes cluster"
+
+  steps = [
+    {
+      name = "Helm install"
+      cmd  = module.helm.install_cmd
+    }
+  ]
+
+  labels = {
+    type = "k8s",
+  }
 }


### PR DESCRIPTION
Batch of test migrations to the new imagetest provider:
* `argo`: https://github.com/chainguard-images/images/pull/2318/commits/20a524b5a8e196c6da204c7be04069c4e303c7ed
* `atlantis`: https://github.com/chainguard-images/images/pull/2318/commits/58a6e397b673bf0cdb262943fce2d49f267d07a8
* `aws-for-fluent-bit`: https://github.com/chainguard-images/images/pull/2318/commits/13db0472ea87ecffb121d1172727e613eab81334
* `bank-vaults`: https://github.com/chainguard-images/images/pull/2318/commits/e2670b0ec30d0babec89a6d90ada28e10105d607