### PR TITLE
fix(pytorch-cuda12): Increase Helm timeout again

### DIFF
--- a/images/pytorch-cuda12/tests/main.tf
+++ b/images/pytorch-cuda12/tests/main.tf
@@ -34,7 +34,7 @@ module "helm" {
   namespace = "pytorch"
   repo      = "https://charts.bitnami.com/bitnami"
   chart     = "pytorch"
-  timeout   = "900s"
+  timeout   = "1200s"
 
   values = {
     containerName = "pytorch"


### PR DESCRIPTION
CI still doens't have sufficient time to retrieve the image. Increase this by 5 minutes again