### PR TITLE
add shadowsocks-rust

### DIFF
--- a/images/shadowsocks-rust/README.md
+++ b/images/shadowsocks-rust/README.md
@@ -1,0 +1,71 @@
+<!--monopod:start-->
+# shadowsocks-rust
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/shadowsocks-rust` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/shadowsocks-rust/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Shadowsocks-rust is a Rust implementation of the Shadowsocks protocol, aimed at ensuring secure and private internet access by encrypting connections and circumventing internet restrictions.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/shadowsocks-rust:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+Create a configuration file `config.json`:
+
+```bash
+cat <<EOF > config.json
+{
+    "server": "127.0.0.1",
+    "server_port": 8388,
+    "local_port": 1080,
+    "local_address": "127.0.0.1",
+    "password": "password",
+    "timeout": 300,
+    "method": "aes-256-gcm"
+}
+EOF
+```
+
+* Start the `sslocal`:
+
+```bash
+docker run \
+  --name sslocal-rust \
+  --restart always \
+  -p 1080:1080/tcp \
+  -v /path/to/config.json:/etc/shadowsocks-rust/config.json \
+  -dit cgr.dev/chainguard/shadowsocks-rust-ssserver:latest
+```
+
+* Start the `ssserver`:
+
+```bash
+docker run \
+  --name ssserver-rust \
+  --restart always \
+  -p 8388:8388/tcp \
+  -p 8388:8388/udp \
+  -v /path/to/config.json:/etc/shadowsocks-rust/config.json \
+  -dit cgr.dev/chainguard/shadowsocks-rust-sslocal:latest
+```
+
+Jump to the official [Getting Started](https://github.com/shadowsocks/shadowsocks-rust?tab=readme-ov-file#getting-started) guide for more detailed usage.
+<!--body:end-->

--- a/images/shadowsocks-rust/configs/main.tf
+++ b/images/shadowsocks-rust/configs/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+locals {
+  packages = {
+    "sslocal"  = "shadowsocks-rust-sslocal${var.suffix}"
+    "ssserver" = "shadowsocks-rust-ssserver${var.suffix}"
+  }
+}
+
+variable "name" {
+  description = "Package name"
+}
+
+variable "suffix" {
+  description = "Package name suffix (e.g. version stream)"
+  default     = ""
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = ["shadowsocks-rust"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.${var.name}.apko.yaml")
+  extra_packages  = concat([local.packages[var.name]], var.extra_packages)
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}
+
+output "main_package" {
+  value = local.packages[var.name]
+}

--- a/images/shadowsocks-rust/configs/template.sslocal.apko.yaml
+++ b/images/shadowsocks-rust/configs/template.sslocal.apko.yaml
@@ -1,0 +1,17 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/docker-entrypoint.sh
+
+cmd: sslocal --log-without-time -c /etc/shadowsocks-rust/config.json

--- a/images/shadowsocks-rust/configs/template.ssserver.apko.yaml
+++ b/images/shadowsocks-rust/configs/template.ssserver.apko.yaml
@@ -1,0 +1,17 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 0 # ssserver requires root to bind to port
+
+entrypoint:
+  command: /usr/bin/docker-entrypoint.sh
+
+cmd: ssserver --log-without-time -a nobody -c /etc/shadowsocks-rust/config.json

--- a/images/shadowsocks-rust/main.tf
+++ b/images/shadowsocks-rust/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+locals {
+  components = toset(["sslocal", "ssserver"])
+}
+
+module "config" {
+  for_each = local.components
+  source   = "./configs"
+  name     = each.key
+}
+
+module "latest" {
+  for_each = local.components
+  source   = "../../tflib/publisher"
+
+  name              = basename(path.module)
+  target_repository = "${var.target_repository}-${each.key}"
+  config            = module.config[each.key].config
+  build-dev         = true
+}
+
+module "test" {
+  source  = "./tests"
+  digests = { for k, v in module.latest : k => v.image_ref }
+}
+
+resource "oci_tag" "latest" {
+  for_each = local.components
+
+  digest_ref = module.latest[each.key].image_ref
+  tag        = "latest"
+  depends_on = [module.test]
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each = local.components
+
+  digest_ref = module.latest[each.key].dev_ref
+  tag        = "latest-dev"
+  depends_on = [module.test]
+}

--- a/images/shadowsocks-rust/metadata.yaml
+++ b/images/shadowsocks-rust/metadata.yaml
@@ -1,0 +1,11 @@
+name: shadowsocks-rust
+image: cgr.dev/chainguard/shadowsocks-rust
+logo: https://storage.googleapis.com/chainguard-academy/logos/shadowsocks-rust.svg
+endoflife: ""
+console_summary: ""
+short_description: Shadowsocks-rust is a Rust implementation of the Shadowsocks protocol, aimed at ensuring secure and private internet access by encrypting connections and circumventing internet restrictions.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/shadowsocks/shadowsocks-rust
+keywords:
+  - application

--- a/images/shadowsocks-rust/tests/01-smoke.sh
+++ b/images/shadowsocks-rust/tests/01-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+echo "${SERVER_IMAGE_NAME}"
+echo "${LOCAL_IMAGE_NAME}"
+
+PREFIX="shadowsocks"
+SERVER_CONTAINER_NAME="${PREFIX}-ssserver-$(uuidgen)"
+LOCAL_CONTAINER_NAME="${PREFIX}-sslocal-$(uuidgen)"
+NETWORK_NAME="${PREFIX}-net-$(uuidgen)"
+SSSERVER_PORT="${FREE_PORT}"
+SSLOCAL_PORT="$((${SSSERVER_PORT} + 1))"
+
+cleanup() {
+    docker logs ${SERVER_CONTAINER_NAME}
+    docker logs ${LOCAL_CONTAINER_NAME}
+    docker kill ${SERVER_CONTAINER_NAME}
+    docker kill ${LOCAL_CONTAINER_NAME}
+    docker network rm ${NETWORK_NAME}
+}
+
+trap cleanup EXIT
+
+docker network create ${NETWORK_NAME}
+
+cat <<EOF > config.json
+{
+    "server": "127.0.0.1",
+    "server_port": 8388,
+    "local_port": 1080,
+    "local_address": "127.0.0.1",
+    "password": "password",
+    "timeout": 300,
+    "method": "aes-256-gcm"
+}
+EOF
+
+# Start sserver
+docker run \
+    -d \
+    --name ${SERVER_CONTAINER_NAME} \
+    --network ${NETWORK_NAME} \
+    -p "${SSSERVER_PORT}":8388/tcp \
+    -p 8388:8388/udp \
+    -v $(pwd)/config.json:/etc/shadowsocks-rust/config.json \
+    ${SERVER_IMAGE_NAME}
+
+sleep 5
+docker logs ${SERVER_CONTAINER_NAME} | grep -q "listening on"
+
+# Start sslocal
+docker run \
+    -d \
+    --name ${LOCAL_CONTAINER_NAME} \
+    --network ${NETWORK_NAME} \
+    -p "${SSLOCAL_PORT}":1080/tcp \
+    -v $(pwd)/config.json:/etc/shadowsocks-rust/config.json \
+    ${LOCAL_IMAGE_NAME}
+
+sleep 5
+docker logs ${LOCAL_CONTAINER_NAME} | grep -q "listening on"

--- a/images/shadowsocks-rust/tests/main.tf
+++ b/images/shadowsocks-rust/tests/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    sslocal  = string
+    ssserver = string
+  })
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+data "oci_exec_test" "smoke" {
+  digest = var.digests["ssserver"] # This doesn't actually matter here, just pass it something valid
+  script = "${path.module}/01-smoke.sh"
+
+  env {
+    name  = "SERVER_IMAGE_NAME"
+    value = "${data.oci_string.ref["ssserver"].registry_repo}:${data.oci_string.ref["ssserver"].pseudo_tag}"
+  }
+  env {
+    name  = "LOCAL_IMAGE_NAME"
+    value = "${data.oci_string.ref["sslocal"].registry_repo}:${data.oci_string.ref["sslocal"].pseudo_tag}"
+  }
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "shadowsocks-rust"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    envs = {
+      "IMAGE_NAME_SSLOCAL"  = "${data.oci_string.ref["sslocal"].registry_repo}:${data.oci_string.ref["sslocal"].pseudo_tag}"
+      "IMAGE_NAME_SSSERVER" = "${data.oci_string.ref["ssserver"].registry_repo}:${data.oci_string.ref["ssserver"].pseudo_tag}"
+    }
+  }
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the shadowsocks-rust."
+
+  steps = [
+    {
+      name = "Deploy"
+      cmd  = <<EOF
+ kubectl apply -f https://raw.githubusercontent.com/shadowsocks/shadowsocks-rust/master/k8s/shadowsocks-rust.yaml
+ kubectl set image deployment/shadowsocks-rust shadowsocks-rust="${data.oci_string.ref["ssserver"].registry_repo}:${data.oci_string.ref["ssserver"].pseudo_tag}"
+       EOF
+    },
+    {
+      name  = "Ensure it comes up healthy"
+      cmd   = <<EOF
+ kubectl rollout status deployment/shadowsocks-rust --timeout=120s
+ kubectl wait --for=condition=ready pod --selector app.kubernetes.io/name=shadowsocks-rust
+       EOF
+      retry = { attempts = 3, delay = "2s", factor = 2 }
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1254,6 +1254,11 @@ module "semgrep" {
   target_repository = "${var.target_repository}/semgrep"
 }
 
+module "shadowsocks-rust" {
+  source            = "./images/shadowsocks-rust"
+  target_repository = "${var.target_repository}/shadowsocks-rust"
+}
+
 module "sigstore-policy-controller" {
   source            = "./images/sigstore-policy-controller"
   target_repository = "${var.target_repository}/sigstore-policy-controller"


### PR DESCRIPTION
* shadowsocks-rust-sslocal
> **Note**
> **Before:** `14.2MB, 15 packages, 0-CVE`
> **After:** `31.6MB, 10 packages, 0-CVE`

* shadowsocks-rust-ssserver
> **Note**
> **Before:** `12.5MB, 15 packages, 0-CVE`
> **After:** `29.9MB, 10 packages, 0-CVE`


## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [X] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes: On both images, `/usr/lib/locale` is sized `18MB`.

<img width="410" alt="image" src="https://github.com/chainguard-images/images/assets/16493751/e0c397f7-37c5-4cf8-856e-5a882ac37718">

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [X] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [X] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [X] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

Notes: ssserver requires root

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [X] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
