### PR TITLE
Deflake rabbitmq test

### DIFF
--- a/images/rabbitmq/tests/02-perf.sh
+++ b/images/rabbitmq/tests/02-perf.sh
@@ -17,28 +17,28 @@ loopback_users.guest = false
 log.console = true
 EOF
 
-docker network create rmq
+docker network create "$NETWORK_NAME"
 
-docker run -d --rm --network rmq --name rabbitmq \
+docker run -d --rm --network "$NETWORK_NAME" --name rabbitmq \
 	-v $(pwd)/dev.conf:/etc/rabbitmq/conf.d/10-defaults.conf \
 	-p 15672:15672 $IMAGE_NAME
 
 sleep 10
 
 # vary publishing rate
-docker run --rm --network rmq pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 20 --variable-rate 10:5 --variable-rate 1000:10 --variable-rate 500:5 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 20 --variable-rate 10:5 --variable-rate 1000:10 --variable-rate 500:5 --shutdown-timeout 0
 sleep 1
 
 # vary message size
-docker run --rm --network rmq pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 15 --variable-size 1000:5 --variable-size 10000:5 --variable-size 5000:5 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 15 --variable-size 1000:5 --variable-size 10000:5 --variable-size 5000:5 --shutdown-timeout 0
 sleep 1
 
 # try a json body
-docker run --rm --network rmq pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 15 --json-body --size 16000 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 15 --json-body --size 16000 --shutdown-timeout 0
 sleep 1
 
 # vary consumer latency
-docker run --rm --network rmq pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 30 --variable-latency 1000:15 --variable-latency 1000000:15 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 30 --variable-latency 1000:15 --variable-latency 1000000:15 --shutdown-timeout 0
 sleep 1
 
 # dump the server logs

--- a/images/rabbitmq/tests/02-perf.sh
+++ b/images/rabbitmq/tests/02-perf.sh
@@ -27,23 +27,23 @@ docker run -d --rm --network "$NETWORK_NAME" --name "$RANDOM_NAME" \
 sleep 10
 
 # vary publishing rate
-docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 20 --variable-rate 10:5 --variable-rate 1000:10 --variable-rate 500:5 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://"$RANDOM_NAME" -z 20 --variable-rate 10:5 --variable-rate 1000:10 --variable-rate 500:5 --shutdown-timeout 0
 sleep 1
 
 # vary message size
-docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 15 --variable-size 1000:5 --variable-size 10000:5 --variable-size 5000:5 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://"$RANDOM_NAME" -z 15 --variable-size 1000:5 --variable-size 10000:5 --variable-size 5000:5 --shutdown-timeout 0
 sleep 1
 
 # try a json body
-docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 15 --json-body --size 16000 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://"$RANDOM_NAME" -z 15 --json-body --size 16000 --shutdown-timeout 0
 sleep 1
 
 # vary consumer latency
-docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://rabbitmq -z 30 --variable-latency 1000:15 --variable-latency 1000000:15 --shutdown-timeout 0
+docker run --rm --network "$NETWORK_NAME" pivotalrabbitmq/perf-test:latest --uri amqp://"$RANDOM_NAME" -z 30 --variable-latency 1000:15 --variable-latency 1000000:15 --shutdown-timeout 0
 sleep 1
 
 # dump the server logs
-docker logs rabbitmq
+docker logs "$RANDOM_NAME"
 
 function cleanup {
   docker kill "$RANDOM_NAME"

--- a/images/rabbitmq/tests/02-perf.sh
+++ b/images/rabbitmq/tests/02-perf.sh
@@ -17,9 +17,10 @@ loopback_users.guest = false
 log.console = true
 EOF
 
+NETWORK_NAME="rmq-${RANDOM_NAME}"
 docker network create "$NETWORK_NAME"
 
-docker run -d --rm --network "$NETWORK_NAME" --name rabbitmq \
+docker run -d --rm --network "$NETWORK_NAME" --name "$RANDOM_NAME" \
 	-v $(pwd)/dev.conf:/etc/rabbitmq/conf.d/10-defaults.conf \
 	-p 15672:15672 $IMAGE_NAME
 
@@ -43,3 +44,9 @@ sleep 1
 
 # dump the server logs
 docker logs rabbitmq
+
+function cleanup {
+  docker kill "$RANDOM_NAME"
+  docker network rm "$NETWORK_NAME"
+}
+trap cleanup EXIT

--- a/images/rabbitmq/tests/main.tf
+++ b/images/rabbitmq/tests/main.tf
@@ -21,7 +21,7 @@ data "oci_exec_test" "perf" {
   digest = var.digest
   script = "${path.module}/02-perf.sh"
   env {
-    name  = "NETWORK_NAME"
-    value = "rmq-${random_pet.suffix.id}"
+    name  = "RANDOM_NAME"
+    value = random_pet.suffix.id
   }
 }

--- a/images/rabbitmq/tests/main.tf
+++ b/images/rabbitmq/tests/main.tf
@@ -16,6 +16,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm --entrypoint rabbitmqctl $IMAGE_NAME version"
 }
 
+# TODO: Convert to imagetest_harness_container when ready
 data "oci_exec_test" "perf" {
   digest = var.digest
   script = "${path.module}/02-perf.sh"

--- a/images/rabbitmq/tests/main.tf
+++ b/images/rabbitmq/tests/main.tf
@@ -4,6 +4,8 @@ terraform {
   }
 }
 
+resource "random_pet" "suffix" {}
+
 variable "digest" {
   description = "The image digest to run tests over."
 }
@@ -17,4 +19,8 @@ data "oci_exec_test" "version" {
 data "oci_exec_test" "perf" {
   digest = var.digest
   script = "${path.module}/02-perf.sh"
+  env {
+    name  = "NETWORK_NAME"
+    value = "rmq-${random_pet.suffix.id}"
+  }
 }


### PR DESCRIPTION
Whenever we run rabbit test modules in parallel they conflict on the network name