### PR TITLE
chore(wasm): use regular Go with experimental flags

### DIFF
--- a/images/wasmer/tests/02-use.sh
+++ b/images/wasmer/tests/02-use.sh
@@ -14,8 +14,10 @@ chmod -R 777 "${TMPDIR}"
 cp helloworld.go "${TMPDIR}"
 docker run --rm -v "${TMPDIR}:/work" \
   -w /work \
-  tinygo/tinygo:0.31.1 \
-    tinygo build -o wasmtest -target wasi helloworld.go
+  --env GOARCH=wasm \
+  --env GOOS=wasip1 \
+  cgr.dev/chainguard/go:latest \
+    build -o wasmtest helloworld.go
 
 echo "${IMAGE_NAME}"
 


### PR DESCRIPTION
Go 1.21 introduced an experimental mode for building WebAssembly System Interface applications. This change switches back to using our Chainguard Go Image with the experimental flags.

Ref: https://tip.golang.org/doc/go1.21#wasip1