### PR TITLE
add cert-manager-webhook-pdns

### DIFF
--- a/images/cert-manager-webhook-pdns/README.md
+++ b/images/cert-manager-webhook-pdns/README.md
@@ -1,0 +1,40 @@
+<!--monopod:start-->
+# cert-manager-webhook-pdns
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/cert-manager-webhook-pdns` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/cert-manager-webhook-pdns/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+A PowerDNS webhook for cert-manager
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/cert-manager-webhook-pdns:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+This image is a drop-in replacement for the upstream image.
+You can run it using the Helm Chart with:
+
+```shell
+$ helm repo add cert-manager-webhook-pdns https://zachomedia.github.io/cert-manager-webhook-pdns
+$ helm install cert-manager-webhook-pdns cert-manager-webhook-pdns/cert-manager-webhook-pdns \
+    --set image.registry=cgr.dev/chainguard/cert-manager-webhook-pdns \
+    --set image.tag=latest
+```
+<!--body:end-->

--- a/images/cert-manager-webhook-pdns/config/main.tf
+++ b/images/cert-manager-webhook-pdns/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = ["cert-manager-webhook-pdns"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/cert-manager-webhook-pdns/config/template.apko.yaml
+++ b/images/cert-manager-webhook-pdns/config/template.apko.yaml
@@ -1,0 +1,18 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  GROUP_NAME: "acme.zacharyseguin.ca"
+
+entrypoint:
+  command: webhook

--- a/images/cert-manager-webhook-pdns/main.tf
+++ b/images/cert-manager-webhook-pdns/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "cert-manager-webhook-pdns" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.cert-manager-webhook-pdns.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.cert-manager-webhook-pdns.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.cert-manager-webhook-pdns.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/cert-manager-webhook-pdns/metadata.yaml
+++ b/images/cert-manager-webhook-pdns/metadata.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-webhook-pdns
+image: cgr.dev/chainguard/cert-manager-webhook-pdns
+logo: https://storage.googleapis.com/chainguard-academy/logos/cert-manager-webhook-pdns.svg
+endoflife: ""
+console_summary: ""
+short_description: A PowerDNS webhook for cert-manager
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/zachomedia/cert-manager-webhook-pdns
+keywords:
+  - application
+  - kubernetes
+  - cert-manager

--- a/images/cert-manager-webhook-pdns/tests/01-smoke.sh
+++ b/images/cert-manager-webhook-pdns/tests/01-smoke.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+PASSWORD=$(echo -n 'admin:admin' | base64)
+
+# https://github.com/PowerDNS-Admin/PowerDNS-Admin/blob/master/docs/API.md
+kubectl expose deployment powerdns -n powerdns
+
+# Fixes the following issue:
+# Error presenting challenge: pdns.acme.zacharyseguin.ca is forbidden: User "system:serviceaccount:default:cert-manager" cannot create resource "pdns" in API group "acme.zacharyseguin.ca" at the cluster scope
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-pdns
+rules:
+- apiGroups: ["acme.zacharyseguin.ca"]
+  resources: ["pdns"]
+  verbs: ["create", "update", "delete", "get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-pdns
+subjects:
+- kind: ServiceAccount
+  name: cert-manager
+  namespace: cert-manager
+roleRef:
+  kind: ClusterRole
+  name: cert-manager-pdns
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+# https://github.com/zachomedia/cert-manager-webhook-pdns?tab=readme-ov-file#issuerclusterissuer
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pdns-api-key
+  namespace: ${NAMESPACE}
+type: Opaque
+data:
+  key: ${PASSWORD}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+  namespace: ${NAMESPACE}
+spec:
+  acme:
+    email: certificates@example.ca
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - dns01:
+          webhook:
+            groupName: acme.zacharyseguin.ca
+            solverName: pdns
+            config:
+              host: http://powerdns.powerdns.svc.cluster.local:8081
+              apiKeySecretRef:
+                name: pdns-api-key
+                key: key
+              serverID: localhost
+EOF
+
+sleep 10
+
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-example-ca
+  namespace: ${NAMESPACE}
+spec:
+  secretName: example-com-tls
+  dnsNames:
+  - example.ca
+  - www.example.ca
+  issuerRef:
+    name: letsencrypt-staging
+    kind: Issuer
+    group: cert-manager.io
+EOF
+
+# Wait a while until the request get hooked and reconciled. 
+sleep 10
+
+kubectl get events -A --sort-by='.lastTimestamp' | tail -n 10
+kubectl get secrets -A
+kubectl get certificates.cert-manager.io -A
+kubectl get challenges.acme.cert-manager.io -A
+
+logs=$(kubectl logs -l app.kubernetes.io/name=cert-manager-webhook-pdns -n ${NAMESPACE})
+
+echo "$logs" | grep -q "\"Presenting challenge\" dnsName=\"example.ca\" resolvedZone=\"ca.\""
+echo "$logs" | grep -q "\"Presenting challenge\" dnsName=\"www.example.ca\" resolvedZone=\"ca.\""

--- a/images/cert-manager-webhook-pdns/tests/main.tf
+++ b/images/cert-manager-webhook-pdns/tests/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "oci_exec_test" "help" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME -h"
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "cert-manager-webhook-pdns"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ],
+    envs = {
+      "NAMESPACE" = "cert-manager-webhook-pdns-${random_pet.suffix.id}"
+    }
+  }
+}
+
+resource "random_pet" "suffix" {}
+
+module "helm" {
+  source = "../../../tflib/imagetest/helm"
+
+  name      = "cert-manager-webhook-pdns-${random_pet.suffix.id}"
+  namespace = "cert-manager-webhook-pdns-${random_pet.suffix.id}"
+  repo      = "https://zachomedia.github.io/cert-manager-webhook-pdns"
+  chart     = "cert-manager-webhook-pdns"
+  timeout   = "600s"
+
+  values = {
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = data.oci_string.ref.pseudo_tag
+    }
+  }
+}
+
+module "helm-cert-manager" {
+  source = "../../../tflib/imagetest/helm"
+
+  name      = "cert-manager"
+  repo      = "https://charts.jetstack.io"
+  chart     = "cert-manager"
+  namespace = "cert-manager"
+  timeout   = "600s"
+
+  values = {
+    installCRDs = "true"
+  }
+}
+
+module "helm-powerdns" {
+  source = "../../../tflib/imagetest/helm"
+
+  name      = "powerdns"
+  repo      = "https://k8s-at-home.com/charts"
+  chart     = "powerdns"
+  namespace = "powerdns"
+  timeout   = "600s"
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "basic"
+  description = "Basic functionality of cert-manager-webhook-pdns installed in a Kubernetes cluster"
+
+  steps = [
+    {
+      # App needs cert-manager and its CRDs as a prerequisite.
+      name = "cert-manager install"
+      cmd  = module.helm-cert-manager.install_cmd
+    },
+    {
+      # Smoke tests needs PowerDNS.
+      name = "PowerDNS install"
+      cmd  = module.helm-powerdns.install_cmd
+    },
+    {
+      name = "Helm install"
+      cmd  = module.helm.install_cmd
+    },
+    {
+      name = "Run smoke tests"
+      cmd  = "/tests/01-smoke.sh"
+    },
+  ]
+
+  labels = {
+    type = "k8s",
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -242,6 +242,11 @@ module "cert-manager" {
   target_repository = "${var.target_repository}/cert-manager"
 }
 
+module "cert-manager-webhook-pdns" {
+  source            = "./images/cert-manager-webhook-pdns"
+  target_repository = "${var.target_repository}/cert-manager-webhook-pdns"
+}
+
 module "cfssl" {
   source            = "./images/cfssl"
   target_repository = "${var.target_repository}/cfssl"


### PR DESCRIPTION
> **Note**
> **Before:** `71.5MB, 113 packages, 13 CVEs`
> **After:** `57.4MB, 101 packages, 0-CVE`

## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [X] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [X] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [X] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [X] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [X] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [X] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [X] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [X] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes: Their Deployment uses Readiness probes so additional functional tests might not need to.

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [X] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [X] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [X] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [X] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [X] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [X] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [X] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [X] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [X] A README file has been provided and it follows the README template.
