### PR TITLE
ability to override init container name for velero-plugin-for-aws

### DIFF
--- a/images/velero-plugin-for-aws/tests/docker-test.sh
+++ b/images/velero-plugin-for-aws/tests/docker-test.sh
@@ -2,6 +2,8 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
+# Image using an init-container to 
+INIT_CONTAINER_NAME=${INIT_CONTAINER_NAME:-testing-velero-plugin-for-aws:unused}
 
 # Function to install Velero using Minio as the backup storage
 install_velero(){
@@ -21,11 +23,11 @@ EOF
                  --provider aws \
                  --plugins ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG} \
                  --image ${VELERO_IMAGE_REGISTRY}/${VELERO_IMAGE_REPOSITORY}:${VELERO_IMAGE_TAG} --dry-run -oyaml > velero-install.yaml
-              
+
   awk '
   BEGIN {change=0}
   /initContainers:/ {inInit=1}
-  inInit && /name: testing-velero-plugin-for-aws:unused/ && !change {print "          name: velero-plugin-for-aws"; change=1; next}
+  inInit && /name: '$INIT_CONTAINER_NAME'/ && !change {print "          name: velero-plugin-for-aws"; change=1; next}
   {print}
   ' velero-install.yaml > updated-velero-install.yaml
 

--- a/images/velero-plugin-for-aws/tests/main.tf
+++ b/images/velero-plugin-for-aws/tests/main.tf
@@ -13,6 +13,11 @@ variable "digests" {
   })
 }
 
+variable "init_container_name" {
+  description = "Init container name to override"
+  default     = "testing-velero-plugin-for-aws:unused"
+}
+
 data "oci_string" "ref" {
   for_each = var.digests
   input    = each.value
@@ -33,6 +38,8 @@ resource "imagetest_harness_k3s" "this" {
       "VELERO_IMAGE_REGISTRY"   = data.oci_string.ref["velero"].registry
       "VELERO_IMAGE_REPOSITORY" = data.oci_string.ref["velero"].repo
       "VELERO_IMAGE_TAG"        = data.oci_string.ref["velero"].pseudo_tag
+
+      "INIT_CONTAINER_NAME" = var.init_container_name
     }
     mounts = [
       {


### PR DESCRIPTION
This is required to tests pass if repo/image name is different than `velero-plugin-for-aws`.