### PR TITLE
[go] Only include openssh-client

### DIFF
--- a/images/go/config/template.apko.yaml
+++ b/images/go/config/template.apko.yaml
@@ -3,7 +3,7 @@ contents:
     - busybox
     - build-base
     - git
-    - openssh
+    - openssh-client
     # Go comes via var.extra_packages
 
 accounts:


### PR DESCRIPTION
I noticed while doing some image analysis that we're including `openssh-server` in the Go image. I don't see why this is needed, so following what the git image is doing and only include the client.