### PR TITLE
remove packages value from trust-manager

### DIFF
--- a/images/trust-manager/config/template.apko.yaml
+++ b/images/trust-manager/config/template.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - trust-manager
 
 accounts:
   groups:


### PR DESCRIPTION
_trust-manager_ is listed under both [packages](https://github.com/chainguard-images/images/blob/main/images/trust-manager/config/template.apko.yaml#L3) in template.apko.yaml and [extra_packages](https://github.com/chainguard-images/images/blob/main/images/trust-manager/config/main.tf#L9) in config/main.tf, causing a conflict and leading to the incorrect package selection.

To fix this, the pull request removes the redundant _trust-manager_ entry from the _packages_ field. This allows the build process to correctly select the appropriate package based on the extra_packages field.