### PR TITLE
Add step cli and step-ca

### DIFF
--- a/images/step-ca/README.md
+++ b/images/step-ca/README.md
@@ -1,0 +1,28 @@
+<!--monopod:start-->
+# step-ca
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/step-ca` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/step-ca/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+[step-ca](https://smallstep.com/docs/step-ca) is an online Certificate Authority (CA) for secure, automated X.509 and SSH certificate management
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/step-ca:latest
+```
+<!--getting:end-->
+
+<!--body:start--><!--body:end-->

--- a/images/step-ca/config/main.tf
+++ b/images/step-ca/config/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "step-ca",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/step-ca/config/template.apko.yaml
+++ b/images/step-ca/config/template.apko.yaml
@@ -1,0 +1,16 @@
+contents:
+  packages: []
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/step-ca
+cmd: --help

--- a/images/step-ca/main.tf
+++ b/images/step-ca/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "step-ca" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev      = true
+  extra_packages = ["step"]
+}
+
+module "test" {
+  source            = "./tests"
+  digest            = module.step-ca.image_ref
+  target_repository = var.target_repository
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.step-ca.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.step-ca.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/step-ca/main.tf
+++ b/images/step-ca/main.tf
@@ -15,9 +15,7 @@ module "step-ca" {
   name              = basename(path.module)
   target_repository = var.target_repository
   config            = module.config.config
-
-  build-dev      = true
-  extra_packages = ["step"]
+  build-dev         = true
 }
 
 module "test" {

--- a/images/step-ca/metadata.yaml
+++ b/images/step-ca/metadata.yaml
@@ -7,4 +7,9 @@ short_description: "[step-ca](https://smallstep.com/docs/step-ca) is an online C
 compatibility_notes: ""
 readme_file: README.md
 upstream_url: https://github.com/smallstep/certificates
-keywords: []
+keywords:
+  - application
+  - developer
+  - kubernetes
+  - security
+  - tools

--- a/images/step-ca/metadata.yaml
+++ b/images/step-ca/metadata.yaml
@@ -1,0 +1,10 @@
+name: step-ca
+image: cgr.dev/chainguard/step-ca
+logo: https://storage.googleapis.com/chainguard-academy/logos/step-ca.svg
+endoflife: ""
+console_summary: ""
+short_description: "[step-ca](https://smallstep.com/docs/step-ca) is an online Certificate Authority (CA) for secure, automated X.509 and SSH certificate management"
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/smallstep/certificates
+keywords: []

--- a/images/step-ca/tests/k8s-test.sh
+++ b/images/step-ca/tests/k8s-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+# Function to install step-ca
+install_step_ca() {
+    helm repo add smallstep https://smallstep.github.io/helm-charts/
+    helm repo update
+    helm install --create-namespace -n step-ca \
+        --set image.repository=${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} --set image.tag=${IMAGE_TAG} \
+        --set command="{/usr/bin/step-ca}" \
+        step-certificates smallstep/step-certificates
+    # step-certificates smallstep/step-certificates \
+}
+
+test_helm_install() {
+    # Test if step-ca is installed and pod is ready in a loop
+    while ! kubectl -n step-ca get pods -o jsonpath='{.items[1].status.containerStatuses[0].ready}' | grep -q true; do
+        sleep 15
+    done
+}
+
+apk add helm
+
+install_step_ca
+test_helm_install

--- a/images/step-ca/tests/k8s-test.sh
+++ b/images/step-ca/tests/k8s-test.sh
@@ -2,17 +2,6 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# # Function to install step-ca
-# install_step_ca() {
-#     helm repo add smallstep https://smallstep.github.io/helm-charts/
-#     helm repo update
-#     helm install --create-namespace -n step-ca \
-#         --set image.repository=${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} --set image.tag=${IMAGE_TAG} \
-#         --set command="{/usr/bin/step-ca}" \
-#         step-certificates smallstep/step-certificates
-#     # step-certificates smallstep/step-certificates \
-# }
-
 declare -a expected_logs=(
     "Building new tls configuration using step-ca x509 Signer Interface"
     "Starting Smallstep CA"

--- a/images/step-ca/tests/k8s-test.sh
+++ b/images/step-ca/tests/k8s-test.sh
@@ -2,25 +2,58 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-# Function to install step-ca
-install_step_ca() {
-    helm repo add smallstep https://smallstep.github.io/helm-charts/
-    helm repo update
-    helm install --create-namespace -n step-ca \
-        --set image.repository=${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} --set image.tag=${IMAGE_TAG} \
-        --set command="{/usr/bin/step-ca}" \
-        step-certificates smallstep/step-certificates
-    # step-certificates smallstep/step-certificates \
-}
+# # Function to install step-ca
+# install_step_ca() {
+#     helm repo add smallstep https://smallstep.github.io/helm-charts/
+#     helm repo update
+#     helm install --create-namespace -n step-ca \
+#         --set image.repository=${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} --set image.tag=${IMAGE_TAG} \
+#         --set command="{/usr/bin/step-ca}" \
+#         step-certificates smallstep/step-certificates
+#     # step-certificates smallstep/step-certificates \
+# }
 
-test_helm_install() {
+declare -a expected_logs=(
+    "Building new tls configuration using step-ca x509 Signer Interface"
+    "Starting Smallstep CA"
+    "Serving HTTPS on :9000 ..."
+)
+declare -a missing_logs=()
+
+# Loop to check the helm chart deployed and pod is ready
+verify_helm_install() {
     # Test if step-ca is installed and pod is ready in a loop
     while ! kubectl -n step-ca get pods -o jsonpath='{.items[1].status.containerStatuses[0].ready}' | grep -q true; do
         sleep 15
     done
 }
 
-apk add helm
+# Check to see if pod logs contain the expected log lines
+test_validate_pod_logs() {
+    local logs=$(kubectl logs -n step-ca step-ca-step-certificates-0 -c step-certificates)
+    local logs_found=true
+    # Search the pod logs for our expected log lines
+    for log in "${expected_logs[@]}"; do
+        if ! echo "$logs" | grep -Fq "$log"; then
+            logs_found=false
+        fi
+    done
 
-install_step_ca
-test_helm_install
+    if $logs_found; then
+        return 0
+    fi
+
+    # Record missing logs
+    for log in "${expected_logs[@]}"; do
+        if ! echo "${logs}" | grep -Fq "$log"; then
+            missing_logs+=("${log}")
+        fi
+    done
+
+    echo "FAILED: The following log lines were not found:"
+    printf '%s\n' "${missing_logs[@]}"
+    exit 1
+}
+
+verify_helm_install
+test_validate_pod_logs

--- a/images/step-ca/tests/main.tf
+++ b/images/step-ca/tests/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The digest of the image"
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+variable "target_repository" {
+  description = "The docker repo name"
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "step-ca"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    envs = {
+      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
+      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
+      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+    }
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ]
+  }
+}
+
+resource "imagetest_feature" "helm-install" {
+  name    = "step-ca"
+  harness = imagetest_harness_k3s.this
+
+  description = "Testing step-ca helm deployment in k3s cluster."
+
+  steps = [
+    {
+      name = "Test the image deployment"
+      cmd  = "/tests/k8s-test.sh"
+    }
+  ]
+
+  timeouts = {
+    # Bump the default, cassandra is stupid big.
+    create = "3m"
+  }
+}

--- a/images/step-cli/README.md
+++ b/images/step-cli/README.md
@@ -1,0 +1,28 @@
+<!--monopod:start-->
+# step-cli
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/step-cli` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/step-cli/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+[step-cli](https://smallstep.com/docs/step-cli) is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/step-cli:latest
+```
+<!--getting:end-->
+
+<!--body:start--><!--body:end-->

--- a/images/step-cli/config/main.tf
+++ b/images/step-cli/config/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default = [
+    "step",
+  ]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/step-cli/config/template.apko.yaml
+++ b/images/step-cli/config/template.apko.yaml
@@ -11,6 +11,13 @@ accounts:
       gid: 65532
   run-as: 65532
 
+# paths:
+#   - path: /tmp
+#     type: directory
+#     permissions: 0o777
+#     uid: 65532
+#     gid: 65532
+
 entrypoint:
   command: step
 cmd: --help

--- a/images/step-cli/config/template.apko.yaml
+++ b/images/step-cli/config/template.apko.yaml
@@ -1,0 +1,16 @@
+contents:
+  packages: []
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: step
+cmd: --help

--- a/images/step-cli/config/template.apko.yaml
+++ b/images/step-cli/config/template.apko.yaml
@@ -11,13 +11,6 @@ accounts:
       gid: 65532
   run-as: 65532
 
-# paths:
-#   - path: /tmp
-#     type: directory
-#     permissions: 0o777
-#     uid: 65532
-#     gid: 65532
-
 entrypoint:
   command: step
 cmd: --help

--- a/images/step-cli/main.tf
+++ b/images/step-cli/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "step-cli" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev = true
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.step-cli.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.step-cli.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.step-cli.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/step-cli/metadata.yaml
+++ b/images/step-cli/metadata.yaml
@@ -7,4 +7,9 @@ short_description: "[step-cli](https://smallstep.com/docs/step-cli) is an easy-t
 compatibility_notes: ""
 readme_file: README.md
 upstream_url: https://github.com/smallstep/cli
-keywords: []
+keywords:
+  - application
+  - developer
+  - kubernetes
+  - security
+  - tools

--- a/images/step-cli/metadata.yaml
+++ b/images/step-cli/metadata.yaml
@@ -1,0 +1,10 @@
+name: step-cli
+image: cgr.dev/chainguard/step-cli
+logo: https://storage.googleapis.com/chainguard-academy/logos/step-cli.svg
+endoflife: ""
+console_summary: ""
+short_description: "[step-cli](https://smallstep.com/docs/step-cli) is an easy-to-use CLI tool for building, operating, and automating Public Key Infrastructure (PKI) systems and workflows"
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/smallstep/cli
+keywords: []

--- a/images/step-cli/tests/main.tf
+++ b/images/step-cli/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "version" {
+  digest = var.digest
+  script = "docker run --rm $IMAGE_NAME version"
+}

--- a/images/step-cli/tests/main.tf
+++ b/images/step-cli/tests/main.tf
@@ -10,5 +10,5 @@ variable "digest" {
 
 data "oci_exec_test" "generate_otp" {
   digest = var.digest
-  script = "docker run --rm -v $PWD/step:/home/step $IMAGE_NAME crypto otp generate --issuer smallstep.com --account name@smallstep.com --qr /home/step/smallstep.png"
+  script = "docker run --rm $IMAGE_NAME crypto otp generate --issuer smallstep.com --account name@smallstep.com --qr /home/nonroot/smallstep.png"
 }

--- a/images/step-cli/tests/main.tf
+++ b/images/step-cli/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_exec_test" "version" {
+data "oci_exec_test" "generate_otp" {
   digest = var.digest
-  script = "docker run --rm $IMAGE_NAME version"
+  script = "docker run --rm -v $PWD/step:/home/step $IMAGE_NAME crypto otp generate --issuer smallstep.com --account name@smallstep.com --qr /home/step/smallstep.png"
 }

--- a/main.tf
+++ b/main.tf
@@ -1385,6 +1385,16 @@ module "statsd" {
   target_repository = "${var.target_repository}/statsd"
 }
 
+module "step-ca" {
+  source            = "./images/step-ca"
+  target_repository = "${var.target_repository}/step-ca"
+}
+
+module "step-cli" {
+  source            = "./images/step-cli"
+  target_repository = "${var.target_repository}/step-cli"
+}
+
 module "stunnel" {
   source            = "./images/stunnel"
   target_repository = "${var.target_repository}/stunnel"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
