### PR TITLE
remove packages value from cadvisor apko

### DIFF
--- a/images/cadvisor/config/template.apko.yaml
+++ b/images/cadvisor/config/template.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - cadvisor
 
 accounts:
   groups:


### PR DESCRIPTION
This PR resolves a build issue with the cadvisor FIPS image by removing the _'cadvisor'_ value from the _packages_ field in the _template.apko.yaml_ file. 

The cadvisor package is already included in the **_extra_packages_** field, which means that the build process should automatically select the correct package (FIPS or non-FIPS). However, the explicit inclusion of 'cadvisor' in the packages field was causing a conflict, leading to the incorrect package selection.