### PR TITLE
Add kubernetes-autoscaler-addon-resizer

### DIFF
--- a/images/kubernetes-autoscaler-addon-resizer/README.md
+++ b/images/kubernetes-autoscaler-addon-resizer/README.md
@@ -1,0 +1,37 @@
+<!--monopod:start-->
+# kubernetes-autoscaler-addon-resizer
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/kubernetes-autoscaler-addon-resizer` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/kubernetes-autoscaler-addon-resizer/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Addon-resizer is a container that vertically scales a Deployment based on the number of nodes in your cluster.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/kubernetes-autoscaler-addon-resizer:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/deploy/example.yaml
+kubectl set image deployment/nanny-v1 pod-nanny=cgr.dev/chainguard/kubernetes-autoscaler-addon-resizer:latest
+```
+
+Find more on the [official documentation](https://github.com/kubernetes/autoscaler/blob/master/addon-resizer/README.md)!
+<!--body:end-->

--- a/images/kubernetes-autoscaler-addon-resizer/config/main.tf
+++ b/images/kubernetes-autoscaler-addon-resizer/config/main.tf
@@ -1,0 +1,17 @@
+variable "extra_packages" {
+  description = "Additional packages to install."
+  type        = list(string)
+  default     = ["addon-resizer", "addon-resizer-compat"]
+}
+
+module "accts" { source = "../../../tflib/accts" }
+
+output "config" {
+  value = jsonencode({
+    contents = {
+      packages = var.extra_packages
+    }
+    accounts = module.accts.block
+    cmd      = "/pod_nanny"
+  })
+}

--- a/images/kubernetes-autoscaler-addon-resizer/main.tf
+++ b/images/kubernetes-autoscaler-addon-resizer/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "config" { source = "./config" }
+
+module "kubernetes-autoscaler-addon-resizer" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.config.config
+  build-dev         = true
+}
+
+module "test" {
+  source = "./tests"
+  digest = module.kubernetes-autoscaler-addon-resizer.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test]
+  digest_ref = module.kubernetes-autoscaler-addon-resizer.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test]
+  digest_ref = module.kubernetes-autoscaler-addon-resizer.dev_ref
+  tag        = "latest-dev"
+}
+

--- a/images/kubernetes-autoscaler-addon-resizer/metadata.yaml
+++ b/images/kubernetes-autoscaler-addon-resizer/metadata.yaml
@@ -1,0 +1,13 @@
+name: kubernetes-autoscaler-addon-resizer
+image: cgr.dev/chainguard/kubernetes-autoscaler-addon-resizer
+logo: https://storage.googleapis.com/chainguard-academy/logos/kubernetes-autoscaler-addon-resizer.svg
+endoflife: ""
+console_summary: ""
+short_description: Addon-resizer is a container that vertically scales a Deployment based on the number of nodes in your cluster.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/kubernetes/autoscaler/tree/master/addon-resizer
+keywords:
+  - application
+  - kubernetes
+  - autoscaler

--- a/images/kubernetes-autoscaler-addon-resizer/tests/main.tf
+++ b/images/kubernetes-autoscaler-addon-resizer/tests/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    oci       = { source = "chainguard-dev/oci" }
+    imagetest = { source = "chainguard-dev/imagetest" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_string" "ref" { input = var.digest }
+
+data "imagetest_inventory" "this" {}
+
+resource "imagetest_harness_k3s" "this" {
+  name      = "kubernetes-autoscaler-addon-resizer"
+  inventory = data.imagetest_inventory.this
+}
+
+resource "imagetest_feature" "basic" {
+  harness     = imagetest_harness_k3s.this
+  name        = "Basic"
+  description = "Basic functionality of the kubernetes-autoscaler-addon-resizer."
+
+  steps = [
+    {
+      name = "Deploy"
+      cmd  = <<EOF
+ kubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/deploy/example.yaml
+ kubectl set image deployment/nanny-v1 pod-nanny="${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+       EOF
+    },
+    {
+      name  = "Ensure it comes up healthy"
+      cmd   = <<EOF
+ kubectl rollout status deployment/nanny-v1 --timeout=120s
+ kubectl wait --for=condition=ready pod --selector k8s-app=nanny
+       EOF
+      retry = { attempts = 3, delay = "2s", factor = 2 }
+    },
+    {
+      name = "Check logs"
+      cmd  = "kubectl logs deployment/nanny-v1 | grep -qi 'Watching namespace'"
+    }
+  ]
+
+  labels = {
+    type = "k8s"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -785,6 +785,11 @@ module "kuberay-operator" {
   target_repository = "${var.target_repository}/kuberay-operator"
 }
 
+module "kubernetes-autoscaler-addon-resizer" {
+  source            = "./images/kubernetes-autoscaler-addon-resizer"
+  target_repository = "${var.target_repository}/kubernetes-autoscaler-addon-resizer"
+}
+
 module "kubernetes-csi-external-attacher" {
   source            = "./images/kubernetes-csi-external-attacher"
   target_repository = "${var.target_repository}/kubernetes-csi-external-attacher"


### PR DESCRIPTION
> **Note**
> **Before:** `35.9MB, 38 packages, 9 vulnerabilities`
> **After:** `29.9MB, 4 packages, 0-CVE`

---

## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [x] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [x] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [x] A Helm chart was not provided.

Notes:

### Processor Architectures

- [x] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [x] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [x] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [x] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [x] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [x] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [x] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [x] Environment variables not added and not required.

### SIGTERM

- [x] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [x] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [x] A README file has been provided and it follows the README template.
