### PR TITLE
new image: gomplate

### DIFF
--- a/images/gomplate/README.md
+++ b/images/gomplate/README.md
@@ -1,0 +1,38 @@
+<!--monopod:start-->
+# gomplate
+| | |
+| - | - |
+| **OCI Reference** | `cgr.dev/chainguard/gomplate` |
+
+
+* [View Image in Chainguard Academy](https://edu.chainguard.dev/chainguard/chainguard-images/reference/gomplate/overview/)
+* [View Image Catalog](https://console.enforce.dev/images/catalog) for a full list of available tags.
+* [Contact Chainguard](https://www.chainguard.dev/chainguard-images) for enterprise support, SLAs, and access to older tags.*
+
+---
+<!--monopod:end-->
+
+<!--overview:start-->
+Minimalist Wolfi-based gomplate image for template rendering.
+<!--overview:end-->
+
+<!--getting:start-->
+## Download this Image
+The image is available on `cgr.dev`:
+
+```
+docker pull cgr.dev/chainguard/gomplate:latest
+```
+<!--getting:end-->
+
+<!--body:start-->
+## Usage
+
+Example usage
+
+```
+$ docker run --rm cgr.dev/chainguard/gomplate:latest -i 'the answer is: {{ mul 6 7 }}'
+the answer is: 42
+```
+
+<!--body:end-->

--- a/images/gomplate/config/main.tf
+++ b/images/gomplate/config/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "extra_packages" {
+  description = "The additional packages to install (e.g. gomplate)."
+  default     = ["gomplate"]
+}
+
+data "apko_config" "this" {
+  config_contents = file("${path.module}/template.apko.yaml")
+  extra_packages  = var.extra_packages
+}
+
+output "config" {
+  value = jsonencode(data.apko_config.this.config)
+}

--- a/images/gomplate/config/template.apko.yaml
+++ b/images/gomplate/config/template.apko.yaml
@@ -1,0 +1,16 @@
+contents:
+  packages:
+    - gomplate
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/gomplate

--- a/images/gomplate/main.tf
+++ b/images/gomplate/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "latest-config" { source = "./config" }
+
+module "latest" {
+  source            = "../../tflib/publisher"
+  name              = basename(path.module)
+  target_repository = var.target_repository
+  config            = module.latest-config.config
+  build-dev         = true
+}
+
+module "test-latest" {
+  source = "./tests"
+  digest = module.latest.image_ref
+}
+
+resource "oci_tag" "latest" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.image_ref
+  tag        = "latest"
+}
+
+resource "oci_tag" "latest-dev" {
+  depends_on = [module.test-latest]
+  digest_ref = module.latest.dev_ref
+  tag        = "latest-dev"
+}

--- a/images/gomplate/metadata.yaml
+++ b/images/gomplate/metadata.yaml
@@ -1,0 +1,12 @@
+name: gomplate
+image: cgr.dev/chainguard/gomplate
+logo: https://storage.googleapis.com/chainguard-academy/logos/gomplate.svg
+endoflife: ""
+console_summary: ""
+short_description: Minimalist Wolfi-based gomplate image for template rendering.
+compatibility_notes: ""
+readme_file: README.md
+upstream_url: https://github.com/hairyhenderson/gomplate
+keywords:
+  - application
+  - tools

--- a/images/gomplate/tests/01-template.sh
+++ b/images/gomplate/tests/01-template.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o errtrace -o pipefail -x
+
+docker run --rm "${IMAGE_NAME}" -i 'the answer is: {{ mul 6 7 }}'

--- a/images/gomplate/tests/main.tf
+++ b/images/gomplate/tests/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    oci = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "digest" {
+  description = "The image digest to run tests over."
+}
+
+data "oci_exec_test" "template" {
+  digest = var.digest
+  script = "${path.module}/01-template.sh"
+}

--- a/main.tf
+++ b/main.tf
@@ -525,6 +525,11 @@ module "go" {
   target_repository = "${var.target_repository}/go"
 }
 
+module "gomplate" {
+  source            = "./images/gomplate"
+  target_repository = "${var.target_repository}/gomplate"
+}
+
 module "go-ipfs" {
   source            = "./images/go-ipfs"
   target_repository = "${var.target_repository}/go-ipfs"


### PR DESCRIPTION
## New Image Pull Request Template

Fixes: https://github.com/chainguard-images/images/issues/2497

![image](https://github.com/chainguard-images/images/assets/627278/dd3fc727-cf32-4472-97e5-71430c2058e4)

smaller than public counterpart

```
hairyhenderson/gomplate                         latest    fab49dfd161c   4 days ago      65.6MB
ttl.sh/tuananh/gomplate/gomplate                <none>    385661ad5a07   9 days ago      59.1MB
```

0 cve

```
grype ttl.sh/tuananh/gomplate/gomplate:latest@sha256:bc7969ad93826822ded01143c35636103ea8e83c2e963126b75ca6628bf1f0db
 ✔ Vulnerability DB                [updated]  
 ✔ Loaded image                    ttl.sh/tuananh/gomplate/gomplate:latest@sha256:bc7969ad93826822ded01143c35636103ea8e83c2e963126b75ca6628  
 ✔ Parsed image                                                     sha256:385661ad5a07f6d2e80ce5fb06f0933ae95113b8fd34d6a8b04a83de672c8b53
 ✔ Cataloged contents                                                      94ed30f9af85975191f8f55128dd7e7f132bf28847cd5baa1ed00989558ac5b1
   ├── ✔ Packages                        [132 packages]  
   ├── ✔ File digests                    [56 files]  
   ├── ✔ File metadata                   [56 locations]  
   └── ✔ Executables                     [20 executables]  
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored 
No vulnerabilities found
```

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [x] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [x] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [x] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [x] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [x] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
