### PR TITLE
fixes for datadog agent

### DIFF
--- a/images/datadog-agent/config/agent/latest.apko.yaml
+++ b/images/datadog-agent/config/agent/latest.apko.yaml
@@ -1,3 +1,8 @@
+contents:
+  packages:
+    - busybox
+    - datadog-agent-oci-compat
+
 accounts:
   groups:
     - groupname: nonroot
@@ -6,7 +11,8 @@ accounts:
     - username: nonroot
       uid: 65532
       gid: 65532
-  run-as: 65532
+  # by default, datadog-agent performs system monitoring and needs privilege
+  run-as: 0
 
 paths:
   - path: /etc/datadog-agent
@@ -16,6 +22,12 @@ paths:
     permissions: 0o755
     recursive: true
   - path: /opt/datadog-agent
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /etc/s6
     type: directory
     uid: 65532
     gid: 65532

--- a/images/datadog-agent/config/agent/main.tf
+++ b/images/datadog-agent/config/agent/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  default     = ["datadog-agent", "datadog-agent-oci-compat"]
+  default     = ["datadog-agent"]
 }
 
 data "apko_config" "this" {


### PR DESCRIPTION
fixes the entrypoints dependencies on `s6-overlay` v2.x

depends on https://github.com/wolfi-dev/os/pull/18194/files