### PR TITLE
Add new PHP image variant for Laravel

### DIFF
--- a/images/php/README.md
+++ b/images/php/README.md
@@ -26,18 +26,13 @@ docker pull cgr.dev/chainguard/php:latest
 <!--getting:end-->
 
 <!--body:start-->
-
-- [Documentation](https://edu.chainguard.dev/chainguard/chainguard-images/reference/php)
-- [Getting Started Guide](https://edu.chainguard.dev/chainguard/chainguard-images/reference/php/getting-started-php/)
-- [Provenance Information](https://edu.chainguard.dev/chainguard/chainguard-images/reference/php/provenance_info/)
-
 ## Image Variants
 
-Our `latest` tags use the most recent build of the [Wolfi PHP](https://github.com/wolfi-dev/os/blob/main/php.yaml) package. The following tagged variants are available without authentication:
+Our `latest` tags use the most recent build of the [Wolfi PHP](https://github.com/wolfi-dev/os/blob/main/php.yaml) package. All variants have `-dev` versions that include Composer and other utilities that are suitable for developing and building PHP applications. Check the [Tags](https://edu.chainguard.dev/chainguard/chainguard-images/reference/php/tags_history/) page for more details on available tags, and the [Details]() page for information about included packages per variant.
 
-- `latest`: This is a distroless image for running command-line PHP applications. It does not include Composer or busybox, so no shell will be available.
-- `latest-dev`: This is a development / builder image that includes Composer, apk-tools, and busybox. This variant allows you to customize your final image with additional Wolfi packages.
+- `latest`: This is a distroless image for running command-line PHP applications.
 - `latest-fpm`: This is the distroless `php-fpm` image variant, designed to be used together with our [Nginx](https://edu.chainguard.dev/chainguard/chainguard-images/reference/nginx) image.
+- `latest-laravel`: This is an experimental image designed to develop and run [Laravel](https://laravel.com) applications, including all required extensions.
 
 ### PHP Version
 This will automatically pull the image to your local system and execute the command `php --version`:

--- a/images/php/config/laravel/main.tf
+++ b/images/php/config/laravel/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. php-fpm)."
-  default     = ["php", "php-fpm", "php-ctype", "php-xml", "php-dom", "php-simplexml", "php-fileinfo"]
+  default     = ["curl", "ca-certificates", "php", "php-fpm", "php-ctype", "php-curl", "php-dom", "php-fileinfo", "php-iconv", "php-mbstring", "php-mysqlnd", "php-openssl", "php-phar", "php-pdo", "php-pdo_sqlite", "php-pdo_mysql", "php-sodium", "php-simplexml", "php-xml"]
 }
 
 data "apko_config" "this" {

--- a/images/php/config/laravel/main.tf
+++ b/images/php/config/laravel/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. php-fpm)."
+  default     = ["php", "php-fpm", "php-ctype", "php-xml", "php-dom", "php-simplexml", "php-fileinfo"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/php/config/laravel/template.apko.yaml
+++ b/images/php/config/laravel/template.apko.yaml
@@ -1,17 +1,5 @@
 contents:
   packages:
-    - ca-certificates
-    - curl
-    - php-curl
-    - php-openssl
-    - php-iconv
-    - php-mbstring
-    - php-mysqlnd
-    - php-pdo
-    - php-pdo_sqlite
-    - php-pdo_mysql
-    - php-sodium
-    - php-phar
     # extra packages come from var.extra_packages
 
 entrypoint:

--- a/images/php/config/laravel/template.apko.yaml
+++ b/images/php/config/laravel/template.apko.yaml
@@ -1,0 +1,46 @@
+contents:
+  packages:
+    - ca-certificates
+    - curl
+    - php-curl
+    - php-openssl
+    - php-iconv
+    - php-mbstring
+    - php-mysqlnd
+    - php-pdo
+    - php-pdo_sqlite
+    - php-pdo_mysql
+    - php-sodium
+    - php-phar
+    # extra packages come from var.extra_packages
+
+entrypoint:
+  type: service-bundle
+  services:
+    php-fpm: /usr/sbin/php-fpm
+
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin
+
+paths:
+  - path: /app
+    type: directory
+    permissions: 0o777
+    uid: 65532
+    gid: 65532
+
+work-dir: /app
+
+accounts:
+  groups:
+    - groupname: php
+      gid: 65532
+  users:
+    - username: php
+      uid: 65532
+      gid: 65532
+    - username: laravel
+      uid: 1000
+      gid: 1000
+
+  run-as: 65532

--- a/images/php/laravel.tf
+++ b/images/php/laravel.tf
@@ -1,0 +1,37 @@
+module "laravel-config" { source = "./config/laravel" }
+
+module "laravel" {
+  source = "../../tflib/publisher"
+
+  name               = basename(path.module)
+  target_repository  = var.target_repository
+  config             = module.laravel-config.config
+  extra_dev_packages = ["composer", "php-xmlwriter"]
+}
+
+module "test-laravel" {
+  source    = "./tests"
+  digest    = module.laravel.image_ref
+  check-fpm = true
+  check-laravel = true
+}
+
+module "test-laravel-dev" {
+  source    = "./tests"
+  check-fpm = true
+  check-dev = true
+  check-laravel = true # Check for Laravel extra packages.
+  digest    = module.laravel.dev_ref
+}
+
+resource "oci_tag" "latest-laravel" {
+  depends_on = [module.test-laravel]
+  digest_ref = module.laravel.image_ref
+  tag        = "latest-laravel"
+}
+
+resource "oci_tag" "latest-laravel-dev" {
+  depends_on = [module.test-laravel-dev]
+  digest_ref = module.laravel.dev_ref
+  tag        = "latest-laravel-dev"
+}

--- a/images/php/laravel.tf
+++ b/images/php/laravel.tf
@@ -10,18 +10,18 @@ module "laravel" {
 }
 
 module "test-laravel" {
-  source    = "./tests"
-  digest    = module.laravel.image_ref
-  check-fpm = true
+  source        = "./tests"
+  digest        = module.laravel.image_ref
+  check-fpm     = true
   check-laravel = true
 }
 
 module "test-laravel-dev" {
-  source    = "./tests"
-  check-fpm = true
-  check-dev = true
+  source        = "./tests"
+  check-fpm     = true
+  check-dev     = true
   check-laravel = true # Check for Laravel extra packages.
-  digest    = module.laravel.dev_ref
+  digest        = module.laravel.dev_ref
 }
 
 resource "oci_tag" "latest-laravel" {

--- a/images/php/tests/main.tf
+++ b/images/php/tests/main.tf
@@ -18,6 +18,11 @@ variable "check-fpm" {
   description = "Whether to check for php-fpm extensions"
 }
 
+variable "check-laravel" {
+  default     = false
+  description = "Whether to check for Laravel framework extensions"
+}
+
 data "oci_exec_test" "version" {
   digest = var.digest
   script = "docker run --entrypoint php --rm $IMAGE_NAME --version"
@@ -39,4 +44,10 @@ data "oci_exec_test" "fpm-shutdown" {
   count  = var.check-fpm ? 1 : 0
   digest = var.digest
   script = "${path.module}/02-shutdown.sh"
+}
+
+data "oci_exec_test" "laravel-extensions" {
+  count  = var.check-laravel ? 1 : 0
+  digest = var.digest
+  script = "docker run --rm --entrypoint php $IMAGE_NAME -m | grep fileinfo"
 }


### PR DESCRIPTION
This image is part of an initiative to provide users with images that are plug-and-play for their framework of choice. [Laravel](https://laravel.com) is a popular PHP framework currently in high demand within the PHP ecosystem.


<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [X] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [X] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:
The CVE detected was not introduced by this image version, it is in the php-fpm package.

```
php-8.2-fpm  8.2.16-r2            apk   CVE-2015-3211  Medium
```

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [X] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:
I am unable to run this test at the moment

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:
I am unable to run this test at the moment

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [X] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [X] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [X] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
