### PR TITLE
fix(pytorch-cuda12): Increase timeout for installing Helm chart

### DIFF
--- a/images/pytorch-cuda12/tests/main.tf
+++ b/images/pytorch-cuda12/tests/main.tf
@@ -34,6 +34,7 @@ module "helm" {
   namespace = "pytorch"
   repo      = "https://charts.bitnami.com/bitnami"
   chart     = "pytorch"
+  timeout   = "600s"
 
   values = {
     containerName = "pytorch"


### PR DESCRIPTION
More time is needed to pull the containers

