### PR TITLE
Test built kyverno images

### DIFF
--- a/images/kyverno/tests/helm/main.tf
+++ b/images/kyverno/tests/helm/main.tf
@@ -1,3 +1,7 @@
+// WARNING: This has the potential to be flaky for tests using this module. If
+// the upstream helm chart introduces a breaking change we'll need to build and
+// publish the kyverno images before dependent modules will be able to use the
+// updated images and pass tests.
 variable "values" {
   type = any
   default = {

--- a/images/kyverno/tests/main.tf
+++ b/images/kyverno/tests/main.tf
@@ -33,6 +33,51 @@ module "helm" {
   # Use a separate module because this chart is re-used by
   # the kyverno-policy-reporter tests
   source = "./helm"
+  values = {
+    admissionController = {
+      container = {
+        image = {
+          registry   = data.oci_string.ref["admission"].registry
+          repository = data.oci_string.ref["admission"].repo
+          tag        = data.oci_string.ref["admission"].pseudo_tag
+        }
+      }
+      initContainer = {
+        image = {
+          registry   = data.oci_string.ref["init"].registry
+          repository = data.oci_string.ref["init"].repo
+          tag        = data.oci_string.ref["init"].pseudo_tag
+        }
+      }
+    }
+    backgroundController = {
+      container = {
+        image = {
+          registry = data.oci_string.ref["background"].registry
+          registry = data.oci_string.ref["background"].repo
+          tag      = data.oci_string.ref["background"].pseudo_tag
+        }
+      }
+    }
+    cleanupController = {
+      container = {
+        image = {
+          registry = data.oci_string.ref["cleanup"].registry
+          registry = data.oci_string.ref["cleanup"].repo
+          tag      = data.oci_string.ref["cleanup"].pseudo_tag
+        }
+      }
+    }
+    reportsController = {
+      container = {
+        image = {
+          registry = data.oci_string.ref["reports"].registry
+          registry = data.oci_string.ref["reports"].repo
+          tag      = data.oci_string.ref["reports"].pseudo_tag
+        }
+      }
+    }
+  }
 }
 
 resource "imagetest_feature" "basic" {


### PR DESCRIPTION
Previously we were only testing the public images vs the images we just built, so the tests were failing when the helm chart upgraded and we weren't testing our newly built images