### PR TITLE
Add metallb controller and speaker images

### DIFF
--- a/images/metallb/README.md
+++ b/images/metallb/README.md
@@ -1,0 +1,34 @@
+<!--monopod:start-->
+# metallb
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/metallb` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/metallb/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+[MetalLB](https://metallb.org) provides network load balancers for bare-metal Kubernetes clusters
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/metallb:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+Configuring MetalLB for your Kubernetes environment is beyond the scope of this document. It has multiple configuration options depending on the mode that it is configured to use (Layer 2 or BGP). Refer to the [MetalLB Concepts](https://metallb.universe.tf/concepts/) documentation for details on how each mode works.
+
+Their [installation guide](https://metallb.universe.tf/installation/) is a good reference that has numerous examples using Kubernetes manifests, Kustomize manifests, and Helm charts.
+
+Finally, visit the [configuration reference pages](https://metallb.universe.tf/configuration/) for details on how to use MetalLb in each mode with different CNI providers.
+<!--body:end-->

--- a/images/metallb/config/main.tf
+++ b/images/metallb/config/main.tf
@@ -1,0 +1,32 @@
+locals {
+  # the controller doesn't need anything, but speaker and its containers rely on the extras here
+  extra_packages = var.main_package != "metallb-controller" ? ["busybox", "bash", "python3", "metallb-frr-compat", "tini"] : []
+}
+
+variable "main_package" {
+  description = "Main package to install"
+  type        = string
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = []
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  # speaker seems to only want to run as root
+  run-as = var.main_package == "metallb-speaker" ? 0 : 65534
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = concat([var.main_package], local.extra_packages, var.extra_packages)
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/${var.main_package}"
+    }
+  })
+}

--- a/images/metallb/main.tf
+++ b/images/metallb/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+locals {
+  components = toset(["controller", "speaker"])
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  for_each     = local.components
+  source       = "./config"
+  main_package = "metallb-${each.key}"
+}
+
+module "latest" {
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
+  name = basename(path.module)
+
+  target_repository = "${var.target_repository}-${each.key}"
+  config            = module.config[each.key].config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test-latest]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest-dev"
+}
+

--- a/images/metallb/metadata.yaml
+++ b/images/metallb/metadata.yaml
@@ -1,0 +1,10 @@
+name: metallb
+image: cgr.dev/chainguard/metallb
+logo: https://storage.googleapis.com/chainguard-academy/logos/metallb.svg
+endoflife: ""
+console_summary: ""
+short_description: "[MetalLB](https://metallb.org) provides network load balancers for bare-metal Kubernetes clusters"
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/metallb/metallb
+keywords: []

--- a/images/metallb/tests/install/main.tf
+++ b/images/metallb/tests/install/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "values" {
+  type = any
+  default = {
+    controller = {
+      image = {
+        repository = "cgr.dev/chainguard/metallb-controller"
+        tag        = "latest"
+      }
+    }
+    speaker = {
+      image = {
+        repository = "cgr.dev/chainguard/metallb-speaker"
+        tag        = "latest"
+      }
+      frr = {
+        enabled = false
+      }
+    }
+  }
+}
+
+module "helm" {
+  source = "../../../../tflib/imagetest/helm"
+
+  namespace = "metallb"
+  chart     = "metallb"
+  repo      = "https://metallb.github.io/metallb"
+
+  values = var.values
+}
+
+output "install_cmd" {
+  value = module.helm.install_cmd
+}
+
+output "release_name" {
+  value = module.helm.release_name
+}

--- a/images/metallb/tests/main.tf
+++ b/images/metallb/tests/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digests" {
+  description = "The image digest to run tests over."
+  type = object({
+    controller = string
+    speaker    = string
+  })
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "metallb"
+  inventory = data.imagetest_inventory.this
+}
+
+module "helm_metallb" {
+  source = "./install"
+
+  values = {
+    controller = {
+      image = {
+        repository = data.oci_string.ref["controller"].registry_repo
+        tag        = data.oci_string.ref["controller"].pseudo_tag
+      }
+    }
+    speaker = {
+      image = {
+        repository = data.oci_string.ref["speaker"].registry_repo
+        tag        = data.oci_string.ref["speaker"].pseudo_tag
+      }
+      frr = {
+        enabled = false
+      }
+    }
+  }
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the metallb helm chart."
+
+  steps = [
+    {
+      name = "Install metallb",
+      cmd  = module.helm_metallb.install_cmd
+    },
+    {
+      name  = "Check CRDs, service, and pods",
+      cmd   = <<EOF
+        kubectl get crd |grep metallb
+        kubectl get svc/metallb-webhook-service -n metallb
+        kubectl wait --for=condition=Ready po -n metallb -l app.kubernetes.io/component=controller
+        kubectl wait --for=condition=Ready po -n metallb -l app.kubernetes.io/component=speaker
+      EOF
+      retry = { attempts = 5, delay = "10s" }
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -870,6 +870,11 @@ module "metacontroller" {
   target_repository = "${var.target_repository}/metacontroller"
 }
 
+module "metallb" {
+  source            = "./images/metallb"
+  target_repository = "${var.target_repository}/metallb"
+}
+
 module "metrics-server" {
   source            = "./images/metrics-server"
   target_repository = "${var.target_repository}/metrics-server"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [X] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

Notes: the speaker image seems to only work when running as root. I think it is to do with how it manipulates network interfaces. I'd like to investigate this some more in the future.

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
