### PR TITLE
Image for velero-restore-helper

### DIFF
--- a/images/velero-restore-helper/README.md
+++ b/images/velero-restore-helper/README.md
@@ -27,4 +27,13 @@ docker pull cgr.dev/chainguard/velero-restore-helper:latest
 
 <!--body:start-->
 Velero uses a helper init container when performing a FSB restore. By default, the image for this container is velero/velero-restore-helper:<VERSION>, where VERSION matches the version/tag of the main Velero image. You can customize the image that is used for this helper by creating a ConfigMap in the Velero namespace with the alternate image.
+
+## Installation and Usage
+
+```bash
+docker run cgr.dev/chainguard/velero-restore-helper:latest help
+```
+
+For more information, refer to the velero documentation:
+- [Velero GitHub](https://github.com/vmware-tanzu/velero)
 <!--body:end-->

--- a/images/velero-restore-helper/README.md
+++ b/images/velero-restore-helper/README.md
@@ -1,0 +1,30 @@
+<!--monopod:start-->
+# velero-restore-helper
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/velero-restore-helper` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/velero-restore-helper/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Backup and migrate Kubernetes applications and their persistent volumes
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/velero-restore-helper:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+Velero uses a helper init container when performing a FSB restore. By default, the image for this container is velero/velero-restore-helper:<VERSION>, where VERSION matches the version/tag of the main Velero image. You can customize the image that is used for this helper by creating a ConfigMap in the Velero namespace with the alternate image.
+<!--body:end-->

--- a/images/velero-restore-helper/README.md
+++ b/images/velero-restore-helper/README.md
@@ -26,7 +26,7 @@ docker pull cgr.dev/chainguard/velero-restore-helper:latest
 <!--getting:end-->
 
 <!--body:start-->
-Velero uses a helper init container when performing a FSB restore. By default, the image for this container is velero/velero-restore-helper:<VERSION>, where VERSION matches the version/tag of the main Velero image. You can customize the image that is used for this helper by creating a ConfigMap in the Velero namespace with the alternate image.
+Velero uses a helper init container when performing a filesystem restore (FSB in Velero's terminology). To use this image as the helper follow the [File System Backup](https://velero.io/docs/main/file-system-backup/#customize-restore-helper-container) documentation, and edit the provided `ConfigMap` to use `cgr.dev/chainguard/velero-restore-helper`.
 
 ## Installation and Usage
 

--- a/images/velero-restore-helper/config/latest.apko.yaml
+++ b/images/velero-restore-helper/config/latest.apko.yaml
@@ -1,0 +1,15 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: "/usr/bin/velero-restore-helper"

--- a/images/velero-restore-helper/config/main.tf
+++ b/images/velero-restore-helper/config/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = [
+    "velero",
+    "velero-restore-helper",
+    "velero-compat"
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/latest.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/velero-restore-helper/main.tf
+++ b/images/velero-restore-helper/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "velero-restore-helper" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.velero-restore-helper.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.velero-restore-helper.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.velero-restore-helper.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/velero-restore-helper/metadata.yaml
+++ b/images/velero-restore-helper/metadata.yaml
@@ -1,0 +1,13 @@
+name: velero-restore-helper
+image: cgr.dev/chainguard/velero-restore-helper
+logo: https://storage.googleapis.com/chainguard-academy/logos/velero-restore-helper.svg
+endoflife: ""
+console_summary: ""
+short_description: Backup and migrate Kubernetes applications and their persistent volumes
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/vmware-tanzu/velero/tree/main/cmd/velero-restore-helper
+keywords:
+  - application
+  - tools
+ 

--- a/images/velero-restore-helper/tests/docker-test.sh
+++ b/images/velero-restore-helper/tests/docker-test.sh
@@ -87,7 +87,7 @@ test_velero(){
 EOF
 
 
-  mkdir restore
+  mkdir /restore
 
   # Create a backup
   velero backup create my-backup --include-namespaces velero -w
@@ -115,6 +115,7 @@ EOF
     echo "Files exist in the /restore directory"
   else
     echo "No files found in the /restore directory"
+    exit 1
   fi
 
 }

--- a/images/velero-restore-helper/tests/docker-test.sh
+++ b/images/velero-restore-helper/tests/docker-test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Function to install Velero using Minio as the backup storage
+install_velero(){
+  kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/velero/main/examples/minio/00-minio-deployment.yaml
+
+  # Create a credentials file for Minio
+  cat <<EOF > credentials-velero
+  [default]
+  aws_access_key_id = minio
+  aws_secret_access_key = minio123
+EOF
+
+  velero install --bucket velero \
+                 --secret-file ./credentials-velero \
+                 --use-volume-snapshots=false \
+                 --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000 \
+                 --provider aws \
+                 --plugins velero/velero-plugin-for-aws:v1.9.1 \
+                 --image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+}
+
+# Function to wait for a pod with a specific label to be running
+wait_for_pod() {
+  local label=$1
+  local namespace=$2
+  local timeout=$3
+  local start_time=$(date +%s)
+  local end_time=$((start_time + timeout))
+
+  while true; do
+    if [ "$(date +%s)" -gt "$end_time" ]; then
+      echo "Timeout waiting for pod with label $label to be created"
+      exit 1
+    fi
+
+    if kubectl get pods -n "$namespace" -l "$label" 2>/dev/null | grep -q Running; then
+      break
+    fi
+
+    sleep 5
+  done
+}
+
+# Function to test Velero by creating a backup and restoring it
+test_velero(){
+
+  wait_for_pod "component=velero" "velero" 300
+
+  VELERO_POD_NAME=$(kubectl get pods -n velero -l component=velero -o jsonpath='{.items[0].metadata.name}')
+  STATUS=$(kubectl get pod $VELERO_POD_NAME -n velero -o jsonpath='{.status.phase}')
+
+  if [ "$STATUS" == "Running" ]; then
+    echo "Velero pod is running"
+  else
+    echo "Velero pod is not running"
+  fi
+
+  cat <<EOF | kubectl apply -f -
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: fs-restore-action-config
+    namespace: velero
+    labels:
+      velero.io/plugin-config: ""
+      velero.io/pod-volume-restore: RestoreItemAction
+  data:
+    image: ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}
+    cpuRequest: "200m"
+    memRequest: "128Mi"
+    cpuLimit: "200m"
+    memLimit: "128Mi"
+    secCtxRunAsUser: "1001"
+    secCtxRunAsGroup: "999"
+    secCtxAllowPrivilegeEscalation: "false"
+    secCtx: |
+      capabilities:
+        drop:
+        - ALL
+      allowPrivilegeEscalation: "false"
+      readOnlyRootFilesystem: "true"
+      runAsUser: 1001
+      runAsGroup: 999
+EOF
+
+
+  mkdir restore
+
+  # Create a backup
+  velero backup create my-backup --include-namespaces velero -w
+
+  cd /restore
+
+  # Perform restore from the specified directory and capture the restore name
+  velero restore create --from-backup my-backup -w > restore_name.txt
+
+  # Wait for the restore to complete
+  while true; do
+    restore_status=$(velero restore get -o json | jq -r '.status.phase')
+    if [ "$restore_status" == "Completed" ]; then
+      echo "Restore completed successfully"
+      break
+    elif [ "$restore_status" == "Failed" ]; then
+      echo "Restore failed"
+      exit 1
+    fi
+    sleep 10
+  done
+
+  # List the contents of the /restore directory and check if any output is produced
+  if ls -1 | grep -q .; then
+    echo "Files exist in the /restore directory"
+  else
+    echo "No files found in the /restore directory"
+  fi
+
+}
+
+apk add velero velero-compat velero-restore-helper jq
+install_velero
+test_velero

--- a/images/velero-restore-helper/tests/docker-test.sh
+++ b/images/velero-restore-helper/tests/docker-test.sh
@@ -110,7 +110,7 @@ EOF
     sleep 10
   done
 
-  # List the contents of the /restore directory and check if any output is produced
+  # List the contents of the /restore directory
   if ls -1 | grep -q .; then
     echo "Files exist in the /restore directory"
   else

--- a/images/velero-restore-helper/tests/main.tf
+++ b/images/velero-restore-helper/tests/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The image digests to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "velero-restore-helper"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    envs = {
+      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
+      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
+      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+    }
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ]
+  }
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the velero helm chart."
+
+  steps = [
+    {
+      name = "Basic smoke test that providers install"
+      cmd  = "/tests/docker-test.sh"
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+
+  timeouts = {
+    # This can take a while since we're working in serial to avoid disk
+    # pressure
+    create = "15m"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1428,6 +1428,11 @@ module "velero" {
   target_repository = "${var.target_repository}/velero"
 }
 
+module "velero-restore-helper" {
+  source            = "./images/velero-restore-helper"
+  target_repository = "${var.target_repository}/velero-restore-helper"
+}
+
 module "vertical-pod-autoscaler" {
   source            = "./images/vertical-pod-autoscaler"
   target_repository = "${var.target_repository}/vertical-pod-autoscaler"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [x] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
