### PR TITLE
fix(cassandra-medusa): Add python-3.11 to extra packages

### DIFF
--- a/images/cassandra-medusa/config/main.tf
+++ b/images/cassandra-medusa/config/main.tf
@@ -9,6 +9,7 @@ variable "extra_packages" {
   default = [
     "py3-cassandra-medusa",
     "py3-cassandra-medusa-compat",
+    "python-3.11",
   ]
 }
 


### PR DESCRIPTION
Since cassandra-medusa enables no-depends, python-3.11 is not installed as an implicit runtime dependency so we need to explicitly require it

