### PR TITLE
chore(envoy-ratelimit): move script tests to imagetest

### DIFF
--- a/images/envoy-ratelimit/tests/runs.sh
+++ b/images/envoy-ratelimit/tests/runs.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit -o nounset -o errtrace -o pipefail -x
-
-set +o pipefail  # We expect the command to fail, but want its output anyway.
-
-docker run --rm "${IMAGE_NAME}" 2>&1 | grep "creating redis connection error"


### PR DESCRIPTION
Migrate the basic container test to use the new Docker harness in imagetest.