### PR TITLE
withdraw kubeflow-pipelines

### DIFF
--- a/withdrawn-repos.txt
+++ b/withdrawn-repos.txt
@@ -11,3 +11,6 @@ pytorch
 
 # https://github.com/chainguard-images/images/pull/2376
 slim-toolkit-debug
+
+# split into multiple "kubeflow-pipelines-*" images
+kubeflow-pipelines


### PR DESCRIPTION
The `kubeflows-pipelines` image has been decomposed into [multiple separate images](https://github.com/chainguard-images/images/blob/main/images/kubeflow-pipelines/main.tf#L8) and is no longer being released as a standalone entity. Therefore, withdrawing it from our registry.