### PR TITLE
feat(harbor): Add Harbor DB

### DIFF
--- a/images/harbor/README.md
+++ b/images/harbor/README.md
@@ -41,6 +41,7 @@ Now that we've added the repository, we can deploy Harbor!:
 ```bash
 helm install harbor harbor/harbor \
   --set core.image.repository=cgr.dev/chainguard/harbor-core,core.image.tag=latest \
+  --set database.internal.image.repository=cgr.dev/chainguard/harbor-db,database.internal.image.tag=latest \
   --set jobservice.image.repository=cgr.dev/chainguard/harbor-jobservice,jobservice.image.tag=latest \
   --set portal.image.repository=cgr.dev/chainguard/harbor-portal,portal.image.tag=latest \
   --set registry.registry.image.repository=cgr.dev/chainguard/harbor-registry,registry.registry.image.tag=latest \
@@ -49,6 +50,8 @@ helm install harbor harbor/harbor \
 ```
 
 You will need to override the `image` and `tag` values for each image like we've done here to point to Chainguard's Harbor images and tags.
+
+Also, please note that in a production environment, you'll likely want to use an external database instead of the one provided with Harbor. Additional information on how to configure an external database may be found in Harbor's Helm documentation found [here](https://goharbor.io/docs/2.10.0/install-config/harbor-ha-helm/).
 
 Additionally, you may fetch Harbor's Helm chart after adding the repository and edit values directly without overriding them on installation:
 

--- a/images/harbor/config/main.tf
+++ b/images/harbor/config/main.tf
@@ -8,9 +8,17 @@ variable "component" {
   default = {}
 }
 
+variable "postgres_versions" {
+  default = ["", ""]
+}
+
 locals {
+  postgres_old     = var.postgres_versions[0]
+  postgres_current = var.postgres_versions[1]
+
   commands = {
     "core" : "/harbor/harbor_core",
+    "db" : "/usr/bin/docker-entrypoint.sh ${local.postgres_old} ${local.postgres_current}",
     "jobservice" : "/harbor/harbor_jobservice -c /etc/jobservice/config.yml",
     "portal" : "nginx -g 'daemon off;'"
     "registry" : "/usr/bin/registry_DO_NOT_USE_GC serve /etc/registry/config.yml"
@@ -57,6 +65,19 @@ locals {
       local.certs_path,
       local.harbor_path,
     ]
+    "db" : [{
+      path        = "/var/lib/postgresql/data"
+      type        = "directory"
+      uid         = module.accts.block.run-as
+      gid         = module.accts.block.run-as
+      permissions = 511
+      }, {
+      path        = "/var/run/postgresql"
+      type        = "directory"
+      uid         = module.accts.block.run-as
+      gid         = module.accts.block.run-as
+      permissions = 511
+    }]
     "jobservice" : [{
       path        = "/var/log/jobs"
       type        = "directory"
@@ -147,6 +168,7 @@ locals {
 
   users = {
     "core" : "harbor",
+    "db" : "postgres",
     "jobservice" : "harbor",
     "portal" : "nginx",
     "registry" : "harbor",
@@ -156,6 +178,7 @@ locals {
 
   work-dirs = {
     "core" : "/harbor",
+    "db" : "/",
     "jobservice" : "/harbor",
     "portal" : "/",
     "registry" : "/",
@@ -176,9 +199,9 @@ variable "environment" {
 
 module "accts" {
   source = "../../../tflib/accts"
-  run-as = 65532
-  uid    = 65532
-  gid    = 65532
+  run-as = var.component == "db" ? 999 : 65532
+  uid    = var.component == "db" ? 999 : 65532
+  gid    = var.component == "db" ? 999 : 65532
   name   = local.users[var.component]
 }
 
@@ -190,9 +213,12 @@ output "config" {
     entrypoint = {
       command = local.commands[var.component]
     }
-    accounts    = module.accts.block
-    environment = var.environment
-    paths       = local.paths[var.component]
-    work-dir    = local.work-dirs[var.component]
+    accounts = module.accts.block
+    environment = var.component == "db" ? merge({
+      "PGDATA" : "/var/lib/postgresql/data",
+      "LANG" : "en_US.UTF-8"
+    }, var.environment) : var.environment
+    paths    = local.paths[var.component]
+    work-dir = local.work-dirs[var.component]
   })
 }

--- a/images/harbor/main.tf
+++ b/images/harbor/main.tf
@@ -11,6 +11,7 @@ variable "target_repository" {
 locals {
   components = toset([
     "core",
+    "db",
     "jobservice",
     "portal",
     "registry",
@@ -29,13 +30,17 @@ locals {
   repositories = {
     for k, v in local.components : k => "${var.target_repository}-${k}"
   }
+
+  // Update this when PostgreSQL versions for the latest Harbor DB release change
+  postgres_versions = ["13", "14"]
 }
 
 module "latest-config" {
-  for_each       = local.components
-  source         = "./config"
-  component      = each.key
-  extra_packages = local.packages[each.key]
+  for_each          = local.components
+  source            = "./config"
+  component         = each.key
+  postgres_versions = local.postgres_versions
+  extra_packages    = local.packages[each.key]
 }
 
 module "latest" {

--- a/images/harbor/tests/main.tf
+++ b/images/harbor/tests/main.tf
@@ -9,6 +9,7 @@ variable "digests" {
   description = "The image digests to run tests over."
   type = object({
     core          = string
+    db            = string
     jobservice    = string
     portal        = string
     registry      = string
@@ -51,6 +52,14 @@ module "helm" {
       image = {
         repository = data.oci_string.ref["core"].registry_repo
         tag        = data.oci_string.ref["core"].pseudo_tag
+      }
+    }
+    database = {
+      internal = {
+        image = {
+          repository = data.oci_string.ref["db"].registry_repo
+          tag        = data.oci_string.ref["db"].pseudo_tag
+        }
       }
     }
     jobservice = {


### PR DESCRIPTION
## New Image Pull Request Template

<!--
*** NEW IMAGE PULL REQUEST CHECKLIST: PLEASE START HERE WHEN CREATING NEW IMAGES***

* You are required to check at least one box per section -- no exceptions!

See BEST_PRACTICES.md for more information.
-->

### Image Size
<!--
Image size refers to the amount of disk space / storage space (i.e., MB, GB, etc.)
The common public counterpart is normally the public image available on Docker or equivalent public container registry
-->

- [ ] The Image is smaller in size than its common public counterpart.
- [ ] The Image is larger in size than its common public counterpart (please explain in the notes).

Notes:

### Image Vulnerabilities
<!-- The image should be scanned using the Grype vulnerability scanner -->

- [ ] The Grype vulnerability scan returned 0 CVE(s).
- [ ] The Grype vulnerability scan returned > 0 CVE(s) (please explain in the notes).

Notes:

### Image Tagging
<!-- The image should be tagged with :latest and maybe :latest-dev -->

- [ ] The image is _not_ tagged with version tags.
- [ ] The image is tagged with :latest
- [ ] The image is not tagged with :latest (please explain in the notes).

Notes:

### Basic Testing - K8s cluster
<!-- The container image should run in K8s -->

- [ ] The container image was successfully loaded into a kind cluster.
- [ ] The container image could not be loaded into a kind cluster (please explain in the notes).

Notes:

### Basic Testing - Package/Application
<!-- The package/application should start-up after launching in K8s -->

- [ ] The application is accessible to the user/cluster/etc. after start-up.
- [ ] The application is not accessible to the user/cluster/etc. after start-up. (please explain in the notes).

Notes:

### Helm
<!-- Upstream Helm charts are a great reference and they help ensure quality -->

- [ ] A Helm chart has been provided and the container image can be used with the chart.  If needed, please add a -compat package to close any gaps with the public helm chart.
- [ ] A Helm chart has been provided and the container image is not working with the chart (please explain in the notes).
- [ ] A Helm chart was not provided.

Notes:

### Processor Architectures

- [ ] The image was built and tested for x86_64.
- [ ] The image could not be built for x86_64 (please explain in the notes).
- [ ] The image was built and tested for aarch64.
- [ ] The image could not be built for aarch64. (please explain in the notes).

Notes:

### Functional Testing + Documentation
<!--
You are confident that a customer can run this image in production. Functional tests are a requirement -- no exceptions.

* For builder images (go, python, etc), build a sample app successfully
* For services images (rabbit, databases, webservers) test basic functionality, upstream install/getting started, port availability, admin access. Document differences from public image.
-->

- [ ] Functional tests have been included and the tests are passing.  All tests have been documnted in the notes section.

Notes:

### Environment Testing + Documentation
<!--
Some of our container images will require additional configuration to run on a public cloud provider.
-->

- [ ] There has not been a request and/or there is no indication that this image needs tested on a public cloud provider.
- [ ] The container image has been tested successfully on a public cloud provider (AWS, GCP, Azure).
- [ ] The container image has not been tested successfully on a public cloud provider (AWS, GCP, Azure) (please explain in the notes).

Notes:

### Version

- [ ] The package version is the latest version of the package.  The latest tag points to this version.
- [ ] The package version is the not the latest version of the package (please explain in the notes).

Notes:

### Dev Tag Availability

- [ ] There is a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base')
- [ ] There is not a dev tag available that includes a shell and apk tools (by depending on 'wolfi-base') (please explain in the notes).

Notes:

### Access Control + Authentication

- [ ] The image runs as `nonroot` and GID/UID are set to 65532 or upstream default
- [ ] Alternatively the username and GID/UID may be a commonly used one from the ecosystem e.g: postgres
- [ ] The image requires a non-standard username or non-standard GID/UID (please explain in the notes).

### ENTRYPOINT

- [ ] applications/servers/utilities set to call main program with no arguments e.g. [redis-server]
- [ ] applications/servers/utilities not set to call main program with no arguments e.g. [redis-server] (please explain in the notes)
- [ ] base images leave empty.
- [ ] base image and not empty (please explain in the notes).
- [ ] dev variants is set to entrypoint script that falls back to system.
- [ ] dev variants is not set to entrypoint script that falls back to system (please explain in the notes).

### CMD

- [ ] For server applications give arguments to start in daemon mode (may be empty)
- [ ] For utilities/tooling bring up help e.g. `–help`
- [ ] For base images with a shell, call it e.g. [/bin/sh]

### Environment Variables

- [ ] Environment variables added.
- [ ] Environment variables not added and not required.

### SIGTERM

- [ ] The image responds to SIGTERM (e.g., `docker kill $(docker run -d --rm cgr.dev/chainguard/nginx)`)

### Logs

- [ ] Error logs write to stderr and normal logs to stdout. Logs DO NOT write to file.

### Documentation - README

- [ ] A README file has been provided and it follows the README template.
