### PR TITLE
velero plugin for aws

### DIFF
--- a/images/velero-plugin-for-aws/README.md
+++ b/images/velero-plugin-for-aws/README.md
@@ -1,0 +1,42 @@
+<!--monopod:start-->
+# velero-plugin-for-aws
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/velero-plugin-for-aws` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/velero-plugin-for-aws/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Plugins to support Velero on AWS
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/velero-plugin-for-aws:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+
+##  Usage
+
+The [Velero plugin for AWS documentation](https://velero.io/plugins/) can be found on Velero's official website. Velero have a guide on [getting started with Velero plugin for AWS](https://github.com/vmware-tanzu/velero-plugin-for-aws#setup), which demonstrates how to the plugin to backup and restore your Kubernetes cluster resources to AWS S3.  
+
+To use the Chainguard Image version of the plugin, follow the Velero instructions and replace the `velero/velero-plugin-for-aws` image with `cgr.dev/chainguard/velero-plugin-for-aws` in the Velero's install command.  
+
+```bash
+$ velero install \
+    --provider aws \
+    --plugins cgr.dev/chainguard/velero-plugin-for-aws:latest \
+   ...
+```
+<!--body:end-->

--- a/images/velero-plugin-for-aws/config/main.tf
+++ b/images/velero-plugin-for-aws/config/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = []
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/bin/cp-plugin /plugins/velero-plugin-for-aws /target/velero-plugin-for-aws"
+    }
+  })
+}
+

--- a/images/velero-plugin-for-aws/main.tf
+++ b/images/velero-plugin-for-aws/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+locals {
+  components = toset(["velero-plugin-for-aws"])
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  for_each       = local.components
+  source         = "./config"
+  extra_packages = [each.key, "${each.key}-compat"]
+}
+
+module "velero-plugin-for-aws" {
+  for_each          = local.components
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config[each.key].config
+
+  build-dev    = true
+  main_package = each.key
+}
+
+data "oci_ref" "velero" {
+  ref = "cgr.dev/chainguard/velero:latest"
+}
+
+module "test" {
+  source = "./tests"
+  digests = {
+    velero                = "cgr.dev/chainguard/velero:latest@${data.oci_ref.velero.digest}"
+    velero-plugin-for-aws = module.velero-plugin-for-aws["velero-plugin-for-aws"].image_ref
+  }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test]
+  digest_ref = module.velero-plugin-for-aws[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test]
+  digest_ref = module.velero-plugin-for-aws[each.key].dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/velero-plugin-for-aws/metadata.yaml
+++ b/images/velero-plugin-for-aws/metadata.yaml
@@ -1,0 +1,10 @@
+name: velero-plugin-for-aws
+image: cgr.dev/chainguard/velero-plugin-for-aws
+logo: https://storage.googleapis.com/chainguard-academy/logos/velero-plugin-for-aws.svg
+endoflife: ""
+console_summary: ""
+short_description: Plugins to support Velero on AWS
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/vmware-tanzu/velero-plugin-for-aws
+keywords: []

--- a/images/velero-plugin-for-aws/tests/docker-test.sh
+++ b/images/velero-plugin-for-aws/tests/docker-test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+
+# Function to install Velero using Minio as the backup storage
+install_velero(){
+  kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/velero/main/examples/minio/00-minio-deployment.yaml
+
+  # Create a credentials file for Minio
+  cat <<EOF > credentials-velero
+  [default]
+  aws_access_key_id = minio
+  aws_secret_access_key = minio123
+EOF
+
+  velero install --bucket velero \
+                 --secret-file ./credentials-velero \
+                 --use-volume-snapshots=false \
+                 --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000 \
+                 --provider aws \
+                 --plugins ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG} \
+                 --image ${VELERO_IMAGE_REGISTRY}/${VELERO_IMAGE_REPOSITORY}:${VELERO_IMAGE_TAG} --dry-run -oyaml > velero-install.yaml
+              
+  awk '
+  BEGIN {change=0}
+  /initContainers:/ {inInit=1}
+  inInit && /name: testing-velero-plugin-for-aws:unused/ && !change {print "          name: velero-plugin-for-aws"; change=1; next}
+  {print}
+  ' velero-install.yaml > updated-velero-install.yaml
+
+  cat updated-velero-install.yaml
+
+  # this is a workaround to fix the issue with the CRD not being created
+  set +e
+  kubectl apply -f updated-velero-install.yaml
+  sleep 10
+  set -e
+  kubectl apply -f updated-velero-install.yaml
+}
+
+# Function to wait for a pod with a specific label to be running
+wait_for_pod() {
+  local label=$1
+  local namespace=$2
+  local timeout=$3
+  local start_time=$(date +%s)
+  local end_time=$((start_time + timeout))
+
+  while true; do
+    if [ "$(date +%s)" -gt "$end_time" ]; then
+      echo "Timeout waiting for pod with label $label to be created"
+      exit 1
+    fi
+
+    if kubectl get pods -n "$namespace" -l "$label" 2>/dev/null | grep -q Running; then
+      break
+    fi
+
+    sleep 5
+  done
+}
+
+# Function to test Velero by creating a backup and restoring it
+test_velero(){
+
+  wait_for_pod "component=velero" "velero" 300
+
+  VELERO_POD_NAME=$(kubectl get pods -n velero -l component=velero -o jsonpath='{.items[0].metadata.name}')
+  STATUS=$(kubectl get pod $VELERO_POD_NAME -n velero -o jsonpath='{.status.phase}')
+
+  if [ "$STATUS" == "Running" ]; then
+    echo "Velero pod is running"
+  else
+    echo "Velero pod is not running"
+  fi
+
+
+  kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/velero/main/examples/nginx-app/base.yaml
+
+
+  # Create a test backup
+  velero backup create nginx-backup --selector app=nginx -w
+
+  # Simulate a disaster
+  kubectl delete namespace nginx-example
+
+  # Restore from backup
+  velero restore create --from-backup nginx-backup -w
+  
+  restore_status=$(velero restore get -o json | jq -r '.status.phase')
+  if [ "$restore_status" == "Completed" ]; then
+    echo "Backup creation successful"
+    break
+  elif [ "$restore_status" == "Failed" ]; then
+    echo "Backup creation failed"
+    exit 1
+  fi
+}
+
+apk add velero velero-compat velero-restore-helper jq
+install_velero
+test_velero

--- a/images/velero-plugin-for-aws/tests/main.tf
+++ b/images/velero-plugin-for-aws/tests/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    velero                = string
+    velero-plugin-for-aws = string
+  })
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "velero-plugin-for-aws"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    envs = {
+      "IMAGE_REGISTRY"   = data.oci_string.ref["velero-plugin-for-aws"].registry
+      "IMAGE_REPOSITORY" = data.oci_string.ref["velero-plugin-for-aws"].repo
+      "IMAGE_TAG"        = data.oci_string.ref["velero-plugin-for-aws"].pseudo_tag
+
+      "VELERO_IMAGE_REGISTRY"   = data.oci_string.ref["velero"].registry
+      "VELERO_IMAGE_REPOSITORY" = data.oci_string.ref["velero"].repo
+      "VELERO_IMAGE_TAG"        = data.oci_string.ref["velero"].pseudo_tag
+    }
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ]
+  }
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the velero helm chart."
+
+  steps = [
+    {
+      name = "Basic smoke test that providers install"
+      cmd  = "/tests/docker-test.sh"
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+
+  timeouts = {
+    # This can take a while since we're working in serial to avoid disk
+    # pressure
+    create = "15m"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1443,6 +1443,11 @@ module "velero-restore-helper" {
   target_repository = "${var.target_repository}/velero-restore-helper"
 }
 
+module "velero-plugin-for-aws" {
+  source            = "./images/velero-plugin-for-aws"
+  target_repository = "${var.target_repository}/velero-plugin-for-aws"
+}
+
 module "vertical-pod-autoscaler" {
   source            = "./images/vertical-pod-autoscaler"
   target_repository = "${var.target_repository}/vertical-pod-autoscaler"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [x] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes: we include the binary twice in different locations this is why we have bigger images because we use -compat here to make sure that we have that binary in the location where Dockerfile expects to be

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
