### PR TITLE
Fix reaper tmpdir envrionment variables

### DIFF
--- a/images/cassandra-reaper/config/template.apko.yaml
+++ b/images/cassandra-reaper/config/template.apko.yaml
@@ -22,6 +22,18 @@ entrypoint:
 cmd: cassandra-reaper
 
 paths:
+  - path: /var/tmp/cassandra-reaper
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o777
+    recursive: true
+  - path: /var/lib/cassandra-reaper/storage
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o777
+    recursive: true
   - path: /etc/cassandra-reaper/
     type: directory
     permissions: 0o777
@@ -99,3 +111,5 @@ environment:
   REAPER_HTTP_MANAGEMENT_ENABLE: "false"
   REAPER_HTTP_MANAGEMENT_KEYSTORE_PATH: ""
   REAPER_HTTP_MANAGEMENT_TRUSTSTORE_PATH: ""
+  REAPER_TMP_DIRECTORY: "/var/tmp/cassandra-reaper"
+  REAPER_MEMORY_STORAGE_DIRECTORY: "/var/lib/cassandra-reaper/storage"


### PR DESCRIPTION
Looks like we do need the environment variables mentioned in https://github.com/chainguard-images/images/pull/2567

I fired up the container and checked the process and it's running with

```
    1 nonroot   0:56 java -Xms2147483648 -Xmx2147483648 -Djava.io.tmpdir= -cp /usr/local/lib/* io.cassandrareaper.ReaperApplication server /etc/cassandra-reaper/cassandra-reaper.yml
```

Which is setting the tmpdir to an empty string since the env is missing and the entrypoint tries to use it. 