### PR TITLE
Added TESTING.md to nfs-subdir-ext-provisioner

### DIFF
--- a/images/nfs-subdir-external-provisioner/TESTING.md
+++ b/images/nfs-subdir-external-provisioner/TESTING.md
@@ -1,0 +1,63 @@
+## Testing
+
+Currently, nfs-server is not deployed on the k8s cluster, but is run from multipass. The instructions to be followed are:
+
+1) Install Multipass
+```shell
+brew install multipass
+```
+2) Create a vm to install nfs in it
+```shell
+multipass create --name nfs-server
+multipass exec nfs-server -- bash
+$sudo apt install nfs-kernel-server
+```
+3) Create nfs directory to mount and share
+```shell
+$sudo mkdir /nfs
+$sudo nano /etc/exports
+```
+add the following line
+``` shell
+nfs *(rw,sync,no_subtree_check,no_root_squash,no_all_squash,insecure)
+```
+4) Save the file, export the shares and restart the nfs server
+``` shell
+sudo exportfs -ar
+sudo systemctl restart nfs-server
+exit
+```
+5) Get IP of multipass node
+``` shell
+multipass ls
+```
+
+## Create a local cluster with kind
+
+Using kind you can create your local cluster
+
+```shell
+kind create cluster
+```
+
+## Pulling the image locally
+```shell
+docker pull cgr.dev/chainguard/nfs-subdir-external-provisioner:latest
+```
+
+## Runing the helm chart
+
+```shell
+helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+
+helm install nfs-subdir-external-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+    --set image.repository=cgr.dev/chainguard/nfs-subdir-external-provisioner \
+    --set image.tag=latest \
+    --set nfs.server=x.x.x.x \
+    --set nfs.path=/exported/path
+```
+
+Expected logs will include: 
+  "successfully acquired lease"
+  "Starting provisioner controller"
+  "Started provisioner controller"


### PR DESCRIPTION
Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Functional Testing + Documentation

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

- This image requires a kubernetes cluster as well as a nfs share setup. I have included more input on the values I have used on the nfs share in the README.md. Note that variables nfs_server and nfs_path will have to be updated depending on the actual values for the nfs server.
- This checks the logs for certain phrases (i.e: "successfully acquired lease", "Starting provisioner controller", "Started provisioner controller")

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
