### PR TITLE
Jenkins: add git and openssh-client

### DIFF
--- a/images/jenkins/config/template.apko.yaml
+++ b/images/jenkins/config/template.apko.yaml
@@ -1,6 +1,8 @@
 contents:
   packages:
     # jenkins and openjdk provided by extra_packages
+    - git
+    - openssh-client
 
 accounts:
   groups:


### PR DESCRIPTION
Added git to the Jenkins image. This change is necessary as the GitHub push webhook wasn't functioning without the presence of git in the image.