### PR TITLE
Minor change to aspnet-runtime README

### DIFF
--- a/images/aspnet-runtime/README.md
+++ b/images/aspnet-runtime/README.md
@@ -28,5 +28,7 @@ docker pull cgr.dev/chainguard/aspnet-runtime:latest
 <!--body:start-->
 ## Usage
 
-The `aspnet-runtime` Chainguard Image contains both the ASP.NET runtime and the .NET core runtime, allowing you to run ASP.NET applications. For more information, please refer to the official [ASP.NET documentation](https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-8.0).
+The `aspnet-runtime` Chainguard Image contains both the ASP.NET runtime and the .NET core runtime, allowing you to run ASP.NET applications. Note that if your use case depends on running `aspnet-runtime` with a package manger or shell, you can use the `:latest-dev` variant.
+
+For more information, please refer to the official [ASP.NET documentation](https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-8.0).
 <!--body:end-->

--- a/images/aspnet-runtime/README.md
+++ b/images/aspnet-runtime/README.md
@@ -28,7 +28,7 @@ docker pull cgr.dev/chainguard/aspnet-runtime:latest
 <!--body:start-->
 ## Usage
 
-The `aspnet-runtime` Chainguard Image contains both the ASP.NET runtime and the .NET core runtime, allowing you to run ASP.NET applications. Note that if your use case depends on running `aspnet-runtime` with a package manger or shell, you can use the `:latest-dev` variant.
+The `aspnet-runtime` Chainguard Image contains both the ASP.NET runtime and the .NET core runtime, allowing you to run ASP.NET applications. Note that if your use case depends on running `aspnet-runtime` with a package manager or shell, you can use the `:latest-dev` variant.
 
 For more information, please refer to the official [ASP.NET documentation](https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-8.0).
 <!--body:end-->


### PR DESCRIPTION
This PR only includes a minor change to the `aspnet-runtime` Image README.

The reason behind this change was some customer feedback. See [this slack thread](https://chainguard-dev.slack.com/archives/C046AF0NCQY/p1710958553719919) for more info.