### PR TITLE
check SBOM with SPDX tool

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,16 +2,16 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/chainguard-dev/apko" {
-  version     = "0.15.2"
-  constraints = "0.15.2"
+  version     = "0.15.3"
+  constraints = "0.15.3"
   hashes = [
-    "h1:ZAxVcQUI8ZRDiYDd599YQPAyPhb/9Mj28EUjsmEL0oc=",
-    "h1:pDYdU+HO6RchUNnGKiCVsp+3XFFS35Bfqre5mwTZ0Vg=",
-    "zh:29d2d68a8c49c216e3f29070bdb2bc259420b6b4074f3c9300540b2add567573",
-    "zh:35b3c7cc68a2a91572c1974660cf5dbf6a1acf907f1468650e256e6c18f193b5",
+    "h1:JciBxtjb+K6a2oVDtKyeinoaCrEzVb9lOxnqLyTq3iY=",
+    "h1:gJyWtRNrDnJtqLrGswiLvCjJV5f1PIeGJcbucR4zMcE=",
+    "zh:126935df3b62bd1fbe8873c80e624b25dd85ae96245753def27223c8c1d90c3d",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:a23063b1111045c1ffee258683433777c069d6e8c63dffb1e882818445ad859f",
-    "zh:ec0145598f7bf9c235faea0ffda227bb86432745f20902bbe0f8ed4ce0700c75",
+    "zh:b7ac149f5e77d9b0a1a7627695f3adf5bd9c1644e36a02778c93b17af0077f18",
+    "zh:f0a34de43f1151f683eef7bf1180773018de803bd53f962959265cdf1266c002",
+    "zh:f2c27998cc3e16d1b10898c332ce4f1d103b28b86295247752b2c625501dd3db",
   ]
 }
 

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,16 +2,16 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/chainguard-dev/apko" {
-  version     = "0.15.3"
-  constraints = "0.15.3"
+  version     = "0.15.4"
+  constraints = "0.15.4"
   hashes = [
-    "h1:JciBxtjb+K6a2oVDtKyeinoaCrEzVb9lOxnqLyTq3iY=",
-    "h1:gJyWtRNrDnJtqLrGswiLvCjJV5f1PIeGJcbucR4zMcE=",
-    "zh:126935df3b62bd1fbe8873c80e624b25dd85ae96245753def27223c8c1d90c3d",
+    "h1:lw+YLko+Erafan5v3daXCWqHbKkqcBAXiVBMO85xv4g=",
+    "h1:yvDcOJqBhHYwIYnwqRxw3wRegTFRygkVJ4XH9AecAIY=",
+    "zh:0c8830a48eafd77c64feafdcb66d9219dde4ee4ae207862f1902c8ecfff3dc51",
+    "zh:10abcdc1813b1f8fc31ff34d9e8a672877d5885d7c4c8240a96c1f7f535f987c",
+    "zh:3cc7ceac204541b4bf3dad4378bf89d7dd0ba7086f5617c270f4664caae48bbf",
+    "zh:629c27526263da496471690253adf23bbb34ee45b292daa0b36eae9fa3a95861",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:b7ac149f5e77d9b0a1a7627695f3adf5bd9c1644e36a02778c93b17af0077f18",
-    "zh:f0a34de43f1151f683eef7bf1180773018de803bd53f962959265cdf1266c002",
-    "zh:f2c27998cc3e16d1b10898c332ce4f1d103b28b86295247752b2c625501dd3db",
   ]
 }
 

--- a/images/docker-selenium/main.tf
+++ b/images/docker-selenium/main.tf
@@ -19,6 +19,7 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.config.config
   build-dev         = true
+  check-sbom        = false # TODO: font-ubuntu has an invalid SPDX license identifier.
 }
 
 module "test" {

--- a/images/min-toolkit-debug/main.tf
+++ b/images/min-toolkit-debug/main.tf
@@ -17,6 +17,7 @@ module "latest" {
 
   target_repository = var.target_repository
   config            = module.latest-config.config
+  check-sbom        = false # TODO ngrep has an invalid SPDX license identifier.
 }
 
 module "test-latest" {

--- a/images/opensearch-dashboards/main.tf
+++ b/images/opensearch-dashboards/main.tf
@@ -16,6 +16,7 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.latest-config.config
   build-dev         = true
+  check-sbom        = false # TODO: has an invalid SPDX license identifier.
 }
 
 module "test-latest" {

--- a/images/r-base/main.tf
+++ b/images/r-base/main.tf
@@ -16,6 +16,7 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.latest-config.config
   build-dev         = true
+  check-sbom        = false # TODO: has an invalid SPDX license identifier.
 }
 
 module "test-latest" {

--- a/images/rstudio/main.tf
+++ b/images/rstudio/main.tf
@@ -18,6 +18,7 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.config.config
   build-dev         = true
+  check-sbom        = false # TODO: has an invalid SPDX license identifier.
 }
 
 module "test" {

--- a/images/zig/main.tf
+++ b/images/zig/main.tf
@@ -16,6 +16,7 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.latest-config.config
   build-dev         = true
+  check-sbom        = false # TODO: zig package doesn't build to rebuild with valid SBOM.
 }
 
 module "test-latest" {

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -94,7 +94,7 @@ module "this" {
   source  = "chainguard-dev/apko/publisher"
   version = "0.0.11"
 */
-  source = "git@github.com:imjasonh/terraform-publisher-apko.git?ref=spdx-check"
+  source = "https://github.com/imjasonh/terraform-publisher-apko.git?ref=spdx-check"
   //source = "/Users/jason/git/terraform-publisher-apko"
 
   target_repository = var.target_repository

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     apko = {
       source  = "chainguard-dev/apko"
-      version = "0.15.2"
+      version = "0.15.3"
     }
     oci = {
       source  = "chainguard-dev/oci"

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     apko = {
       source  = "chainguard-dev/apko"
-      version = "0.15.3"
+      version = "0.15.4"
     }
     oci = {
       source  = "chainguard-dev/oci"

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -94,7 +94,7 @@ module "this" {
   source  = "chainguard-dev/apko/publisher"
   version = "0.0.11"
 */
-  source = "https://github.com/imjasonh/terraform-publisher-apko.git?ref=spdx-check"
+  source = "git::https://github.com/imjasonh/terraform-publisher-apko.git?ref=spdx-check"
   //source = "/Users/jason/git/terraform-publisher-apko"
 
   target_repository = var.target_repository

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -55,7 +55,7 @@ variable "update-repo" {
 
 variable "check-sbom" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to run the NTIA conformance checker over the images we produce prior to attesting the SBOMs."
 }
 
@@ -90,8 +90,12 @@ locals {
 }
 
 module "this" {
+  /*
   source  = "chainguard-dev/apko/publisher"
   version = "0.0.11"
+*/
+  source = "git@github.com:imjasonh/terraform-publisher-apko.git?ref=spdx-check"
+  //source = "/Users/jason/git/terraform-publisher-apko"
 
   target_repository = var.target_repository
   config            = yamlencode(local.updated_config)


### PR DESCRIPTION
Opening this as draft to see what fails.

Also upgrades to tf-apko 0.15.3 which doesn't emit files, since this can make NTIA's checker very slow for large images, and we should upgrade anyway.

current status: needs https://github.com/chainguard-dev/apko/pull/1095 (and a bump in tf-apko and a module bump here) since we weren't stripping enough references to `files`