### PR TITLE
fix(conda): Initialize and enter base environment at startup

### DIFF
--- a/images/conda/config/template.apko.yaml
+++ b/images/conda/config/template.apko.yaml
@@ -2,18 +2,13 @@ contents:
   packages:
     - busybox
     - conda
+    - conda-base
+    - conda-wrapper
 
 accounts:
-  groups:
-    - groupname: nonroot
-      gid: 65532
-  users:
-    - username: nonroot
-      uid: 65532
-      gid: 65532
-  run-as: 65532
+  run-as: 0
 
 entrypoint:
-  command: /usr/bin/conda
+  command: /usr/bin/conda-wrapper
 
 cmd: --help


### PR DESCRIPTION
Adds the base environment as well as a wrapper for initialization out of the box

Also runs image as root so that conda recognizes the base env exists

