### PR TITLE
Add waits and retries

### DIFF
--- a/images/cassandra-medusa/tests/medusa-install.sh
+++ b/images/cassandra-medusa/tests/medusa-install.sh
@@ -4,13 +4,40 @@ set -o errexit -o nounset -o errtrace -o pipefail -x
 
 apk add helm
 
-# cert-manager is required as a dependency.
+# Function to retry a command until it succeeds or reaches max attempts
+# Arguments:
+#   $1: max_attempts
+#   $2: interval (seconds)
+#   $3: description of the operation
+#   ${@:4}: command to execute
+retry_command() {
+    local max_attempts=$1
+    local interval=$2
+    local description=$3
+    local cmd="${@:4}"
+    local attempt=1
+
+    echo "Retrying: $description"
+    while [ $attempt -le $max_attempts ]; do
+        echo "Attempt $attempt: $cmd"
+        if eval $cmd; then
+            echo "Success on attempt $attempt for: $description"
+            return 0
+        else
+            echo "Failure on attempt $attempt for: $description"
+            sleep $interval
+        fi
+        ((attempt++))
+    done
+
+    echo "Error: Failed after $max_attempts attempts for: $description"
+    return 1
+}
+
+# Install cert-manager
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm install \
-  cert-manager jetstack/cert-manager \
-    --namespace ${NAMESPACE} \
-    --create-namespace \
+helm install cert-manager jetstack/cert-manager --namespace ${NAMESPACE} --create-namespace \
     --set image.repository=cgr.dev/chainguard/cert-manager-controller \
     --set image.tag=latest \
     --set cainjector.image.repository=cgr.dev/chainguard/cert-manager-cainjector \
@@ -21,10 +48,10 @@ helm install \
     --set webhook.image.tag=latest \
     --set installCRDs=true
 
-# wait for cert-manager to be ready
-kubectl wait --for=condition=ready pod --selector app.kubernetes.io/instance=cert-manager --namespace ${NAMESPACE}
+# Check readiness of cert-manager pods
+retry_command 5 15 "cert-manager pod readiness" "kubectl wait --for=condition=ready pod --selector app.kubernetes.io/instance=cert-manager --namespace ${NAMESPACE} --timeout=1m"
 
-# install k8ssandra-operator
+# Install k8ssandra-operator
 helm repo add k8ssandra https://helm.k8ssandra.io/stable
 helm repo update
 helm install k8ssandra-operator k8ssandra/k8ssandra-operator \
@@ -33,36 +60,38 @@ helm install k8ssandra-operator k8ssandra/k8ssandra-operator \
   --set image.registry=cgr.dev \
   --set image.repository=chainguard/k8ssandra-operator \
   --set image.tag=latest
-sleep 30
 
-# create a secret, needed for medusa
-cat <<EOF | kubectl apply -f -
+# Check readiness of k8sandra-operator
+retry_command 5 15 "k8ssandra-operator pod readiness" "kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=k8ssandra-operator --namespace ${NAMESPACE} --timeout=1m"
+
+# Create secret for Medusa
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
- name: medusa-bucket-key
- namespace: "${NAMESPACE}"
+  name: medusa-bucket-key
+  namespace: ${NAMESPACE}
 type: Opaque
 stringData:
- # Note that this currently has to be set to credentials!
- credentials: |-
-   [default]
-   aws_access_key_id = k8ssandra
-   aws_secret_access_key = k8ssandra
+  credentials: |-
+    [default]
+    aws_access_key_id = k8ssandra
+    aws_secret_access_key = k8ssandra
 EOF
 
-cat <<EOF | kubectl apply -n ${NAMESPACE} -f -
+# Create K8ssandraCluster
+kubectl apply -n ${NAMESPACE} -f - <<EOF
 apiVersion: k8ssandra.io/v1alpha1
 kind: K8ssandraCluster
 metadata:
-  name: "${NAME}"
-  namespace: "${NAMESPACE}"
+  name: ${NAME}
+  namespace: ${NAMESPACE}
 spec:
   cassandra:
     serverVersion: "4.0.1"
     datacenters:
       - metadata:
-          name: "${NAME}"
+          name: ${NAME}
         size: 1
         storageConfig:
           cassandraDataVolumeClaimSpec:
@@ -96,82 +125,27 @@ spec:
       secure: false
 EOF
 
-# NOTE: There is usually a delay (up to 60 seconds), before the mesuda pod is
-# created by the operator. So we can't immediately run `kubectl wait`, as it'll
-# fail if no pod exists.
-for ((i = 0; i < 10; i++)); do
-	if kubectl get pod -l app=${NAME}-cassandra-medusa-medusa-standalone -n ${NAMESPACE} &>/dev/null; then
-		echo "medusa-standalone pod exists, checking readiness..."
-        # Wait for pod to be ready before exiting the loop
-        if kubectl wait --for=condition=Ready pod -l app=${NAME}-cassandra-medusa-medusa-standalone -n ${NAMESPACE} --timeout=3m; then
-            echo "medusa-standalone pod is ready."
-            break
-        else
-            echo "medusa-standalone pod is not ready yet."
-        fi
-	fi
-	sleep 15
-done
+# Check readiness of the Cassandra Medusa pod
+retry_command 5 15 "Cassandra Medusa pod readiness" "kubectl wait --for=condition=Ready pod -l app=${NAME}-cassandra-medusa-medusa-standalone -n ${NAMESPACE} --timeout=2m"
 
-if [ $i -eq 10 ]; then
-    echo "medusa-standalone pod was not ready after ${i} attempts."
-    exit 1
-fi
+# Check readiness of the Cassandra stateful set
+retry_command 20 30 "Cassandra stateful set readiness" "kubectl get statefulset ${NAME}-cassandra-medusa-default-sts -n ${NAMESPACE} --no-headers -o custom-columns=READY:.status.readyReplicas | grep -q '1'"
 
-# Similarly, the stateful set may take a while to be created, so we need to
-# first check for it's presence, before checking that the statefulset is ready.
-for ((i = 0; i < 20; i++)); do
-  if kubectl get statefulset ${NAME}-cassandra-medusa-default-sts -n ${NAMESPACE} &>/dev/null; then
-    echo "cassandra-medusa statefulset exists, checking readiness..."
-    if ready_statefulset=$(kubectl get statefulset ${NAME}-cassandra-medusa-default-sts -n ${NAMESPACE} --no-headers -o custom-columns=READY:.status.readyReplicas); then
-        if [ "$ready_statefulset" -ge 1 ]; then
-            echo "cassandra-medusa statefulset is ready."
-            break
-        else
-            echo "cassandra-medusa statefulset is not ready yet."
-        fi
-    else
-        echo "Error fetching the status of the statefulset."
-    fi
-  fi
-	sleep 30
-done
-
-if [ $i -eq 10 ]; then
-    echo "cassandra-medusa statefulset was not ready after ${i} attempts."
-    exit 1
-fi
-
-# check if medusa grpc server started
+# Check Medusa gRPC server startup
 sleep 5
 kubectl logs -l app=${NAME}-cassandra-medusa-medusa-standalone --tail -1 -n ${NAMESPACE} | grep "Starting server. Listening on port 50051"
 
 # Create Medusa Backup
-cat <<EOF | kubectl apply -n ${NAMESPACE} -f -
+kubectl apply -n ${NAMESPACE} -f - <<EOF
 apiVersion: medusa.k8ssandra.io/v1alpha1
 kind: MedusaBackup
 metadata:
-  name: "${NAME}-backup"
-  namespace: "${NAMESPACE}"
+  name: ${NAME}-backup
+  namespace: ${NAMESPACE}
 spec:
   backupType: full
-  cassandraDatacenter: "${NAME}"
+  cassandraDatacenter: ${NAME}
 EOF
 
-# Check if the MedusaBackup resource was created. Note medusa only supports
-# Cloud storage backends, so all we can do at this point is check the backup
-# job was created.
-for ((i = 0; i < 10; i++)); do
-    output=$(kubectl get medusabackup -n ${NAMESPACE} 2>&1)
-    if echo "$output" | grep -q "cassandra-medusa-backup"; then
-        echo "medusa backup task was successfully created."
-        break
-    else
-        sleep 15
-    fi
-done
-
-if [ $i -eq 10 ]; then
-    echo "Failed to find medusa backup task after 10 attempts."
-    exit 1
-fi
+# Verify creation of the MedusaBackup resource
+retry_command 5 15 "MedusaBackup resource creation" "kubectl get medusabackup -n ${NAMESPACE} 2>&1 | grep -q '${NAME}-backup'"


### PR DESCRIPTION
There are lots of moving parts in this test. Resources and dependencies take a while to get created, and become ready.

Also switching some of the dependencies to pull in chainguard images