### PR TITLE
prometheus-blackbox-exporter

### DIFF
--- a/images/prometheus-blackbox-exporter/README.md
+++ b/images/prometheus-blackbox-exporter/README.md
@@ -1,0 +1,43 @@
+<!--monopod:start-->
+# prometheus-blackbox-exporter
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/prometheus-blackbox-exporter` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/prometheus-blackbox-exporter/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Prometheus blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP, ICMP and gRPC.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/prometheus-blackbox-exporter:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+The easiest way to install the Prometheus Blackbox exporter is to use the Helm chart.
+
+```bash
+$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+$ helm repo update
+$ helm install blackbox-exporter prometheus-community/prometheus-blackbox-exporter \
+ --set image.registry=cgr.dev \
+ --set image.repository=chainguard/prometheus-blackbox-exporter \
+ --set image.tag=latest
+```
+
+For more detail, please refer to the [Blackbox exporter documentation](https://github.com/prometheus/blackbox_exporter).
+<!--body:end-->

--- a/images/prometheus-blackbox-exporter/config/main.tf
+++ b/images/prometheus-blackbox-exporter/config/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = []
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/bin/blackbox_exporter"
+    }
+    cmd = "--config.file=/etc/blackbox_exporter/config.yml"
+  })
+}

--- a/images/prometheus-blackbox-exporter/main.tf
+++ b/images/prometheus-blackbox-exporter/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+locals {
+  components = toset(["prometheus-blackbox-exporter"])
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  for_each       = local.components
+  source         = "./config"
+  extra_packages = [each.key, "${each.key}-compat"]
+}
+
+module "latest" {
+  for_each          = local.components
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config[each.key].config
+
+  build-dev    = true
+  main_package = each.key
+}
+
+module "test" {
+  for_each      = local.components
+  source        = "./tests"
+  digest        = module.latest[each.key].image_ref
+  chart_version = "8.10.0"
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test]
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test]
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/prometheus-blackbox-exporter/metadata.yaml
+++ b/images/prometheus-blackbox-exporter/metadata.yaml
@@ -1,0 +1,10 @@
+name: prometheus-blackbox-exporter
+image: cgr.dev/chainguard/prometheus-blackbox-exporter
+logo: https://storage.googleapis.com/chainguard-academy/logos/prometheus-blackbox-exporter.svg
+endoflife: ""
+console_summary: ""
+short_description: "Prometheus blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP, ICMP and gRPC."
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/prometheus/blackbox_exporter
+keywords: []

--- a/images/prometheus-blackbox-exporter/tests/main.tf
+++ b/images/prometheus-blackbox-exporter/tests/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "help" {
+  digest = var.digest
+  script = "${path.module}/smoke-test.sh"
+}
+
+variable "chart_version" {
+  description = "The version of the chart to test."
+  default     = "latest"
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "prometheus-blackbox-exporter"
+  inventory = data.imagetest_inventory.this
+}
+
+resource "random_pet" "suffix" {}
+
+module "helm" {
+  source = "../../../tflib/imagetest/helm"
+
+  name          = "prometheus-blackbox-exporter-${random_pet.suffix.id}"
+  namespace     = "prometheus-blackbox-exporter-${random_pet.suffix.id}"
+  repo          = "https://prometheus-community.github.io/helm-charts"
+  chart         = "prometheus-blackbox-exporter"
+  chart_version = var.chart_version
+
+  values = {
+    image = {
+      registry   = data.oci_string.ref.registry
+      repository = data.oci_string.ref.repo
+      tag        = data.oci_string.ref.pseudo_tag
+    }
+  }
+}
+
+resource "imagetest_feature" "basic" {
+  name        = "Basic"
+  description = "Test a basic installation of the prometheus-blackbox-exporter with Helm chart."
+  harness     = imagetest_harness_k3s.this
+
+  steps = [
+    {
+      name = "Helm install"
+      cmd  = module.helm.install_cmd
+    }
+  ]
+
+  labels = {
+    type = "k8s",
+  }
+}
+
+
+

--- a/images/prometheus-blackbox-exporter/tests/smoke-test.sh
+++ b/images/prometheus-blackbox-exporter/tests/smoke-test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Docker details
+container_name="blackbox-exporter-$(uuidgen)"
+container_port=${FREE_PORT}
+port_mapping="$container_port:9115"
+config_file="./blackbox.yml" # Path to your Blackbox configuration file
+
+
+# Function to stop and remove the container
+cleanup() {
+    echo "Stopping and removing the Blackbox Exporter container..."
+    docker rm -f ${container_name}
+}
+
+# Register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+# Start the Blackbox Exporter container
+echo "Starting Blackbox Exporter container..."
+docker run -d --name ${container_name} --rm -p ${port_mapping} $IMAGE_NAME
+
+# Define the Blackbox Exporter address
+blackbox_exporter_address="http://localhost:${container_port}"
+
+# Wait for the Blackbox Exporter to become responsive
+max_attempts=5  # Number of curl attempts before timing out
+delay_between_attempts=2  # Delay between attempts in seconds
+
+echo "Waiting for Blackbox Exporter to become available..."
+
+attempt_counter=0
+while ! curl --output /dev/null --silent --head --fail "${blackbox_exporter_address}"; do
+    if ((attempt_counter >= max_attempts)); then
+        echo "Blackbox Exporter is not up after $((max_attempts * delay_between_attempts)) seconds."
+        exit 1
+    fi
+    printf '.'
+    attempt_counter=$((attempt_counter+1))
+    sleep $delay_between_attempts
+done
+
+echo "Blackbox Exporter is up and running."
+
+# Define the module and target for the test
+module="http_2xx"
+target="http://example.com"
+
+# Perform the test using curl and check the response
+response=$(curl -s "${blackbox_exporter_address}/probe?module=${module}&target=${target}" | grep "^probe_success" | cut -d ' ' -f2)
+
+# Check if the probe was successful
+if [ "$response" == "1" ]; then
+  echo "Probe successful!"
+else
+  echo "Probe failed!"
+fi
+
+# Additionally, print out the entire metrics result for detailed inspection
+echo "Full metrics output from the Blackbox Exporter:"
+curl -s "${blackbox_exporter_address}/probe?module=${module}&target=${target}"

--- a/main.tf
+++ b/main.tf
@@ -885,6 +885,11 @@ module "metrics-server" {
   target_repository = "${var.target_repository}/metrics-server"
 }
 
+module "min-toolkit-debug" {
+  source            = "./images/min-toolkit-debug"
+  target_repository = "${var.target_repository}/min-toolkit-debug"
+}
+
 module "minio" {
   source            = "./images/minio"
   target_repository = "${var.target_repository}/minio"
@@ -1077,6 +1082,11 @@ module "prometheus-alertmanager" {
   target_repository = "${var.target_repository}/prometheus-alertmanager"
 }
 
+module "prometheus-blackbox-exporter" {
+  source            = "./images/prometheus-blackbox-exporter"
+  target_repository = "${var.target_repository}/prometheus-blackbox-exporter"
+}
+
 module "prometheus-cloudwatch-exporter" {
   source            = "./images/prometheus-cloudwatch-exporter"
   target_repository = "${var.target_repository}/prometheus-cloudwatch-exporter"
@@ -1247,11 +1257,6 @@ module "sigstore-scaffolding" {
 module "skaffold" {
   source            = "./images/skaffold"
   target_repository = "${var.target_repository}/skaffold"
-}
-
-module "min-toolkit-debug" {
-  source            = "./images/min-toolkit-debug"
-  target_repository = "${var.target_repository}/min-toolkit-debug"
 }
 
 module "smarter-device-manager" {


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
