### PR TITLE
Add iptables to istio-install-cni image

### DIFF
--- a/images/istio/configs/install-cni/main.tf
+++ b/images/istio/configs/install-cni/main.tf
@@ -7,6 +7,7 @@ terraform {
 variable "extra_packages" {
   description = "The additional packages to install (e.g. istio-install-cni, istio-cni...)"
   default = [
+    "iptables",
     "istio-install-cni",
     "istio-install-cni-compat",
     "istio-cni",


### PR DESCRIPTION
The istio-install-cni image needs `iptables` to function correctly: 

https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni#L16
https://github.com/istio/istio/blob/master/tools/istio-iptables/pkg/README.md