### PR TITLE
Allow all conda packages to be passed in

### DIFF
--- a/images/conda/config/main.tf
+++ b/images/conda/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. conda)."
-  default     = ["conda"]
+  default     = ["conda", "conda-base", "conda-wrapper"]
 }
 
 data "apko_config" "this" {

--- a/images/conda/config/template.apko.yaml
+++ b/images/conda/config/template.apko.yaml
@@ -1,9 +1,6 @@
 contents:
   packages:
     - busybox
-    - conda
-    - conda-base
-    - conda-wrapper
 
 accounts:
   run-as: 0


### PR DESCRIPTION
Allows this module to be re-used and permits passing in different conda packages