### PR TITLE
terraform: upgrade to 1.6.*

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -121,7 +121,7 @@ jobs:
 
     - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3
       with:
-        terraform_version: '1.5.7'
+        terraform_version: '1.6.*'
         terraform_wrapper: false
     # Make cosign/crane CLI available to the tests
     - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3
         with:
-          terraform_version: '1.5.7'
+          terraform_version: '1.6.*'
           terraform_wrapper: false
 
       - uses: chainguard-dev/actions/setup-chainctl@538d1927b846546b620784754c33e2a1db86e217 # main


### PR DESCRIPTION
For consistency with other chainguard image building repositories upgrade to terraform 1.6.* too.