### PR TITLE
new image: aws-cli-v2

### DIFF
--- a/images/aws-cli-v2/README.md
+++ b/images/aws-cli-v2/README.md
@@ -1,0 +1,54 @@
+<!--monopod:start-->
+# aws-cli-v2
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/aws-cli-v2` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/aws-cli-v2/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Minimal [aws-cli v2](https://github.com/aws/aws-cli/tree/v2) container image.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/aws-cli-v2:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+Before using the aws-cli Chainguard Image, you need to configure your [AWS credentials](https://github.com/aws/aws-cli/tree/v2#getting-started). There are a number of ways you can do this, so we encourage you to review the official [AWS credentials documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#configure-precedence) to determine what method works best for you.
+
+AWS credentials and configurations are typically stored in a directory named `.aws`. Assuming you've already set up your AWS credentials locally, you can share them from your host machine to a container by mounting this directory as a volume. The following command follows this method to pass along AWS credentials in order to retrieve a list of EKS clusters: 
+
+```shell
+docker run --rm -it -v ~/.aws:/home/nonroot/.aws:ro cgr.dev/chainguard/aws-cli-v2:latest s3 ls
+```
+
+Note that Chainguard's aws-cli Image has a single user `nonroot` with uid `65532`, belonging to gid `65532`.; the previous command mounts the local `.aws` directory under this user's home directory. Be aware that if you follow this method you may need to adjust the permissions of your local credentials file in order for the container to be able to read it.
+
+You can get help with any command when using the AWS Command Line Interface (AWS CLI) by following any command name with `help`. For example, the following command displays help for the general AWS CLI options and the available top-level commands:
+
+```shell
+docker run --rm cgr.dev/chainguard/aws-cli-v2:latest help
+```
+
+The following command displays help information for the `aws ec2 run-instances` command:
+
+```shell
+docker run --rm cgr.dev/chainguard/aws-cli-v2:latest ec2 run-instances help
+```
+
+Please refer to the official [Getting Started](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-help.html) guide for more information.
+<!--body:end-->

--- a/images/aws-cli-v2/config/latest.apko.yaml
+++ b/images/aws-cli-v2/config/latest.apko.yaml
@@ -1,0 +1,15 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: aws

--- a/images/aws-cli-v2/config/latest.apko.yaml
+++ b/images/aws-cli-v2/config/latest.apko.yaml
@@ -11,5 +11,8 @@ accounts:
       gid: 65532
   run-as: 65532
 
+environment:
+  LD_LIBRARY_PATH: /usr/lib/aws-cli
+
 entrypoint:
   command: aws

--- a/images/aws-cli-v2/config/main.tf
+++ b/images/aws-cli-v2/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = ["aws-cli-v2"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/latest.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/aws-cli-v2/main.tf
+++ b/images/aws-cli-v2/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/aws-cli-v2/metadata.yaml
+++ b/images/aws-cli-v2/metadata.yaml
@@ -1,0 +1,12 @@
+name: aws-cli-v2
+image: cgr.dev/chainguard/aws-cli-v2
+logo: https://storage.googleapis.com/chainguard-academy/logos/aws-cli.svg
+endoflife: ""
+console_summary: ""
+short_description: Minimal [aws-cli v2](https://github.com/aws/aws-cli/tree/v2) container image.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/aws/aws-cli/tree/v2
+keywords:
+  - application
+  - tools

--- a/images/aws-cli-v2/tests/01-help.sh
+++ b/images/aws-cli-v2/tests/01-help.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+docker run --rm "${IMAGE_NAME}" --version
+docker run --rm "${IMAGE_NAME}" help
+docker run --rm "${IMAGE_NAME}" ec2 help
+docker run --rm "${IMAGE_NAME}" ec2 run-instances help

--- a/images/aws-cli-v2/tests/main.tf
+++ b/images/aws-cli-v2/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "help" {
+  digest = var.digest
+  script = "${path.module}/01-help.sh"
+}

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,11 @@ module "aws-cli" {
   target_repository = "${var.target_repository}/aws-cli"
 }
 
+module "aws-cli-v2" {
+  source            = "./images/aws-cli-v2"
+  target_repository = "${var.target_repository}/aws-cli-v2"
+}
+
 module "aws-ebs-csi-driver" {
   source            = "./images/aws-ebs-csi-driver"
   target_repository = "${var.target_repository}/aws-ebs-csi-driver"


### PR DESCRIPTION
## New Image Pull Request Template

Pretty much a copy of aws-cli image

Fixes: https://github.com/chainguard-images/images/issues/2404

basic test

![image](https://github.com/chainguard-images/images/assets/627278/3be3ebd7-aa0f-46f3-8275-3a78aab520df)

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

![image](https://github.com/chainguard-images/images/assets/627278/3be3ebd7-aa0f-46f3-8275-3a78aab520df)

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [x] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
