### PR TITLE
Added node-feature-discovery public image

### DIFF
--- a/images/node-feature-discovery/README.md
+++ b/images/node-feature-discovery/README.md
@@ -1,0 +1,54 @@
+<!--monopod:start-->
+# node-feature-directory
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/node-feature-directory` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/node-feature-directory/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+A minimal wolfi-based image for node-feature-discovery, Node feature discovery for Kubernetes
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/node-feature-directory:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Upstream documentation
+For more information on grafana, refer to the [node-feature-discovery documentation](https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html).
+Additionally the node-feature-discovery GitHub reposiory can be [found here](https://github.com/kubernetes-sigs/node-feature-discovery).
+
+## Helm
+Node-feature-discovery can be deployed using the following helm chart:
+- [https://artifacthub.io/packages/helm/node-feature-discovery/node-feature-discovery](https://artifacthub.io/packages/helm/node-feature-discovery/node-feature-discovery)
+
+Follow the instructions in the link above to deploy node-feature-discovery using helm. Note you
+will need to override the default image and tag used, replacing with the
+chainguard image, example:
+
+```bash
+helm repo add node-feature-discovery https://kubernetes-sigs.github.io/node-feature-discovery/charts
+helm repo update
+
+export NFD_NS=node-feature-discovery
+helm install nfd/node-feature-discovery --namespace $NFD_NS --create-namespace --generate-name \
+  --set image.repository=cgr.dev/chainguard/node-feature-discovery \
+  --set image.tag=latest
+```
+
+Refer to the [helm chart documentation](https://artifacthub.io/packages/helm/node-feature-discovery/node-feature-discovery)
+for full instructions on how to use the helm chart.
+
+<!--body:end-->

--- a/images/node-feature-discovery/config/latest.apko.yaml
+++ b/images/node-feature-discovery/config/latest.apko.yaml
@@ -1,0 +1,15 @@
+contents:
+  packages:
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  PATH: /usr/sbin:/sbin:/usr/bin:/bin

--- a/images/node-feature-discovery/config/main.tf
+++ b/images/node-feature-discovery/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install"
+  default     = ["node-feature-discovery"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/latest.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/node-feature-discovery/main.tf
+++ b/images/node-feature-discovery/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/node-feature-discovery/metadata.yaml
+++ b/images/node-feature-discovery/metadata.yaml
@@ -1,0 +1,13 @@
+name: node-feature-directory
+image: cgr.dev/chainguard/node-feature-directory
+logo: https://storage.googleapis.com/chainguard-academy/logos/grafana.svg
+endoflife: ""
+console_summary: ""
+short_description: A minimal wolfi-based image for node-feature-discovery, Node feature discovery for Kubernetes
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/grafana/https://github.com/kubernetes-sigs/node-feature-discovery
+keywords:
+  - kubernetes
+  - application
+  - node-discovery

--- a/images/node-feature-discovery/tests/main.tf
+++ b/images/node-feature-discovery/tests/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    helm      = { source = "hashicorp/helm" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" {
+  input = var.digest
+}
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "node-feature-discovery"
+  inventory = data.imagetest_inventory.this
+
+  sandbox = {
+    mounts = [
+      {
+        source      = path.module
+        destination = "/tests"
+      }
+    ]
+  }
+}
+
+module "helm_node-feature-discovery" {
+  source = "../../../tflib/imagetest/helm"
+  chart  = "node-feature-discovery"
+  repo   = "https://kubernetes-sigs.github.io/node-feature-discovery/charts"
+  name   = "node-feature-discovery"
+  values = {
+    image = {
+      repository = data.oci_string.ref.registry_repo
+      tag        = data.oci_string.ref.pseudo_tag
+      pullPolicy = "Always"
+    }
+  }
+}
+
+resource "imagetest_feature" "test_labels" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Test Labels"
+  description = "Basic functionality of the node-feature-discovery helm chart."
+
+  steps = [
+    {
+      name = "Helm install node-feature-discovery"
+      cmd  = module.helm_node-feature-discovery.install_cmd
+    },
+    {
+      name = "Ensure it has the necessary labels For CPU, Kernel and Storage"
+      cmd  = <<EOF
+apk add jq bash
+bash /tests/test-labels.sh
+      EOF
+    }
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+}

--- a/images/node-feature-discovery/tests/test-labels.sh
+++ b/images/node-feature-discovery/tests/test-labels.sh
@@ -1,5 +1,5 @@
-echo -e "Sleeping for 10 seconds"
-sleep 10
+echo -e "Sleeping for 60 seconds"
+sleep 60
 
 cpu=`kubectl get no -o json | jq '.items[].metadata.labels' | grep 'feature.node.kubernetes.io/cpu-'`
 kernel=`kubectl get no -o json | jq '.items[].metadata.labels' | grep 'feature.node.kubernetes.io/kernel-'`

--- a/images/node-feature-discovery/tests/test-labels.sh
+++ b/images/node-feature-discovery/tests/test-labels.sh
@@ -1,0 +1,13 @@
+echo -e "Sleeping for 10 seconds"
+sleep 10
+
+cpu=`kubectl get no -o json | jq '.items[].metadata.labels' | grep 'feature.node.kubernetes.io/cpu-'`
+kernel=`kubectl get no -o json | jq '.items[].metadata.labels' | grep 'feature.node.kubernetes.io/kernel-'`
+storage=`kubectl get no -o json | jq '.items[].metadata.labels' | grep 'feature.node.kubernetes.io/storage-'`
+
+if [[ ${#cpu} -ge 1 && ${#kernel} -ge 1 && ${#storage} -ge 1 ]]; then
+    exit 0
+else
+    echo "Corresponding CPU or Kernel or storage labels have not been found"
+    exit 1
+fi

--- a/main.tf
+++ b/main.tf
@@ -1033,6 +1033,11 @@ module "node" {
   target_repository = "${var.target_repository}/node"
 }
 
+module "node-feature-discovery" {
+  source            = "./images/node-feature-discovery"
+  target_repository = "${var.target_repository}/node-feature-discovery"
+}
+
 module "node-lts" {
   source            = "./images/node-lts"
   target_repository = "${var.target_repository}/node-lts"


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [x] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documented in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [x] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
