### PR TITLE
node: remove python 3.11 as a dev dependency

### DIFF
--- a/images/node/main.tf
+++ b/images/node/main.tf
@@ -16,9 +16,9 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.latest-config.config
   extra_dev_packages = [
-    "yarn",
     "build-base",
-    "python-3.11",
+    "npm",
+    "yarn",
   ]
 }
 


### PR DESCRIPTION
Also add `npm` explicitly as a dev dependency.

Python 3.11 has been a dev-only dependency since the inception of dev variants for node, back in https://github.com/chainguard-images/images/pull/479 -- it's not clear from that PR why it's needed, and I don't think we have a test that exercises the behavior.

If Python is needed, we should upgrade to 3.12 if possible, and ensure we can smoothly upgrade without toil in the future.

If Python isn't needed, we should remove it. If folks need it, they can `apk add` it themselves.