### PR TITLE
chore(maven): bump latest tag to match the `openjdk-21` version

### DIFF
--- a/images/maven/main.tf
+++ b/images/maven/main.tf
@@ -49,8 +49,7 @@ module "tagger" {
     "openjdk-21" : module.maven["21"].image_ref
     "openjdk-21-dev" : module.maven["21"].dev_ref
 
-    # TODO: Update these to point to openjdk-21
-    "latest" : module.maven["17"].image_ref
-    "latest-dev" : module.maven["17"].dev_ref
+    "latest" : module.maven["21"].image_ref
+    "latest-dev" : module.maven["21"].dev_ref
   }
 }


### PR DESCRIPTION
Match the latest tag of Maven with the version that works with Java 21.