### PR TITLE
Add gitsign image.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -42,15 +42,14 @@ provider "registry.terraform.io/chainguard-dev/cosign" {
 }
 
 provider "registry.terraform.io/chainguard-dev/imagetest" {
-  version = "0.0.13"
+  version = "0.0.14"
   hashes = [
-    "h1:/il2CSlimP9pU64vIw0v7BhbKatRXARrWlVN915lzps=",
-    "h1:dGbbnAy/v9gRiSSi0HpDUyUYpBYtJu4JeU5aQjg2f0E=",
-    "zh:438a40bb17cf5e557d7de65a5efbc2515b62adc3c17350fa3142abc3794e2c8a",
-    "zh:87b981f005b91c434ac838cec48139ffc229b74172dc6d9e9f47eacdec5d88fa",
+    "h1:s0YOuywxEcQTtLYESjG3CuFV/KiZzaLVLNQgKF4IS2E=",
+    "zh:3b312b9d6c8e62720cd10f543998dfa99c14b4b6d0b023f861b9eb1fc215d8ce",
+    "zh:45f128b50dd763f14440a3283ff099a11ee3a98febfa48a202055fe6f9b94010",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:aa461dc29d480aa483af4f2febd35028ec48e7d3063a25fb8199875a20b32d7b",
-    "zh:ee05c8c40acd1d475e4e145884f7870a594c1db9e765f69ecfcf2fb69b151b78",
+    "zh:c194b8456c3842ef8430b433ce9c3b1c4c9bcfdd8783f87dde8062fc043d1182",
+    "zh:e8bd48f901103cf96da6504c04dc6baf82e4dbd988baeed95b4cd4ac8a32f15f",
   ]
 }
 

--- a/images/gitsign/README.md
+++ b/images/gitsign/README.md
@@ -1,0 +1,13 @@
+<!--monopod:start-->
+# gitsign
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/gitsign` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/gitsign/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->

--- a/images/gitsign/config/main.tf
+++ b/images/gitsign/config/main.tf
@@ -1,0 +1,14 @@
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = ["busybox", "git", "gitsign", "gitsign-config"]
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/usr/bin/git"
+    }
+    cmd = "help"
+  })
+}

--- a/images/gitsign/main.tf
+++ b/images/gitsign/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/gitsign/metadata.yaml
+++ b/images/gitsign/metadata.yaml
@@ -1,0 +1,14 @@
+name: gitsign
+image: cgr.dev/chainguard/gitsign
+logo: ""
+endoflife: ""
+console_summary: ""
+short_description:
+  Minimalist Wolfi-based Gitsign images for signing and verifying Git commits
+  using Sigstore.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/sigstore/gitsign
+keywords:
+  - application
+  - tools

--- a/images/gitsign/tests/main.tf
+++ b/images/gitsign/tests/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "git-help" {
+  digest = var.digest
+  script = "docker run --rm -t $IMAGE_NAME help"
+}
+
+data "oci_exec_test" "gitsign-help" {
+  digest = var.digest
+  script = "docker run --entrypoint gitsign --rm -t $IMAGE_NAME help"
+}

--- a/main.tf
+++ b/main.tf
@@ -500,6 +500,11 @@ module "gitness" {
   target_repository = "${var.target_repository}/gitness"
 }
 
+module "gitsign" {
+  source            = "./images/gitsign"
+  target_repository = "${var.target_repository}/gitsign"
+}
+
 module "glibc-dynamic" {
   source            = "./images/glibc-dynamic"
   target_repository = "${var.target_repository}/glibc-dynamic"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

```
# Size
┌──────────────────────────────────┬────────────┬──────────────┐
│              Image               │ Compressed │ Uncompressed │
├──────────────────────────────────┼────────────┼──────────────┤
│ ghcr.io/sigstore/gitsign:v0.10.1 │ 37 MB      │ 92 MB        │
│ ttl.sh/wlynch/gitsign            │ 36 MB      │ 97 MB        │
│ Δ                                │ -3.46%     │ 5.25%        │
└──────────────────────────────────┴────────────┴──────────────┘
```

- [ ] The Image is smaller in size than its common public counterpart.
- [x] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

I don't know 😅 

Upstream image is based off of cgr.dev/chainguard/git:latest-dev, so these should be roughly equivalent. The main difference here is we're including the top level `/etc/gitconfig` to auto-configure gitsign, but this isn't 5MB of data.

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

```
┌──────────────────────────────────┬──────────┬──────┬────────┬─────┬────────────┬─────────┬───────────────────────────┐
│              Image               │ Critical │ High │ Medium │ Low │ Negligible │ Unknown │        Scanned At         │
├──────────────────────────────────┼──────────┼──────┼────────┼─────┼────────────┼─────────┼───────────────────────────┤
│ ghcr.io/sigstore/gitsign:v0.10.1 │ 0        │ 0    │ 4      │ 0   │ 0          │ 0       │ 2024-04-02T14:26:14-04:00 │
│ ttl.sh/wlynch/gitsign            │ 0        │ 0    │ 0      │ 0   │ 0          │ 0       │ 2024-04-02T14:24:59-04:00 │
└──────────────────────────────────┴──────────┴──────┴────────┴─────┴────────────┴─────────┴───────────────────────────┘
```

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [x] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
