### PR TITLE
adds compat package for postgres-operator image

### DIFF
--- a/images/postgres-operator/config/main.tf
+++ b/images/postgres-operator/config/main.tf
@@ -8,6 +8,7 @@ variable "extra_packages" {
   description = "The additional packages to install"
   default = [
     "postgres-operator",
+    "postgres-operator-compat",
   ]
 }
 

--- a/images/postgres-operator/config/template.apko.yaml
+++ b/images/postgres-operator/config/template.apko.yaml
@@ -12,4 +12,4 @@ accounts:
   run-as: 65532
 
 entrypoint:
-  command: "postgres-operator"
+  command: "/postgres-operator"


### PR DESCRIPTION
A minor addition to #2420, I missed adding the compat package that softlinks the binary as helm charts usually expects and this fixes it