### PR TITLE
migrate/fix a few of the infinite timeout images

### DIFF
--- a/images/cadvisor/tests/runs.sh
+++ b/images/cadvisor/tests/runs.sh
@@ -2,13 +2,13 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-NAMESPACE=cadvisor
+apk add jq curl
 
 function manifests() {
-  # if image tag is latest then find the latest version of the git release
-  LATEST=$(curl -s "https://api.github.com/repos/google/cadvisor/releases/latest" | jq -r '.tag_name')
+	# if image tag is latest then find the latest version of the git release
+	LATEST=$(curl -s "https://api.github.com/repos/google/cadvisor/releases/latest" | jq -r '.tag_name')
 
-  cat <<EOF > kustomization.yaml
+	cat <<EOF >kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -25,5 +25,3 @@ manifests
 
 kubectl create namespace ${NAMESPACE}
 kubectl apply -k .
-
-kubectl wait --for=condition=ready pod --selector app=cadvisor --namespace ${NAMESPACE}

--- a/images/newrelic-nri-statsd/tests/smoke.sh
+++ b/images/newrelic-nri-statsd/tests/smoke.sh
@@ -2,16 +2,13 @@
 
 set -o errexit -o nounset -o errtrace -o pipefail -x
 
-container_name="newrelic-nri-statsd-${RANDOM}"
-
 # Step 0: Pull and run a StatsD Docker container
 echo "Starting StatsD Docker container..."
-docker run -d -e NR_API_KEY=${NR_API_KEY} -e NR_STATSD_METRICS_ADDR=":${FREE_PORT}" --name $container_name -p ${FREE_PORT}:${FREE_PORT} ${IMAGE_NAME}
+cid=$(docker run -d -e NR_API_KEY=${NR_API_KEY} ${IMAGE_NAME})
 
-# wait for the container to be ready by checking the connection to 8125
-while ! nc -z localhost ${FREE_PORT}; do
-  echo "Waiting for StatsD Docker container to be ready..."
-  sleep 1
+while ! docker logs $cid 2>&1 | grep "Initialised backend"; do
+	echo "Waiting for StatsD Docker container to be ready..."
+	sleep 1
 done
 
 echo "StatsD Docker container is ready."


### PR DESCRIPTION
migrates a few of the biggest infinite timeout test failures to `imagetest` to take advantage of the builtin timeout cancellation