### PR TITLE
keycloak: fix helm command on doc and missing permission path

### DIFF
--- a/images/keycloak/README.md
+++ b/images/keycloak/README.md
@@ -53,9 +53,10 @@ To launch a development instance of keycloak in k8s using the following
 
 ```bash
 helm install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
-  --set image.repository=cgr.dev/chainguard/keycloak \
+  --set image.registry=cgr.dev \
+  --set image.repository=chainguard/keycloak \
   --set image.tag=latest \
-  --set "args[0]=start-dev"
+  --set "args={start-dev}"
 ```
 
 Refer to the [keycloak](https://github.com/keycloak/keycloak/blob/main/docs/guides/server/containers.adoc)

--- a/images/keycloak/config/main.tf
+++ b/images/keycloak/config/main.tf
@@ -31,7 +31,15 @@ output "config" {
       gid         = module.accts.block.run-as
       permissions = 511 // 0o777 (HCL explicitly does not support octal literals)
       recursive   = true
-    }]
+      }, {
+      path        = "/usr/share/java/keycloak/lib/quarkus"
+      type        = "directory"
+      uid         = module.accts.block.run-as
+      gid         = module.accts.block.run-as
+      permissions = 511 // 0o777 (HCL explicitly does not support octal literals)
+      recursive   = true
+      }
+    ]
     environment = var.environment
     entrypoint = {
       command = "/usr/bin/kc.sh"


### PR DESCRIPTION
Attempt to resolve: `java.lang.IllegalStateException: java.nio.file.FileSystemException: /usr/share/java/keycloak/lib/quarkus/generated-bytecode.jar: Read-only file system` error.