### PR TITLE
add neuvector-prometheus-exporter

### DIFF
--- a/images/neuvector-prometheus-exporter/README.md
+++ b/images/neuvector-prometheus-exporter/README.md
@@ -1,0 +1,53 @@
+<!--monopod:start-->
+# neuvector-prometheus-exporter
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/neuvector-prometheus-exporter` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/neuvector-prometheus-exporter/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Prometheus exporter and Grafana template for NeuVector container security platform.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/neuvector-prometheus-exporter:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+Add the NeuVector Helm repository to your repositories list:
+
+```shell
+helm repo add neuvector https://neuvector.github.io/neuvector-helm/
+helm repo update
+```
+
+Next, install the NeuVector Prometheus Exporter with the following command:
+
+```sh
+helm install neuvector-prometheus-exporter neuvector/monitor \
+    --namespace neuvector \
+    --create-namespace \
+    --set exporter.apiSvc=neuvector-svc-controller:10443 \
+    --set exporter.image.repository=cgr.dev/chainguard/neuvector-prometheus-exporter \
+    --set exporter.image.tag=<set to the latest chainguard tag>
+```
+
+Jump to the official [Helm Chart](https://github.com/neuvector/neuvector-helm/blob/master/charts/monitor/README.md) for more detailed usage.
+
+P.S: The Exporter will not work without the NeuVector Core Service. Install the [neuvector/core](https://github.com/neuvector/neuvector-helm/tree/master/charts/core) first.
+
+<!--body:end-->

--- a/images/neuvector-prometheus-exporter/config/main.tf
+++ b/images/neuvector-prometheus-exporter/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = ["neuvector-prometheus-exporter"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/neuvector-prometheus-exporter/config/template.apko.yaml
+++ b/images/neuvector-prometheus-exporter/config/template.apko.yaml
@@ -1,0 +1,15 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: python3 /usr/bin/nv_exporter.py

--- a/images/neuvector-prometheus-exporter/main.tf
+++ b/images/neuvector-prometheus-exporter/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "neuvector-prometheus-exporter" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.neuvector-prometheus-exporter.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.neuvector-prometheus-exporter.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.neuvector-prometheus-exporter.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/neuvector-prometheus-exporter/metadata.yaml
+++ b/images/neuvector-prometheus-exporter/metadata.yaml
@@ -1,0 +1,14 @@
+name: neuvector-prometheus-exporter
+image: cgr.dev/chainguard/neuvector-prometheus-exporter
+logo: https://storage.googleapis.com/chainguard-academy/logos/neuvector-prometheus-exporter.svg
+endoflife: ""
+console_summary: ""
+short_description: Prometheus exporter and Grafana template for NeuVector container security platform.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/neuvector/prometheus-exporter
+keywords:
+  - application
+  - prometheus
+  - grafana
+  - neuvector

--- a/images/neuvector-prometheus-exporter/tests/main.tf
+++ b/images/neuvector-prometheus-exporter/tests/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "imagetest_inventory" "this" {}
+
+resource "random_pet" "suffix" {}
+
+module "helm-neuvector" {
+  source = "../../../tflib/imagetest/helm"
+
+  name      = "neuvector-core-${random_pet.suffix.id}"
+  namespace = "neuvector"
+  repo      = "https://neuvector.github.io/neuvector-helm"
+  chart     = "core"
+}
+
+module "helm" {
+  source = "../../../tflib/imagetest/helm"
+
+  name      = "neuvector-prometheus-exporter-${random_pet.suffix.id}"
+  namespace = "neuvector"
+  repo      = "https://neuvector.github.io/neuvector-helm"
+  chart     = "monitor"
+
+  values = {
+    exporter = {
+      apiSvc = "neuvector-svc-controller:10443"
+    }
+  }
+}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "neuvector-prometheus-exporter"
+  inventory = data.imagetest_inventory.this
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of neuvector-prometheus-exporter."
+
+  steps = [
+    {
+      name = "Helm install neuvector dependency"
+      cmd  = module.helm-neuvector.install_cmd
+    },
+    {
+      name = "Helm install"
+      cmd  = module.helm.install_cmd
+    },
+
+    {
+      name = "Set image"
+      cmd  = <<EOF
+kubectl set image -n neuvector deployment/neuvector-prometheus-exporter-pod neuvector-prometheus-exporter-pod="${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+       EOF
+    },
+    {
+      name  = "Ensure it comes up healthy"
+      cmd   = <<EOF
+kubectl logs -n neuvector --selector app=neuvector-prometheus-exporter-pod
+kubectl rollout status -n neuvector deployment/neuvector-prometheus-exporter-pod --timeout=120s
+kubectl wait -n neuvector --for=condition=ready pod --selector app=neuvector-prometheus-exporter-pod
+       EOF
+      retry = { attempts = 3, delay = "2s", factor = 2 }
+    },
+    {
+      name  = "Test metrics"
+      cmd   = <<EOF
+apk add curl prometheus
+kubectl port-forward -n neuvector svc/neuvector-prometheus-exporter 8068 &
+until curl -L http://localhost:8068; do sleep 1; done
+set -o errexit -o nounset -o errtrace -o pipefail -x
+curl -s http://localhost:8068 | promtool check metrics || [ $? -eq 3 ] # Exit code 3 means the lint error, it's fine
+EOF
+      retry = { attempts = 5, delay = "5s", factor = 2 }
+    },
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+
+  timeouts = {
+    create = "15m"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -960,6 +960,11 @@ module "netcat" {
   target_repository = "${var.target_repository}/netcat"
 }
 
+module "neuvector-prometheus-exporter" {
+  source            = "./images/neuvector-prometheus-exporter"
+  target_repository = "${var.target_repository}/neuvector-prometheus-exporter"
+}
+
 module "newrelic-fluent-bit-output" {
   source            = "./images/newrelic-fluent-bit-output"
   target_repository = "${var.target_repository}/newrelic-fluent-bit-output"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
