### PR TITLE
newrelic-nri-statsd

### DIFF
--- a/images/newrelic-nri-statsd/README.md
+++ b/images/newrelic-nri-statsd/README.md
@@ -1,0 +1,48 @@
+<!--monopod:start-->
+# newrelic-nri-statsd
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/newrelic-nri-statsd` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/newrelic-nri-statsd/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+The StatsD integration lets you easily get StatsD data into New Relic
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/newrelic-nri-statsd:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+
+## Usage
+
+To run the container, you can use the following command:
+
+```bash
+docker run \
+  -d --restart unless-stopped \
+  --name newrelic-statsd \
+  -h $(hostname) \
+  -e NR_ACCOUNT_ID=YOUR_ACCOUNT_ID \
+  -e NR_API_KEY=NEW_RELIC_LICENSE_KEY \
+  -p 8125:8125/udp \
+  cgr.dev/chainguard/newrelic-nri-statsd:latest
+```
+
+Here is the link to get more detail about it, [official documentation](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/statsd/statsd-monitoring-integration/).
+
+
+<!--body:end-->

--- a/images/newrelic-nri-statsd/config/main.tf
+++ b/images/newrelic-nri-statsd/config/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  // TODO: Add any other packages here you want to conditionally include,
+  // or update this default to [] if this isn't a version stream image.
+  default = [
+    "newrelic-nri-statsd",
+    # "newrelic-nri-statsd-compat",
+    "busybox",
+  ]
+}
+module "accts" {
+  source = "../../../tflib/accts"
+}
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    entrypoint = {
+      command = "/home/nonroot/nri-statsd.sh"
+    },
+    work-dir = "/home/nonroot"
+  })
+}

--- a/images/newrelic-nri-statsd/main.tf
+++ b/images/newrelic-nri-statsd/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+variable "license_key" {}
+
+module "newrelic-nri-statsd" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+
+  build-dev    = true
+  main_package = "newrelic-nri-statsd"
+}
+
+module "test" {
+  source      = "./tests"
+  digest      = module.newrelic-nri-statsd.image_ref
+  license_key = var.license_key
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.newrelic-nri-statsd.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.newrelic-nri-statsd.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/newrelic-nri-statsd/metadata.yaml
+++ b/images/newrelic-nri-statsd/metadata.yaml
@@ -1,0 +1,13 @@
+name: newrelic-nri-statsd
+image: cgr.dev/chainguardnewrelic-nri-statsd
+logo: https://storage.googleapis.com/chainguard-academy/logos/newrelic-nri-statsd.svg
+endoflife: ""
+console_summary: ""
+short_description: The StatsD integration lets you easily get StatsD data into New Relic
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/newrelic/nri-statsd
+keywords:
+  - application
+  - newrelic
+  - statsd

--- a/images/newrelic-nri-statsd/tests/main.tf
+++ b/images/newrelic-nri-statsd/tests/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The image digests to run tests over."
+}
+
+data "oci_string" "ref" {
+  input = var.digest
+}
+
+variable "license_key" {}
+
+data "oci_exec_test" "smoke" {
+  digest      = var.digest
+  script      = "./smoke.sh"
+  working_dir = path.module
+
+  env = [{
+    name  = "NR_API_KEY"
+    value = var.license_key
+  }]
+}

--- a/images/newrelic-nri-statsd/tests/smoke.sh
+++ b/images/newrelic-nri-statsd/tests/smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+container_name="newrelic-nri-statsd-${RANDOM}"
+
+# Step 0: Pull and run a StatsD Docker container
+echo "Starting StatsD Docker container..."
+docker run -d -e NR_API_KEY=${NR_API_KEY} -e NR_STATSD_METRICS_ADDR=":${FREE_PORT}" --name $container_name -p ${FREE_PORT}:${FREE_PORT} ${IMAGE_NAME}
+
+# wait for the container to be ready by checking the connection to 8125
+while ! nc -z localhost ${FREE_PORT}; do
+  echo "Waiting for StatsD Docker container to be ready..."
+  sleep 1
+done
+
+echo "StatsD Docker container is ready."

--- a/main.tf
+++ b/main.tf
@@ -1000,6 +1000,12 @@ module "newrelic-kubernetes" {
   license_key       = var.newrelic_license_key
 }
 
+module "newrelic-nri-statsd" {
+  source            = "./images/newrelic-nri-statsd"
+  target_repository = "${var.target_repository}/newrelic-nri-statsd"
+  license_key       = var.newrelic_license_key
+}
+
 module "newrelic-prometheus" {
   source            = "./images/newrelic-prometheus"
   target_repository = "${var.target_repository}/newrelic-prometheus"


### PR DESCRIPTION
## New Image Pull Request Template

waiting for this: 

- ~https://github.com/wolfi-dev/os/pull/16451~
- thanks to @EyeCantCU, we set entrypoint as `/home/nonroot/nri-statsd.sh` and it worked! 

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [x] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes: needs newrelic account

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [x] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes: needs newrelic account

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes: needs newrelic account

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [x] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
