### PR TITLE
Add dragonfly image.

### DIFF
--- a/images/dragonfly/README.md
+++ b/images/dragonfly/README.md
@@ -1,0 +1,63 @@
+<!--monopod:start-->
+# dragonfly
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/dragonfly` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/dragonfly/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Dragonfly database: A modern replacement for Redis and Memcached
+
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/dragonfly:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+
+## Running dragonfly
+The dragonfly image can be run directly with:
+
+```
+docker run cgr.dev/chainguard/dragonfly
+init.cc:70] dragonfly running in opt mode.
+I20240324 20:31:24.752246     1 dfly_main.cc:627] Starting dragonfly df-dev-0000000
+* Logs will be written to the first available of the following paths:
+/tmp/dragonfly.*
+./dragonfly.*
+* For the available flags type dragonfly [--help | --helpfull]
+* Documentation can be found at: https://www.dragonflydb.io/docs
+W20240324 20:31:24.752985     1 dfly_main.cc:666] SWAP is enabled. Consider disabling it when running Dragonfly.
+I20240324 20:31:24.753018     1 dfly_main.cc:671] maxmemory has not been specified. Deciding myself....
+I20240324 20:31:24.753022     1 dfly_main.cc:680] Found 15.28GiB available memory. Setting maxmemory to 12.23GiB
+I20240324 20:31:24.753651     8 uring_proactor.cc:172] IORing with 1024 entries, allocated 102464 bytes, cq_entries is 2048
+I20240324 20:31:24.758664     1 proactor_pool.cc:146] Running 8 io threads
+I20240324 20:31:24.767096     1 server_family.cc:665] Host OS: Linux 6.6.16-linuxkit aarch64 with 8 threads
+I20240324 20:31:24.770040     1 snapshot_storage.cc:108] Load snapshot: Searching for snapshot in directory: "/"
+W20240324 20:31:24.770195     1 server_family.cc:758] Load snapshot: No snapshot found
+I20240324 20:31:24.772178     9 listener_interface.cc:101] sock[19] AcceptServer - listening on port 6379
+```
+
+### Using Helm charts
+
+As a place to get started, you may also use [this Helm chart](https://www.dragonflydb.io/docs/getting-started/kubernetes) to get dragonfly running:
+
+```
+helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragonfly --version v1.15.1 \
+    --set image.repository=cgr.dev/chainguard/dragonfly
+    -- set image.tag=latest
+```
+<!--body:end-->

--- a/images/dragonfly/config/main.tf
+++ b/images/dragonfly/config/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+
+  default = ["dragonfly", "dragonfly-oci-compat"]
+}
+
+variable "extra_repositories" {
+  description = "The additional repositores to install from (e.g. extras)."
+  default     = ["https://packages.cgr.dev/extras"]
+}
+
+variable "extra_keyring" {
+  description = "The additional keys to use (e.g. extras)."
+  default     = ["https://packages.cgr.dev/extras/chainguard-extras.rsa.pub"]
+}
+
+variable "environment" {
+  default = {}
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  # Dragonfly expects to run as this user
+  run-as = 10000
+  uid    = 10000
+  gid    = 1000
+  name   = "dfly"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages     = var.extra_packages
+      repositories = var.extra_repositories
+      keyring      = var.extra_keyring
+    }
+    accounts    = module.accts.block
+    environment = var.environment
+    entrypoint = {
+      command = "/usr/bin/entrypoint.sh"
+    }
+    cmd = "dragonfly --logtostderr"
+  })
+}

--- a/images/dragonfly/main.tf
+++ b/images/dragonfly/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  source = "./config"
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/dragonfly/metadata.yaml
+++ b/images/dragonfly/metadata.yaml
@@ -1,0 +1,13 @@
+name: dragonfly
+image: cgr.dev/chainguard/dragonfly
+logo: https://storage.googleapis.com/chainguard-academy/logos/dragonfly.svg
+endoflife: ""
+console_summary: ""
+short_description: |
+  Dragonfly database: A modern replacement for Redis and Memcached
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://www.dragonflydb.io
+keywords:
+  - redis
+  - database

--- a/images/dragonfly/tests/main.tf
+++ b/images/dragonfly/tests/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci  = { source = "chainguard-dev/oci" }
+    helm = { source = "hashicorp/helm" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+resource "random_pet" "suffix" {}
+
+# The helm release includes a health and readiness check
+resource "helm_release" "dragonfly" {
+  name             = "dragonfly-${random_pet.suffix.id}"
+  namespace        = "dragonfly"
+  create_namespace = true
+  repository       = "oci://ghcr.io/dragonflydb/dragonfly/helm"
+  chart            = "dragonfly"
+  version          = "v1.15.1"
+  timeout          = 600
+
+  values = [jsonencode({
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = data.oci_string.ref.pseudo_tag
+    }
+  })]
+}
+
+module "helm_cleanup" {
+  source    = "../../../tflib/helm-cleanup"
+  name      = helm_release.dragonfly.id
+  namespace = helm_release.dragonfly.namespace
+}

--- a/main.tf
+++ b/main.tf
@@ -372,6 +372,11 @@ module "dotnet" {
   target_repository = "${var.target_repository}/dotnet"
 }
 
+module "dragonfly" {
+  source            = "./images/dragonfly"
+  target_repository = "${var.target_repository}/dragonfly"
+}
+
 module "dynamic-localpv-provisioner" {
   source            = "./images/dynamic-localpv-provisioner"
   target_repository = "${var.target_repository}/dynamic-localpv-provisioner"


### PR DESCRIPTION
This is built from extra-packages because it's BUSL.

## New Image Pull Request Template


### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [X] The Image is smaller in size than its common public counterpart.

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [X] The image is tagged with :latest

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [X] The image was built and tested for aarch64.

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [X] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')

Notes:

### Access Control + Authentication

- [X] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the 

### CMD

- [X] For server applications give arguments to start in daemon mode (may be empty)

### Environment Variables

- [X] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
