### PR TITLE
bincapz: search for header values rather than assuming criticality

### DIFF
--- a/images/bincapz/tests/main.tf
+++ b/images/bincapz/tests/main.tf
@@ -15,5 +15,5 @@ data "oci_exec_test" "help" {
 
 data "oci_exec_test" "test-bincapz" {
   digest = var.digest
-  script = "docker run --rm $IMAGE_NAME /usr/bin/bincapz | grep Risk: | grep 4/CRITICAL"
+  script = "docker run --rm $IMAGE_NAME /usr/bin/bincapz | grep -Ei "RISK|DESCRIPTION|EVIDENCE"
 }

--- a/images/bincapz/tests/main.tf
+++ b/images/bincapz/tests/main.tf
@@ -15,5 +15,5 @@ data "oci_exec_test" "help" {
 
 data "oci_exec_test" "test-bincapz" {
   digest = var.digest
-  script = "docker run --rm $IMAGE_NAME /usr/bin/bincapz | grep -Ei "RISK|DESCRIPTION|EVIDENCE"
+  script = "docker run --rm $IMAGE_NAME /usr/bin/bincapz | grep -Ei 'RISK|DESCRIPTION|EVIDENCE'"
 }


### PR DESCRIPTION
Fixes broken test: https://github.com/chainguard-images/images/actions/runs/8878974775/job/24375737285?pr=2587#step:12:177

The previous test assumed a particular output format and criticality. That criticality will likely change, so this now tests for output headers. I'm still not convinced this is doing the right thing though.