### PR TITLE
feat(images): Add RStudio

### DIFF
--- a/images/rstudio/README.md
+++ b/images/rstudio/README.md
@@ -1,0 +1,38 @@
+<!--monopod:start-->
+# rstudio
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/rstudio` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/rstudio/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Minimal [RStudio](https://github.com/rstudio/rstudio) container image.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/rstudio:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Running the Image
+In order to run RStudio, execute the following command in a terminal:
+
+```bash
+docker run -it -p 8787:8787 cgr.dev/chainguard/rstudio:latest
+```
+
+The server will now start and the IDE will be accessible at [localhost:8787](http://localhost:8787) in your browser of choice.
+
+<!--body:end-->

--- a/images/rstudio/config/main.tf
+++ b/images/rstudio/config/main.tf
@@ -1,0 +1,89 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = ["rstudio"]
+}
+
+variable "environment" {
+  default = {}
+}
+
+module "accts" {
+  source = "../../../tflib/accts"
+  run-as = 65532
+  uid    = 65532
+  gid    = 65532
+  name   = "rstudio-server"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    environment = merge({
+      "CRAN" : "https://cloud.r-project.org"
+      "USER" : "rstudio-server"
+      "LANG" : "en_US.UTF-8"
+      "LANG_WHICH" : "en"
+      "LANG_WHERE" : "US"
+      "ENCODING" : "UTF-8"
+      "LANGUAGE" : "en_US.UTF-8"
+      "LC_CTYPE" : "en_US"
+      "TZ" : "UTC"
+    })
+    entrypoint = {
+      command = "/usr/bin/rserver"
+    }
+    paths = [{
+      path        = "/etc/R"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/etc/rstudio"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/usr/lib/R"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/usr/share/doc/R"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/var/run/rstudio-server"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+      }, {
+      path        = "/var/lib/rstudio-server"
+      type        = "directory"
+      uid         = module.accts.uid
+      gid         = module.accts.gid
+      permissions = 509
+      recursive   = true
+    }]
+  })
+}

--- a/images/rstudio/main.tf
+++ b/images/rstudio/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  source = "./config"
+}
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/rstudio/metadata.yaml
+++ b/images/rstudio/metadata.yaml
@@ -1,0 +1,12 @@
+name: rstudio
+image: cgr.dev/chainguard/rstudio
+logo: https://storage.googleapis.com/chainguard-academy/logos/rstudio.svg
+endoflife: ""
+console_summary: ""
+short_description: Minimal [RStudio](https://github.com/rstudio/rstudio) container image.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/rstudio/rstudio
+keywords:
+  - application
+  - ide

--- a/images/rstudio/tests/main.tf
+++ b/images/rstudio/tests/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "oci_exec_test" "smoke" {
+  digest = var.digest
+  script = "${path.module}/smoke.sh"
+}

--- a/images/rstudio/tests/smoke.sh
+++ b/images/rstudio/tests/smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+CONTAINER_NAME="rstudio-$(uuidgen)"
+
+RSTUDIO_PORT="${FREE_PORT}"
+
+REQUEST_RETRIES=10
+RETRY_DELAY=15
+
+declare -a expected_logs=(
+  "Adding user to cache"
+  "Running as server user"
+  "Initialized file locks"
+  "Connecting to sqlite3 database"
+  "Creating database connection pool"
+  "Creating secure key file"
+  "Using secure key file"
+)
+declare -a missing_logs=()
+
+# Validate RStudio installation
+# Must be ran before server starts
+docker run \
+  --rm \
+  -p "${RSTUDIO_PORT}":"${RSTUDIO_PORT}" \
+  -e "RS_LOG_LEVEL=debug" \
+  -e "RS_LOGGER_TYPE=stderr" \
+  --name "${CONTAINER_NAME}" \
+  --entrypoint rstudio-server \
+  "${IMAGE_NAME}" \
+  verify-installation
+
+# Run RStudio server
+docker run \
+  -d --rm \
+  -p "${RSTUDIO_PORT}":"${RSTUDIO_PORT}" \
+  -e "RS_LOG_LEVEL=debug" \
+  -e "RS_LOGGER_TYPE=stderr" \
+  --name "${CONTAINER_NAME}" \
+  "${IMAGE_NAME}" \
+  --www-port "${RSTUDIO_PORT}"
+
+# Stop container when script exits
+trap "docker stop ${CONTAINER_NAME}" EXIT
+
+# Validate that RStudio container logs contain expected log messages.
+TEST_validate_container_logs() {
+  for ((i=1; i<=${REQUEST_RETRIES}; i++)); do
+    local logs=$(docker logs "${CONTAINER_NAME}" 2>&1)
+    local logs_found=true
+
+    # Search the container logs for our expected log lines.
+    for log in "${expected_logs[@]}"; do
+      if ! echo "$logs" | grep -Fq "$log"; then
+        logs_found=false
+      fi
+    done
+
+    if $logs_found; then
+      return 0
+    elif [[ $i -lt ${REQUEST_RETRIES} ]]; then
+      echo "Some expected logs were missing. Retrying in ${RETRY_DELAY} seconds..."
+      sleep ${RETRY_DELAY}
+    fi
+  done
+
+  # After all retries, record the missing logs
+  for log in "${expected_logs[@]}"; do
+    if ! echo "${logs}" | grep -Fq "$log"; then
+      missing_logs+=("${log}")
+    fi
+  done
+
+  echo "FAILED: The following log lines where not found:"
+  printf '%s\n' "${missing_logs[@]}"
+  exit 1
+}
+
+# Check that RStudio responds 200 HTTP status code indicating it's operational.
+TEST_http_response() {
+  for ((i=1; i<=${REQUEST_RETRIES}; i++)); do
+    if [ $(curl -o /dev/null -s -w "%{http_code}" "http://localhost:${RSTUDIO_PORT}/unsupported_browser.htm") -eq 200 ]; then
+      return 0 
+    fi
+    sleep ${RETRY_DELAY}
+  done
+
+  echo "FAILED: Did not receive 200 HTTP response from RStudio after ${REQUEST_RETRIES} attempts."
+  exit 1
+}
+
+TEST_install_package() {
+  # Install R package
+  docker exec "${CONTAINER_NAME}" \
+    Rscript -e 'install.packages("ggplot2", repos = "https://cloud.r-project.org")'
+
+  # Import library
+  docker exec "${CONTAINER_NAME}" \
+    Rscript -e 'library("ggplot2")'
+}
+
+TEST_validate_container_logs
+TEST_http_response
+TEST_install_package

--- a/main.tf
+++ b/main.tf
@@ -1224,6 +1224,11 @@ module "rqlite" {
   target_repository = "${var.target_repository}/rqlite"
 }
 
+module "rstudio" {
+  source            = "./images/rstudio"
+  target_repository = "${var.target_repository}/rstudio"
+}
+
 module "ruby" {
   source            = "./images/ruby"
   target_repository = "${var.target_repository}/ruby"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [x] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
