### PR TITLE
use apko_build for the sandbox image

### DIFF
--- a/images/tekton/tests/main.tf
+++ b/images/tekton/tests/main.tf
@@ -57,8 +57,9 @@ resource "imagetest_feature" "basic" {
 
   steps = [
     {
-      name = "Install Tekton"
-      cmd  = "/tests/test.sh"
+      name  = "Install Tekton"
+      cmd   = "/tests/test.sh"
+      retry = { attempts = 5, delay = "10s" }
     },
     {
       name  = "Wait for Tekton"

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,20 @@ terraform {
   backend "inmem" {}
 }
 
-provider "imagetest" {}
+provider "imagetest" {
+  harnesses = {
+    k3s = {
+      sandbox = {
+        image = module.imagetest_k3s_sandbox_image.image_ref
+      }
+    }
+  }
+}
+
+module "imagetest_k3s_sandbox_image" {
+  source            = "./tflib/imagetest/k3s-sandbox-image"
+  target_repository = "${var.target_repository}/imagetest"
+}
 
 variable "target_repository" {
   type        = string

--- a/tflib/imagetest/k3s-sandbox-image/main.tf
+++ b/tflib/imagetest/k3s-sandbox-image/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+    oci  = { source = "chainguard-dev/oci" }
+  }
+}
+
+variable "target_repository" {}
+
+data "apko_config" "this" {
+  extra_packages = [
+    "apk-tools",
+    "busybox",
+    "bash",
+    "curl",
+    "helm",
+    "k9s",
+    "kubectl",
+    "kustomize",
+  ]
+  config_contents = jsonencode({
+    accounts = {
+      "run-as" : 0
+    }
+    entrypoint = {
+      command = "tail -f /dev/null"
+    }
+  })
+}
+
+resource "apko_build" "this" {
+  repo   = var.target_repository
+  config = data.apko_config.this.config
+}
+
+output "image_ref" {
+  value = apko_build.this.image_ref
+}


### PR DESCRIPTION
uses a runtime "dynamic" image built with `apko_build` as the default image for the k3s sandbox harness.

this standardizes some common testing patterns seem in `images`.