### PR TITLE
fix(trino): add `CATALOG_MANAGEMENT` variable to match upstream

### DIFF
--- a/images/trino/config/main.tf
+++ b/images/trino/config/main.tf
@@ -1,3 +1,13 @@
+variable "environment" {
+  description = "The environment variables to set in the final image"
+  type        = map(string)
+  # CATALOG_MANAGEMENT variable as defined in the upstream container:
+  # https://github.com/trinodb/trino/blob/d3b901f83e663dcbfed3e4868a2bc40919deb9c5/core/docker/Dockerfile#L34
+  default = {
+    "CATALOG_MANAGEMENT" : "static"
+  }
+}
+
 variable "extra_packages" {
   description = "The additional packages to install"
   type        = list(string)
@@ -36,29 +46,33 @@ output "config" {
       packages = concat(var.packages, var.extra_packages, var.extra_plugins)
     }
     accounts = module.accts.block
-    paths = [{
-      path        = "/usr/lib/trino/"
-      type        = "directory"
-      uid         = module.accts.uid
-      gid         = module.accts.gid
-      permissions = 493 // 0o755
-      recursive   = true
-      }, {
-
-      path        = "/etc/trino/"
-      type        = "directory"
-      uid         = module.accts.uid
-      gid         = module.accts.gid
-      permissions = 493 // 0o755
-      recursive   = true
-      }, {
-      path        = "/data/trino"
-      type        = "directory"
-      uid         = module.accts.uid
-      gid         = module.accts.gid
-      permissions = 511 // 0o777
-      recursive   = true
-    }]
+    paths = [
+      {
+        path        = "/usr/lib/trino/"
+        type        = "directory"
+        uid         = module.accts.uid
+        gid         = module.accts.gid
+        permissions = 493 // 0o755
+        recursive   = true
+      },
+      {
+        path        = "/etc/trino/"
+        type        = "directory"
+        uid         = module.accts.uid
+        gid         = module.accts.gid
+        permissions = 493 // 0o755
+        recursive   = true
+      },
+      {
+        path        = "/data/trino"
+        type        = "directory"
+        uid         = module.accts.uid
+        gid         = module.accts.gid
+        permissions = 511 // 0o777
+        recursive   = true
+      }
+    ]
+    environment = var.environment
     entrypoint = {
       command = "/usr/bin/run-trino"
     }


### PR DESCRIPTION
The upstream container image contains the `CATALOG_MANAGEMENT` variable set to `static` by default. Ours was failing tests because of this missing variable.

Extra: migrate Helm tests to imagetest.