### PR TITLE
terraform: actually use VCS committed lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ image/%: check-env-tf init
 	$(TERRAFORM) apply $(TF_VARS) -target=module.$*
 
 init:
+	$(TERRAFORM) init -lockfile=readonly
+
+init-upgrade:
 	$(TERRAFORM) init -upgrade
 	$(TERRAFORM) providers lock -platform=darwin_arm64 -platform=linux_amd64
 


### PR DESCRIPTION
Change `make init` to use existing lock file in read-only mode. Add a new target `make init-upgrade` to upgrade dependencies manually if desired.

Separately Dependabot pull requests can upgrade lock file correctly - see https://github.com/chainguard-images/images/pull/2509/files for an example of lifecycle management.

This ensures reproducibility across all developers, in presubmit/production builds, and also across time. As older checkouts from now on, will use matching terraform providers.