### PR TITLE
feat(images): Add Chromium

### DIFF
--- a/images/chromium/README.md
+++ b/images/chromium/README.md
@@ -1,0 +1,49 @@
+<!--monopod:start-->
+# chromium
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/chromium` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/chromium/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Minimal [Chromium](https://chromium.googlesource.com/chromium/src/) container image.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/chromium:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+Running Chromium doesn't require passing any additional parameters to Docker:
+
+```bash
+docker run cgr.dev/chainguard/chromium:latest
+```
+
+Please note that Chromium is ran in a headless state with the sandbox and GPU access disabled with the flags:
+
+```
+--headless --no-sandbox --disable-gpu
+```
+
+We run Chromium headless with GPU access disabled due to the container not having GPU access.
+
+Chromium's sandbox has been disabled as the container is sandboxed from the host environment.
+
+This can be overriden via the environment variable `CHROMIUM_USER_FLAGS` though this is unsupported.
+
+<!--body:end-->

--- a/images/chromium/config/main.tf
+++ b/images/chromium/config/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = ["chromium"]
+}
+
+variable "environment" {
+  default = {}
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  run-as = 65532
+  uid    = 65532
+  gid    = 65532
+  name   = "chrome"
+}
+
+output "config" {
+  value = jsonencode({
+    archs = ["x86_64"]
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    environment = merge({
+      "CHROMIUM_USER_FLAGS" : "--headless --no-sandbox --disable-gpu"
+    })
+    entrypoint = {
+      command = "/usr/bin/chromium-browser"
+    }
+    paths = [{
+      path        = "/usr/lib/chromium"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+    }]
+  })
+}

--- a/images/chromium/main.tf
+++ b/images/chromium/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  source = "./config"
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/chromium/metadata.yaml
+++ b/images/chromium/metadata.yaml
@@ -1,0 +1,12 @@
+name: chromium
+image: cgr.dev/chainguard/chromium
+logo: https://storage.googleapis.com/chainguard-academy/logos/chromium.svg
+endoflife: ""
+console_summary: ""
+short_description: Minimal [Chromium](https://chromium.googlesource.com/chromium/src/) container image.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://chromium.googlesource.com/chromium/src/
+keywords:
+  - application
+  - browser

--- a/images/chromium/tests/main.tf
+++ b/images/chromium/tests/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "oci_exec_test" "smoke" {
+  digest = var.digest
+  script = "${path.module}/smoke.sh"
+}

--- a/images/chromium/tests/smoke.sh
+++ b/images/chromium/tests/smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+CHROME_CONTAINER_NAME="chromium-$(uuidgen)"
+CHROMEDRIVER_CONTAINER_NAME="chromedriver-$(uuidgen)"
+
+# Check status
+docker run \
+  --rm \
+  --platform linux/x86_64 \
+  --name "${CHROME_CONTAINER_NAME}" \
+  "${IMAGE_NAME}" \
+  --dump-dom \
+  https://www.chromestatus.com
+
+# Test ChromeDriver starts successfully
+docker run \
+  -d --rm \
+  --platform linux/x86_64 \
+  --entrypoint chromedriver \
+  --name "${CHROMEDRIVER_CONTAINER_NAME}" \
+  "${IMAGE_NAME}"
+
+# Stop container when script exits
+trap "docker stop ${CHROMEDRIVER_CONTAINER_NAME}" EXIT
+sleep 5
+
+# Retrieve container logs
+logs=$(docker logs "${CHROMEDRIVER_CONTAINER_NAME}" 2>&1)
+
+# Ensure ChromeDriver started successfully
+expected_logs=("ChromeDriver was started successfully.")
+
+for log in "${expected_logs[@]}"; do
+  if ! echo "$logs" | grep -q "$log"; then
+    echo "ChromeDriver failed to start."
+    exit 1
+  fi
+done

--- a/main.tf
+++ b/main.tf
@@ -237,6 +237,11 @@ module "cfssl" {
   target_repository = "${var.target_repository}/cfssl"
 }
 
+module "chromium" {
+  source            = "./images/chromium"
+  target_repository = "${var.target_repository}/chromium"
+}
+
 module "cilium" {
   source            = "./images/cilium"
   target_repository = "${var.target_repository}/cilium"


### PR DESCRIPTION
Adds Chromium image that runs headless with GPU access disabled and sandboxing turned off

## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [x] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
