### PR TITLE
velero plugin for csi

### DIFF
--- a/images/velero-plugin-for-csi/README.md
+++ b/images/velero-plugin-for-csi/README.md
@@ -1,0 +1,49 @@
+<!--monopod:start-->
+# velero-plugin-for-csi
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/velero-plugin-for-csi` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/velero-plugin-for-csi/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Velero plugins for integrating with CSI snapshot API
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/velero-plugin-for-csi:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+
+# Usage
+
+To get more detail about how to use this plugin, please refer to the [Container Storage Interface Snapshot Support in Velero
+](https://velero.io/docs/v1.13/csi/).
+
+To integrate Velero with the CSI volume snapshot APIs, you must enable the EnableCSI feature flag and install the Velero CSI plugins on the Velero server.
+
+Both of these can be added with the velero install command.
+
+```
+velero install \
+--features=EnableCSI \
+--plugins=<object storage plugin>,cgr.dev/chainguard/velero-plugin-for-csi:latest \
+...
+```
+
+For the object storage plugin, you can use the appropriate object storage plugin for your cloud provider. For example, for AWS, you can use the AWS plugin available in Chainguard image catalog: **cgr.dev/chainguard/velero-plugin-for-aws:latest**
+
+
+<!--body:end-->

--- a/images/velero-plugin-for-csi/config/main.tf
+++ b/images/velero-plugin-for-csi/config/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = []
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/bin/cp-plugin /plugins/velero-plugin-for-csi /target/velero-plugin-for-csi"
+    }
+  })
+}
+

--- a/images/velero-plugin-for-csi/main.tf
+++ b/images/velero-plugin-for-csi/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+locals {
+  components = toset(["velero-plugin-for-csi"])
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" {
+  for_each       = local.components
+  source         = "./config"
+  extra_packages = [each.key, "${each.key}-compat"]
+}
+
+module "velero-plugin-for-csi" {
+  for_each          = local.components
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config[each.key].config
+
+  build-dev    = true
+  main_package = each.key
+}
+
+data "oci_ref" "velero" {
+  ref = "cgr.dev/chainguard/velero:latest"
+}
+
+data "oci_ref" "velero-plugin-for-aws" {
+  ref = "cgr.dev/chainguard/velero-plugin-for-aws:latest"
+}
+
+module "test" {
+  source = "./tests"
+  digests = {
+    velero                = "${data.oci_ref.velero.ref}@${data.oci_ref.velero.digest}"
+    velero-plugin-for-aws = "${data.oci_ref.velero-plugin-for-aws.ref}@${data.oci_ref.velero-plugin-for-aws.digest}"
+    velero-plugin-for-csi = module.velero-plugin-for-csi["velero-plugin-for-csi"].image_ref
+  }
+}
+
+resource "oci_tag" "latest" {
+  for_each   = local.components
+  depends_on = [module.test]
+  digest_ref = module.velero-plugin-for-csi[each.key].image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  for_each   = local.components
+  depends_on = [module.test]
+  digest_ref = module.velero-plugin-for-csi[each.key].dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/velero-plugin-for-csi/metadata.yaml
+++ b/images/velero-plugin-for-csi/metadata.yaml
@@ -1,0 +1,13 @@
+name: velero-plugin-for-csi
+image: cgr.dev/chainguard/velero-plugin-for-csi
+logo: https://storage.googleapis.com/chainguard-academy/logos/velero-plugin-for-csi.svg
+endoflife: ""
+console_summary: ""
+short_description: Velero plugins for integrating with CSI snapshot API
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/vmware-tanzu/velero-plugin-for-csi
+keywords:  
+  - application  
+  - kubernetes  
+

--- a/images/velero-plugin-for-csi/tests/docker-test.sh
+++ b/images/velero-plugin-for-csi/tests/docker-test.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/docs/deploy-1.17-and-later.md
+# Function to deploy VolumeSnapshotClasses, VolumeSnapshotContents, VolumeSnapshots CRDs, and snapshot controller
+deploy_snapshotter() {
+    # Set the snapshotter branch and version
+    SNAPSHOTTER_BRANCH="release-6.3"
+    SNAPSHOTTER_VERSION="v6.3.3"
+
+    # Apply VolumeSnapshot CRDs
+    echo "Applying VolumeSnapshotClasses CRD..."
+    kubectl apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
+
+    echo "Applying VolumeSnapshotContents CRD..."
+    kubectl apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
+
+    echo "Applying VolumeSnapshots CRD..."
+    kubectl apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_BRANCH}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
+
+    # Create snapshot controller
+    echo "Creating snapshot controller..."
+    kubectl apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+    kubectl apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
+
+    echo "CSI Snapshotter CRDs and Snapshot Controller have been applied successfully."
+}
+
+
+# Function to install Velero using Minio as the backup storage
+install_velero(){
+  # find the default storage class
+  defaultStorageClass=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+  kubectl apply -f https://raw.githubusercontent.com/vmware-tanzu/velero/main/examples/minio/00-minio-deployment.yaml
+
+  # Create a credentials file for Minio
+  cat <<EOF > credentials-velero
+  [default]
+  aws_access_key_id = minio
+  aws_secret_access_key = minio123
+EOF
+
+  wait_for_pod "component=minio" "velero" 300
+
+  deploy_snapshotter
+
+  wait_for_pod "app=snapshot-controller" "kube-system" 300
+
+  echo "Snapshot controller is running"
+
+  velero install --bucket velero \
+                 --secret-file ./credentials-velero \
+                 --use-volume-snapshots=true \
+                 --backup-location-config region=minio,s3ForcePathStyle="true",s3Url=http://minio.velero.svc:9000 \
+                 --provider aws \
+                 --plugins ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG},${AWS_IMAGE_REGISTRY}/${AWS_IMAGE_REPOSITORY}:${AWS_IMAGE_TAG} \
+                 --image ${VELERO_IMAGE_REGISTRY}/${VELERO_IMAGE_REPOSITORY}:${VELERO_IMAGE_TAG} --dry-run -oyaml \
+                 --features=EnableCSI > velero-install.yaml
+
+ awk '
+ BEGIN {inInit=0; changed1=0; changed2=0}
+ /initContainers:/ {inInit=1}
+ inInit && /name: '$CSI_INIT_CONTAINER_NAME'/ && !changed1 {print "          name: velero-plugin-for-csi"; changed1=1; next}
+ inInit && /name: '$AWS_INIT_CONTAINER_NAME'/ && !changed2 {print "          name: velero-plugin-for-aws"; changed2=1; next}
+ {print}
+ ' velero-install.yaml > updated-velero-install.yaml
+
+  # this is a workaround to fix the issue with the CRD not being created
+  set +e
+  kubectl apply -f updated-velero-install.yaml
+  sleep 10
+  set -e
+  kubectl apply -f updated-velero-install.yaml
+}
+
+# Function to wait for a pod with a specific label to be running
+wait_for_pod() {
+  local label=$1
+  local namespace=$2
+  local timeout=$3
+  local start_time=$(date +%s)
+  local end_time=$((start_time + timeout))
+
+  while true; do
+    if [ "$(date +%s)" -gt "$end_time" ]; then
+      echo "Timeout waiting for pod with label $label to be created"
+      exit 1
+    fi
+
+    if kubectl get pods -n "$namespace" -l "$label" 2>/dev/null | grep -q Running; then
+      break
+    fi
+
+    sleep 5
+  done
+}
+
+# Function to test Velero by creating a backup and restoring it
+test_velero(){
+
+  wait_for_pod "component=velero" "velero" 300
+
+  VELERO_POD_NAME=$(kubectl get pods -n velero -l component=velero -o jsonpath='{.items[0].metadata.name}')
+  STATUS=$(kubectl get pod $VELERO_POD_NAME -n velero -o jsonpath='{.status.phase}')
+  TEST_NAMESPACE=nginx-example
+  
+  if [ "$STATUS" == "Running" ]; then
+    echo "Velero pod is running"
+  else
+    echo "Velero pod is not running"
+  fi
+
+  # find the default storage class
+  defaultStorageClass=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+  
+  # create the VolumeSnapshotClass
+  cat <<EOF | kubectl apply -f -
+    apiVersion: snapshot.storage.k8s.io/v1
+    kind: VolumeSnapshotClass
+    metadata:
+      name: local-path-snapshot-class
+    driver: $defaultStorageClass
+    deletionPolicy: Delete
+    parameters:
+      # Replace these with your MinIO S3 storage details and any additional CSI driver parameters
+      s3Url: "http://minio.velero.svc:9000" # Your MinIO service URL
+      s3BucketName: "velero" # Your MinIO bucket name for snapshots
+      s3Region: "us-east-1"
+      s3AccessKey: "minio" # Use Kubernetes secrets for production
+      s3SecretKey: "minio123" # Use Kubernetes secrets for production
+EOF
+
+# https://raw.githubusercontent.com/vmware-tanzu/velero/main/examples/nginx-app/with-pv.yaml
+  cat <<EOk > base.yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-example
+  labels:
+    app: nginx
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nginx-logs
+  namespace: nginx-example
+  labels:
+    app: nginx
+spec:
+  storageClassName: $defaultStorageClass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: nginx-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        pre.hook.backup.velero.io/container: fsfreeze
+        pre.hook.backup.velero.io/command: '["/sbin/fsfreeze", "--freeze", "/var/log/nginx"]'
+        post.hook.backup.velero.io/container: fsfreeze
+        post.hook.backup.velero.io/command: '["/sbin/fsfreeze", "--unfreeze", "/var/log/nginx"]'
+    spec:
+      volumes:
+        - name: nginx-logs
+          persistentVolumeClaim:
+            claimName: nginx-logs
+      containers:
+        - image: nginx:1.17.6
+          name: nginx
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - mountPath: /var/log/nginx
+              name: nginx-logs
+              readOnly: false
+        - image: ubuntu:bionic
+          name: fsfreeze
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /var/log/nginx
+              name: nginx-logs
+              readOnly: false
+          command:
+            - /bin/bash
+            - -c
+            - sleep infinity
+EOk
+
+  kubectl apply -f base.yaml
+
+  wait_for_pod "app=nginx" "nginx-example" 300
+
+  # Create a test backup
+  velero backup create nginx-backup --include-namespaces $TEST_NAMESPACE -w
+
+  # Wait for backup to complete
+  echo "Waiting for backup to complete..."
+
+  # Simulate a disaster
+  kubectl delete namespace $TEST_NAMESPACE
+
+  # Restore from backup
+  velero restore create --from-backup nginx-backup -w
+  
+  restore_status=$(velero restore get -o json | jq -r '.status.phase')
+  if [ "$restore_status" == "Completed" ]; then
+     echo "Restore completed successfully"
+     echo "Listing pods and PVCs"
+     kubectl get pods,pvc -n $TEST_NAMESPACE
+     # check the PVC is already bound to the application and the nginx pod is up and runninng again
+      kubectl wait --for=condition=ready pod --selector app=nginx -n $TEST_NAMESPACE
+     echo "Backup creation successful"
+    break
+  elif [ "$restore_status" == "Failed" ]; then
+    echo "Backup creation failed"
+    exit 1
+  fi
+}
+
+apk add velero velero-compat velero-restore-helper jq
+install_velero
+test_velero

--- a/images/velero-plugin-for-csi/tests/main.tf
+++ b/images/velero-plugin-for-csi/tests/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digests" {
+  description = "The image digests to run tests over."
+  type = object({
+    velero                = string
+    velero-plugin-for-aws = string
+    velero-plugin-for-csi = string
+  })
+}
+
+variable "init_container_names" {
+  description = "Init container names to override"
+  default = {
+    velero-plugin-for-csi = "testing-velero-plugin-for-csi:unused"
+    velero-plugin-for-aws = "chainguard-velero-plugin-for-aws:unused"
+  }
+}
+
+data "oci_string" "ref" {
+  for_each = var.digests
+  input    = each.value
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "velero-plugin-for-csi"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    envs = {
+      "IMAGE_REGISTRY"   = data.oci_string.ref["velero-plugin-for-csi"].registry
+      "IMAGE_REPOSITORY" = data.oci_string.ref["velero-plugin-for-csi"].repo
+      "IMAGE_TAG"        = data.oci_string.ref["velero-plugin-for-csi"].pseudo_tag
+
+      "AWS_IMAGE_REGISTRY"   = data.oci_string.ref["velero-plugin-for-aws"].registry
+      "AWS_IMAGE_REPOSITORY" = data.oci_string.ref["velero-plugin-for-aws"].repo
+      "AWS_IMAGE_TAG"        = data.oci_string.ref["velero-plugin-for-aws"].pseudo_tag
+
+      "VELERO_IMAGE_REGISTRY"   = data.oci_string.ref["velero"].registry
+      "VELERO_IMAGE_REPOSITORY" = data.oci_string.ref["velero"].repo
+      "VELERO_IMAGE_TAG"        = data.oci_string.ref["velero"].pseudo_tag
+
+      "CSI_INIT_CONTAINER_NAME" = var.init_container_names["velero-plugin-for-csi"]
+      "AWS_INIT_CONTAINER_NAME" = var.init_container_names["velero-plugin-for-aws"]
+    }
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ]
+  }
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the velero helm chart."
+
+  steps = [
+    {
+      name = "Basic smoke test that providers install"
+      cmd  = "/tests/docker-test.sh"
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+
+  timeouts = {
+    # This can take a while since we're working in serial to avoid disk
+    # pressure
+    create = "15m"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1478,14 +1478,19 @@ module "velero" {
   target_repository = "${var.target_repository}/velero"
 }
 
+module "velero-restore-helper" {
+  source            = "./images/velero-restore-helper"
+  target_repository = "${var.target_repository}/velero-restore-helper"
+}
+
 module "velero-plugin-for-aws" {
   source            = "./images/velero-plugin-for-aws"
   target_repository = "${var.target_repository}/velero-plugin-for-aws"
 }
 
-module "velero-restore-helper" {
-  source            = "./images/velero-restore-helper"
-  target_repository = "${var.target_repository}/velero-restore-helper"
+module "velero-plugin-for-csi" {
+  source            = "./images/velero-plugin-for-csi"
+  target_repository = "${var.target_repository}/velero-plugin-for-csi"
 }
 
 module "vertical-pod-autoscaler" {


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [x] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes: we included the binary twice but for two different locations

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
