### PR TITLE
powershell: add less package as dependency

### DIFF
--- a/images/powershell/configs/latest-root.apko.yaml
+++ b/images/powershell/configs/latest-root.apko.yaml
@@ -2,6 +2,7 @@ contents:
   packages:
     - busybox
     - powershell
+    - less
 
 accounts:
   groups:

--- a/images/powershell/configs/latest.apko.yaml
+++ b/images/powershell/configs/latest.apko.yaml
@@ -2,6 +2,7 @@ contents:
   packages:
     - busybox
     - powershell
+    - less
 
 accounts:
   groups:


### PR DESCRIPTION
Powershell uses `less -P` when paging, which is not supported by BusyBox less.