### PR TITLE
feat(harbor): Add trivy adapter image

### DIFF
--- a/images/harbor/README.md
+++ b/images/harbor/README.md
@@ -44,7 +44,8 @@ helm install harbor harbor/harbor \
   --set jobservice.image.repository=cgr.dev/chainguard/harbor-jobservice,jobservice.image.tag=latest \
   --set portal.image.repository=cgr.dev/chainguard/harbor-portal,portal.image.tag=latest \
   --set registry.registry.image.repository=cgr.dev/chainguard/harbor-registry,registry.registry.image.tag=latest \
-  --set registry.registryctl.image.repository=cgr.dev/chainguard/harbor-registryctl,registry.registryctl.image.tag=latest
+  --set registry.registryctl.image.repository=cgr.dev/chainguard/harbor-registryctl,registry.registryctl.image.tag=latest \
+  --set trivy.image.repository=cgr.dev/chainguard/harbor-trivy-adapter,trivy.image.tag=latest
 ```
 
 You will need to override the `image` and `tag` values for each image like we've done here to point to Chainguard's Harbor images and tags.

--- a/images/harbor/config/main.tf
+++ b/images/harbor/config/main.tf
@@ -15,6 +15,7 @@ locals {
     "portal" : "nginx -g 'daemon off;'"
     "registry" : "/usr/bin/registry_DO_NOT_USE_GC serve /etc/registry/config.yml"
     "registryctl" : "/harbor/harbor_registryctl -c /etc/registryctl/config.yml",
+    "trivy-adapter" : "/usr/bin/scanner-trivy",
   }
 
   certs_path = {
@@ -139,6 +140,18 @@ locals {
       local.harbor_path,
       local.registry_conf_path,
     ]
+    "trivy-adapter" : [
+      local.certs_path,
+    ]
+  }
+
+  users = {
+    "core" : "harbor",
+    "jobservice" : "harbor",
+    "portal" : "nginx",
+    "registry" : "harbor",
+    "registryctl" : "harbor",
+    "trivy-adapter" : "scanner",
   }
 
   work-dirs = {
@@ -147,6 +160,7 @@ locals {
     "portal" : "/",
     "registry" : "/",
     "registryctl" : "/",
+    "trivy-adapter" : "/",
   }
 }
 
@@ -165,7 +179,7 @@ module "accts" {
   run-as = 65532
   uid    = 65532
   gid    = 65532
-  name   = var.component == "portal" ? "nginx" : "harbor"
+  name   = local.users[var.component]
 }
 
 output "config" {

--- a/images/harbor/main.tf
+++ b/images/harbor/main.tf
@@ -15,12 +15,15 @@ locals {
     "portal",
     "registry",
     "registryctl",
+    "trivy-adapter",
   ])
 
   packages = merge({
-    for k, v in local.components : k => "harbor-${k}"
+    for k, v in local.components : k => ["harbor-${k}", "busybox"]
     }, {
-    "core" : "harbor"
+    "core" : ["harbor", "busybox"]
+    }, {
+    "trivy-adapter" : ["harbor-scanner-trivy", "trivy", "busybox"]
   })
 
   repositories = {
@@ -32,7 +35,7 @@ module "latest-config" {
   for_each       = local.components
   source         = "./config"
   component      = each.key
-  extra_packages = [local.packages[each.key], "busybox"]
+  extra_packages = local.packages[each.key]
 }
 
 module "latest" {

--- a/images/harbor/main.tf
+++ b/images/harbor/main.tf
@@ -19,11 +19,11 @@ locals {
   ])
 
   packages = merge({
-    for k, v in local.components : k => ["harbor-${k}", "busybox"]
+    for k, v in local.components : k => ["harbor-${k}"]
     }, {
-    "core" : ["harbor", "busybox"]
+    "core" : ["harbor"]
     }, {
-    "trivy-adapter" : ["harbor-scanner-trivy", "trivy", "busybox"]
+    "trivy-adapter" : ["harbor-scanner-trivy", "trivy"]
   })
 
   repositories = {

--- a/images/harbor/tests/main.tf
+++ b/images/harbor/tests/main.tf
@@ -8,11 +8,12 @@ terraform {
 variable "digests" {
   description = "The image digests to run tests over."
   type = object({
-    core        = string
-    jobservice  = string
-    portal      = string
-    registry    = string
-    registryctl = string
+    core          = string
+    jobservice    = string
+    portal        = string
+    registry      = string
+    registryctl   = string
+    trivy-adapter = string
   })
 }
 
@@ -75,6 +76,12 @@ module "helm" {
         image = {
           repository = data.oci_string.ref["registryctl"].registry_repo
           tag        = data.oci_string.ref["registryctl"].pseudo_tag
+        }
+      }
+      trivy = {
+        image = {
+          repository = data.oci_string.ref["trivy-adapter"].registry_repo
+          tag        = data.oci_string.ref["trivy-adapter"].pseudo_tag
         }
       }
     }


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [x] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [x] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
