### PR TITLE
fix(pytorch-cuda12): Further increase Helm timeout

### DIFF
--- a/images/pytorch-cuda12/tests/main.tf
+++ b/images/pytorch-cuda12/tests/main.tf
@@ -34,7 +34,7 @@ module "helm" {
   namespace = "pytorch"
   repo      = "https://charts.bitnami.com/bitnami"
   chart     = "pytorch"
-  timeout   = "600s"
+  timeout   = "900s"
 
   values = {
     containerName = "pytorch"


### PR DESCRIPTION
This is still timing out while pulling the image down because of how large it is. Increases the timeout from 10 minutes to 15 minutes