### PR TITLE
Fix test issue where invalid container name was used

### DIFF
--- a/images/velero-plugin-for-aws/tests/docker-test.sh
+++ b/images/velero-plugin-for-aws/tests/docker-test.sh
@@ -3,7 +3,7 @@
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
 # Image using an init-container to 
-INIT_CONTAINER_NAME=${INIT_CONTAINER_NAME:-testing-velero-plugin-for-aws:unused}
+INIT_CONTAINER_NAME=${INIT_CONTAINER_NAME:-testing-velero-plugin-for-aws}
 
 # Function to install Velero using Minio as the backup storage
 install_velero(){


### PR DESCRIPTION
Removing colon from image name for test, resolves:

```bash
The Deployment "velero" is invalid: spec.template.spec.initContainers[0].name: Invalid value: "chainguard-velero-plugin-for-aws:unused": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

