### PR TITLE
minor update to Python Image README

### DIFF
--- a/images/python/README.md
+++ b/images/python/README.md
@@ -38,6 +38,12 @@ docker pull cgr.dev/chainguard/python:latest
 docker pull cgr.dev/chainguard/python:latest-dev
 ```
 
+Note that in order to access the shell in the `python:latest-dev` image, you'll need to include an `--entrypoint` option, as in the following example.
+
+```sh
+docker run -it --entrypoint bin/bash chainguard/python:latest-dev
+```
+
 ## Usage
 
 The python image can be used directly for simple cases, or with a multi-stage build using python-dev as the build container.

--- a/images/python/README.md
+++ b/images/python/README.md
@@ -41,7 +41,7 @@ docker pull cgr.dev/chainguard/python:latest-dev
 Note that in order to access the shell in the `python:latest-dev` image, you'll need to include an `--entrypoint` option, as in the following example.
 
 ```sh
-docker run -it --entrypoint bin/bash chainguard/python:latest-dev
+docker run -it --entrypoint /bin/bash chainguard/python:latest-dev
 ```
 
 ## Usage


### PR DESCRIPTION
Per [this slack convo](https://chainguard-dev.slack.com/archives/C04PYHWPE1F/p1711726846991599) it was determined that we should document how to access the shell in the `python:latest-dev` image. This PR adds a line explaining how to do so and an example command one can run to open up the shell.