### PR TITLE
fix(postgresql): Build with latest version

### DIFF
--- a/images/postgres/main.tf
+++ b/images/postgres/main.tf
@@ -8,20 +8,15 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
-locals {
-  # TODO: Define a virtual postgres package
-  version = "15"
-}
-
 module "latest-config" {
   source = "./config"
 
   extra_packages = [
-    "postgresql-${local.version}",
-    "postgresql-${local.version}-client",
-    "postgresql-${local.version}-oci-entrypoint",
-    "postgresql-${local.version}-contrib",
-    "libpq-${local.version}",
+    "postgresql",
+    "postgresql-client",
+    "postgresql-oci-entrypoint",
+    "postgresql-contrib",
+    "libpq",
   ]
 }
 


### PR DESCRIPTION
Drops version pinning in favor of always building with the latest version of PostgreSQL in Wolfi