### PR TITLE
chore(harbor): Rename package for harbor core to harbor

### DIFF
--- a/images/harbor/main.tf
+++ b/images/harbor/main.tf
@@ -17,9 +17,11 @@ locals {
     "registryctl",
   ])
 
-  packages = {
+  packages = merge({
     for k, v in local.components : k => "harbor-${k}"
-  }
+    }, {
+    "core" : "harbor"
+  })
 
   repositories = {
     for k, v in local.components : k => "${var.target_repository}-${k}"


### PR DESCRIPTION
Done to simplify package names in version streams

