### PR TITLE
fix metadata issue to resolve invalid bundle error

### DIFF
--- a/images/cert-manager-webhook-pdns/metadata.yaml
+++ b/images/cert-manager-webhook-pdns/metadata.yaml
@@ -10,4 +10,5 @@ upstream_url: https://github.com/zachomedia/cert-manager-webhook-pdns
 keywords:
   - application
   - kubernetes
-  - cert-manager
+  - certmanager
+  - powerdns


### PR DESCRIPTION
Fixes `bundle item "cert-manager" is invalid: each bundle item must match "^[a-z]+(:[a-z]+)?$"`