### PR TITLE
step-ca and step-cli images

### DIFF
--- a/images/step-ca/README.md
+++ b/images/step-ca/README.md
@@ -13,7 +13,7 @@
 <!--monopod:end-->
 
 <!--overview:start-->
-
+[step-ca](https://smallstep.com/docs/step-ca) is an online Certificate Authority (CA) for secure, automated X.509 and SSH certificate management
 <!--overview:end-->
 
 <!--getting:start-->

--- a/images/step-ca/README.md
+++ b/images/step-ca/README.md
@@ -1,0 +1,28 @@
+<!--monopod:start-->
+# step-ca
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/step-ca` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/step-ca/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/step-ca:latest
+```
+<!--getting:end-->
+
+<!--body:start--><!--body:end-->

--- a/images/step-ca/config/main.tf
+++ b/images/step-ca/config/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "step-ca",
+    "step",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/step-ca/config/template.apko.yaml
+++ b/images/step-ca/config/template.apko.yaml
@@ -1,0 +1,20 @@
+contents:
+  packages: [
+    # Package "step-ca" comes in via var.extra_packages
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: step-ca
+cmd: --help

--- a/images/step-ca/main.tf
+++ b/images/step-ca/main.tf
@@ -16,8 +16,8 @@ module "step-ca" {
   target_repository = var.target_repository
   config            = module.config.config
 
-  build-dev         = true
-  extra_packages    = ["step"]
+  build-dev      = true
+  extra_packages = ["step"]
 }
 
 module "test" {

--- a/images/step-ca/main.tf
+++ b/images/step-ca/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "step-ca" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev         = true
+  extra_packages    = ["step"]
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.step-ca.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.step-ca.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.step-ca.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/step-ca/metadata.yaml
+++ b/images/step-ca/metadata.yaml
@@ -1,0 +1,10 @@
+name: step-ca
+image: cgr.dev/chainguard/step-ca
+logo: https://storage.googleapis.com/chainguard-academy/logos/step-ca.svg
+endoflife: ""
+console_summary: ""
+short_description: 
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: 
+keywords: []

--- a/images/step-ca/metadata.yaml
+++ b/images/step-ca/metadata.yaml
@@ -3,8 +3,8 @@ image: cgr.dev/chainguard/step-ca
 logo: https://storage.googleapis.com/chainguard-academy/logos/step-ca.svg
 endoflife: ""
 console_summary: ""
-short_description: 
+short_description: "[step-ca](https://smallstep.com/docs/step-ca) is an online Certificate Authority (CA) for secure, automated X.509 and SSH certificate management"
 compatibility_notes: ""
 readme_file: README.md
-upstream_url: 
+upstream_url: https://github.com/smallstep/certificates
 keywords: []

--- a/images/step-ca/tests/EXAMPLE_TEST.sh
+++ b/images/step-ca/tests/EXAMPLE_TEST.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# TODO: Implement this test.

--- a/images/step-ca/tests/main.tf
+++ b/images/step-ca/tests/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+resource "random_pet" "suffix" {}
+

--- a/images/step-cli/README.md
+++ b/images/step-cli/README.md
@@ -1,0 +1,28 @@
+<!--monopod:start-->
+# step-ca
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/step-ca` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/step-ca/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/step-ca:latest
+```
+<!--getting:end-->
+
+<!--body:start--><!--body:end-->

--- a/images/step-cli/README.md
+++ b/images/step-cli/README.md
@@ -1,11 +1,11 @@
 <!--monopod:start-->
-# step-ca
+# step-cli
 | | |
 | - | - |
-| **OCI Reference** | `cgr.dev/chainguard/step-ca` |
+| **OCI Reference** | `cgr.dev/chainguard/step-cli` |
 
 
-* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/step-ca/overview/)
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/step-cli/overview/)
 * [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
 * [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
 
@@ -13,7 +13,7 @@
 <!--monopod:end-->
 
 <!--overview:start-->
-
+[step-cli](https://smallstep.com/docs/step-cli) is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows
 <!--overview:end-->
 
 <!--getting:start-->
@@ -21,7 +21,7 @@
 The image is available on `cgr.dev`:
 
 ```
-docker pull cgr.dev/chainguard/step-ca:latest
+docker pull cgr.dev/chainguard/step-cli:latest
 ```
 <!--getting:end-->
 

--- a/images/step-cli/config/main.tf
+++ b/images/step-cli/config/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "step",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/step-cli/config/template.apko.yaml
+++ b/images/step-cli/config/template.apko.yaml
@@ -1,0 +1,19 @@
+contents:
+  packages: [
+    # To add a version stream image, see the extra_packages variable in config/main.tf to add packages conditionally.
+    # Otherwise, just add packages here.
+  ]
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: step
+cmd: --help

--- a/images/step-cli/main.tf
+++ b/images/step-cli/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "step-cli" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.step-cli.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.step-cli.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.step-cli.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/step-cli/main.tf
+++ b/images/step-cli/main.tf
@@ -16,7 +16,7 @@ module "step-cli" {
   target_repository = var.target_repository
   config            = module.config.config
 
-  build-dev         = true
+  build-dev = true
 }
 
 module "test" {

--- a/images/step-cli/metadata.yaml
+++ b/images/step-cli/metadata.yaml
@@ -1,10 +1,10 @@
-name: step-ca
-image: cgr.dev/chainguard/step-ca
-logo: https://storage.googleapis.com/chainguard-academy/logos/step-ca.svg
+name: step-cli
+image: cgr.dev/chainguard/step-cli
+logo: https://storage.googleapis.com/chainguard-academy/logos/step-cli.svg
 endoflife: ""
 console_summary: ""
-short_description: 
+short_description: "[step-cli](https://smallstep.com/docs/step-cli) is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows"
 compatibility_notes: ""
 readme_file: README.md
-upstream_url: 
+upstream_url: https://github.com/smallstep/cli
 keywords: []

--- a/images/step-cli/metadata.yaml
+++ b/images/step-cli/metadata.yaml
@@ -1,0 +1,10 @@
+name: step-ca
+image: cgr.dev/chainguard/step-ca
+logo: https://storage.googleapis.com/chainguard-academy/logos/step-ca.svg
+endoflife: ""
+console_summary: ""
+short_description: 
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: 
+keywords: []

--- a/images/step-cli/tests/EXAMPLE_TEST.sh
+++ b/images/step-cli/tests/EXAMPLE_TEST.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# TODO: Implement this test.

--- a/images/step-cli/tests/main.tf
+++ b/images/step-cli/tests/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+resource "random_pet" "suffix" {}
+

--- a/main.tf
+++ b/main.tf
@@ -1295,6 +1295,16 @@ module "statsd" {
   target_repository = "${var.target_repository}/statsd"
 }
 
+module "step-ca" {
+  source            = "./images/step-ca"
+  target_repository = "${var.target_repository}/step-ca"
+}
+
+module "step-cli" {
+  source            = "./images/step-cli"
+  target_repository = "${var.target_repository}/step-cli"
+}
+
 module "stunnel" {
   source            = "./images/stunnel"
   target_repository = "${var.target_repository}/stunnel"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [ ] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
