### PR TITLE
Add tomcat-webapps to tomcat images

### DIFF
--- a/generated.tf
+++ b/generated.tf
@@ -993,11 +993,6 @@ module "openai" {
   target_repository = "${var.target_repository}/openai"
 }
 
-module "openldap" {
-  source            = "./images/openldap"
-  target_repository = "${var.target_repository}/openldap"
-}
-
 module "opensearch" {
   source            = "./images/opensearch"
   target_repository = "${var.target_repository}/opensearch"
@@ -2299,10 +2294,6 @@ output "summary_oauth2-proxy" {
 
 output "summary_openai" {
   value = module.openai.summary
-}
-
-output "summary_openldap" {
-  value = module.openldap.summary
 }
 
 output "summary_opensearch" {

--- a/generated.tf
+++ b/generated.tf
@@ -993,6 +993,11 @@ module "openai" {
   target_repository = "${var.target_repository}/openai"
 }
 
+module "openldap" {
+  source            = "./images/openldap"
+  target_repository = "${var.target_repository}/openldap"
+}
+
 module "opensearch" {
   source            = "./images/opensearch"
   target_repository = "${var.target_repository}/opensearch"
@@ -2294,6 +2299,10 @@ output "summary_oauth2-proxy" {
 
 output "summary_openai" {
   value = module.openai.summary
+}
+
+output "summary_openldap" {
+  value = module.openldap.summary
 }
 
 output "summary_opensearch" {

--- a/images/tomcat/config/main.tf
+++ b/images/tomcat/config/main.tf
@@ -7,7 +7,8 @@ terraform {
 variable "extra_packages" {
   description = "The additional packages to install (e.g. tomcat-10)."
   default = [
-    "tomcat-10",
+    "tomcat-10.1",
+    "tomcat-10.1-webapps",
     "tomcat-native",
     "openjdk-17",
     "openjdk-17-default-jvm",

--- a/images/tomcat/config/template.apko.yaml
+++ b/images/tomcat/config/template.apko.yaml
@@ -59,6 +59,10 @@ paths:
     recursive: true
   - path: /usr/share/tomcat/webapps.dist
     type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+    recursive: true
   - path: /usr/local/tomcat
     type: symlink
     source: /usr/share/tomcat

--- a/images/tomcat/config/template.apko.yaml
+++ b/images/tomcat/config/template.apko.yaml
@@ -57,6 +57,8 @@ paths:
     uid: 65532
     gid: 65532
     recursive: true
+  - path: /usr/share/tomcat/webapps.dist
+    type: directory
   - path: /usr/local/tomcat
     type: symlink
     source: /usr/share/tomcat

--- a/images/tomcat/tests/main.tf
+++ b/images/tomcat/tests/main.tf
@@ -10,7 +10,7 @@ variable "digest" {
 
 variable "war_url" {
   description = "The URL to the WAR file to deploy."
-  default     = "https://tomcat.apache.org/tomcat-10.0-doc/appdev/sample/sample.war"
+  default     = "https://tomcat.apache.org/tomcat-10.1-doc/appdev/sample/sample.war"
 }
 
 data "oci_exec_test" "run" {

--- a/images/tomcat/tests/run.sh
+++ b/images/tomcat/tests/run.sh
@@ -10,7 +10,7 @@ function cleanup() {
 
 trap cleanup EXIT
 
-WAR_URL=${WAR_URL:-https://tomcat.apache.org/tomcat-10.0-doc/appdev/sample/sample.war}
+WAR_URL=${WAR_URL:-https://tomcat.apache.org/tomcat-10.1-doc/appdev/sample/sample.war}
 
 curl -sSL -o "${TMPDIR}/sample.war" ${WAR_URL}
 


### PR DESCRIPTION
This adds the `tomcat-webapps` package to our Tomcat images. It includes the `host-manager` and `manager` applications. They are disabled by default, but users expect them to be available to deploy into the webapps directory.