### PR TITLE
use OCI functions instead of datasources

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -129,7 +129,7 @@ jobs:
 
     - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3
       with:
-        terraform_version: '1.6.*'
+        terraform_version: '1.8.*'
         terraform_wrapper: false
     # Make cosign/crane CLI available to the tests
     - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3
         with:
-          terraform_version: "1.6.*"
+          terraform_version: '1.8.*'
           terraform_wrapper: false
 
       - uses: chainguard-dev/actions/setup-chainctl@538d1927b846546b620784754c33e2a1db86e217 # main

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -47,6 +47,7 @@ provider "registry.terraform.io/chainguard-dev/imagetest" {
   version = "0.0.19"
   hashes = [
     "h1:6UFZHE5Ga0Rp8qHfq5g7wMQgxdfa+j9xtDVx+aC4Aj0=",
+    "h1:NZQTQmLm4yEqR5cWb+QugKE4BxHDl/WMVrnykSOH5xI=",
     "zh:457d4e4b0ea763f14fdf59db4ff31481442a9f7788ecd141cb68d25bfb28d3f8",
     "zh:59bf259ecc4775699d7125dcacd8524330a7e2f3751991706d67888040789480",
     "zh:6a415fd6b4e2b587e1e1c67b150c7c690aa59ed7493c5828b7376dabfeb4cda6",
@@ -56,16 +57,16 @@ provider "registry.terraform.io/chainguard-dev/imagetest" {
 }
 
 provider "registry.terraform.io/chainguard-dev/oci" {
-  version     = "0.0.12"
-  constraints = "0.0.12"
+  version     = "0.0.13"
+  constraints = "0.0.13"
   hashes = [
-    "h1:pOOi4TbOzOXYU8eNxYFBjv9DB1MnSlPncKTtUzAAnb0=",
-    "h1:vvRcY6V6rPs0fanN+3ABaymyF5tKT4rnZ/ee2v3jh1k=",
-    "zh:1a822b18b521582ae60c77f884556124c72a2b33be03ad2ab77a8613ea53f58f",
-    "zh:7c997407e1eee960589d53c7bd34940f8c9d801006ceea7d074e23c6283a3064",
+    "h1:4TAkNspi8imVtrMGFAqeiIcRGFMa9M/PUT3xEzncB7A=",
+    "h1:naQlioU+M4cNrqUrd3jyF/jCXHKUDYUMwCcZFFkyFfk=",
+    "zh:17f7956ca9aaeea198e509bcd938eb78d0fcecf4617c919ad685cb65ce3e0a8e",
+    "zh:3315739ce41ce773d7a54d84017e9c7e9f8972185a45f4d49394fffe41f6f8f3",
+    "zh:7927c1b384c78c6ccf4eae5ac0496fe781db22880f9acb5f781c8e0f430f2852",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:ac5e272f5924dd236f4841cfcf6b0d946c22980721247ff6e7c9925f084388f1",
-    "zh:bbe4a0082c4889d9447731e84b353176725f3a88fa9e10a33ed3f67b94ec66ca",
+    "zh:d3e34b2474454dadd892a24978cae8ab3738d49fe3d5c45d0eba994e45d589a3",
   ]
 }
 
@@ -73,6 +74,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version = "2.13.2"
   hashes = [
     "h1:KHLdE3Xb4XbLCWwCSArYcXulYyBJKTFizaIzBiYVJxQ=",
+    "h1:nlSqCo0PajJzjSlx0lXNUq1YcOr8p9b3ahcUUYN2pEg=",
     "zh:06c0663031ef5aa19e238fe50be5d3cbf5fb00548d2b26e779c607dfd2dc69a7",
     "zh:1850b8f2e729553ba8b96d69dce035b814ce959c6805c25484f407c4e720c497",
     "zh:1ec76814a99461cd79ee4c879ed455ab338a3cb9e63fbe9308f91b5515e72e42",

--- a/images/argo/tests/main.tf
+++ b/images/argo/tests/main.tf
@@ -14,10 +14,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -49,23 +46,23 @@ module "helm" {
     }
     server = {
       image = {
-        registry   = join("", [data.oci_string.ref["cli"].registry, ""])
-        repository = data.oci_string.ref["cli"].repo
-        tag        = data.oci_string.ref["cli"].pseudo_tag
+        registry   = join("", [local.parsed["cli"].registry, ""])
+        repository = local.parsed["cli"].repo
+        tag        = local.parsed["cli"].pseudo_tag
 
       }
       executor = {
         image = {
-          registry   = join("", [data.oci_string.ref["exec"].registry, ""])
-          repository = data.oci_string.ref["exec"].repo
-          tag        = data.oci_string.ref["exec"].pseudo_tag
+          registry   = join("", [local.parsed["exec"].registry, ""])
+          repository = local.parsed["exec"].repo
+          tag        = local.parsed["exec"].pseudo_tag
         }
       }
       controller = {
         image = {
-          registry   = join("", [data.oci_string.ref["worfkflowcontroller"].registry, ""])
-          repository = data.oci_string.ref["worfkflowcontroller"].repo
-          tag        = data.oci_string.ref["worfkflowcontroller"].pseudo_tag
+          registry   = join("", [local.parsed["worfkflowcontroller"].registry, ""])
+          repository = local.parsed["worfkflowcontroller"].repo
+          tag        = local.parsed["worfkflowcontroller"].pseudo_tag
         }
       }
     }

--- a/images/argocd-extension-installer/tests/main.tf
+++ b/images/argocd-extension-installer/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digests to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "smoke" {
   digest      = var.digest

--- a/images/argocd/tests/main.tf
+++ b/images/argocd/tests/main.tf
@@ -17,10 +17,7 @@ variable "name" {
   default = "argocd"
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -42,13 +39,13 @@ module "install" {
       }
     }
     image = {
-      tag        = data.oci_string.ref["server"].pseudo_tag
-      repository = data.oci_string.ref["server"].registry_repo
+      tag        = local.parsed["server"].pseudo_tag
+      repository = local.parsed["server"].registry_repo
     }
     repoServer = {
       image = {
-        tag        = data.oci_string.ref["repo-server"].pseudo_tag
-        repository = data.oci_string.ref["repo-server"].registry_repo
+        tag        = local.parsed["repo-server"].pseudo_tag
+        repository = local.parsed["repo-server"].registry_repo
       }
     }
   }

--- a/images/atlantis/tests/main.tf
+++ b/images/atlantis/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "version" {
   digest = var.digest
@@ -36,8 +36,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
       pullPolicy = "Always"
     }
     github = {

--- a/images/aws-for-fluent-bit/tests/main.tf
+++ b/images/aws-for-fluent-bit/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "startup" {
   digest = var.digest
@@ -34,8 +34,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/aws-load-balancer-controller/tests/main.tf
+++ b/images/aws-load-balancer-controller/tests/main.tf
@@ -14,7 +14,7 @@ variable "chart_version" {
   default     = "latest"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -34,8 +34,8 @@ module "helm" {
 
   values = {
     image = {
-      tag        = data.oci_string.ref.pseudo_tag
-      repository = data.oci_string.ref.registry_repo
+      tag        = local.parsed.pseudo_tag
+      repository = local.parsed.registry_repo
     }
     clusterName = "k3d-k3s-default"
     serviceAccount = {

--- a/images/bank-vaults/tests/main.tf
+++ b/images/bank-vaults/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -36,8 +36,8 @@ module "helm" {
   values = {
     bankVaults = {
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   }

--- a/images/cadvisor/tests/main.tf
+++ b/images/cadvisor/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -26,9 +26,9 @@ resource "imagetest_harness_k3s" "this" {
     ]
     envs = {
       "NAMESPACE"        = "cadvisor"
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = local.parsed.repo
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/calico/kind-tests/main.tf
+++ b/images/calico/kind-tests/main.tf
@@ -25,11 +25,7 @@ variable "refs" {
   }
 }
 
-data "oci_ref" "refs" {
-  for_each = var.refs
-
-  ref = each.value
-}
+locals { fetched = { for k, v in var.refs : k => provider::oci::get(v) } }
 
 data "kubectl_file_documents" "docs" {
   for_each = toset([
@@ -38,11 +34,11 @@ data "kubectl_file_documents" "docs" {
   ])
 
   content = templatefile("${path.module}/manifests/${each.value}.yaml.tpl", {
-    CNI_IMAGE              = data.oci_ref.refs["cni"].ref
-    NODE_IMAGE             = data.oci_ref.refs["node"].ref
-    KUBE_CONTROLLERS_IMAGE = data.oci_ref.refs["kube_controllers"].ref
-    TYPHA_IMAGE            = data.oci_ref.refs["typha"].ref
-    CSI_IMAGE              = data.oci_ref.refs["csi"].ref
+    CNI_IMAGE              = local.fetched["cni"].full_ref
+    NODE_IMAGE             = local.fetched["node"].full_ref
+    KUBE_CONTROLLERS_IMAGE = local.fetched["kube_controllers"].full_ref
+    TYPHA_IMAGE            = local.fetched["typha"].full_ref
+    CSI_IMAGE              = local.fetched["csi"].full_ref
   })
 }
 

--- a/images/calico/tests/main.tf
+++ b/images/calico/tests/main.tf
@@ -19,10 +19,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "image" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -64,19 +61,19 @@ metadata:
 spec:
   images:
     - image: calico/node
-      digest: ${data.oci_string.image["node"].digest}
+      digest: ${local.parsed["node"].digest}
     - image: calico/cni
-      digest: ${data.oci_string.image["cni"].digest}
+      digest: ${local.parsed["cni"].digest}
     - image: calico/kube-controllers
-      digest: ${data.oci_string.image["kube-controllers"].digest}
+      digest: ${local.parsed["kube-controllers"].digest}
     - image: calico/pod2daemon-flexvol
-      digest: ${data.oci_string.image["pod2daemon"].digest}
+      digest: ${local.parsed["pod2daemon"].digest}
     - image: calico/csi
-      digest: ${data.oci_string.image["csi"].digest}
+      digest: ${local.parsed["csi"].digest}
     - image: calico/typha
-      digest: ${data.oci_string.image["typha"].digest}
+      digest: ${local.parsed["typha"].digest}
     - image: calico/node-driver-registrar
-      digest: ${data.oci_string.image["node-driver-registrar"].digest}
+      digest: ${local.parsed["node-driver-registrar"].digest}
 EOm
 
 kubectl apply -f - <<EOm
@@ -86,8 +83,8 @@ metadata:
   name: default
 spec:
   variant: Calico
-  registry: ${data.oci_string.image["node"].registry}
-  imagePath: ${split("/", data.oci_string.image["node"].repo)[0]}
+  registry: ${local.parsed["node"].registry}
+  imagePath: ${split("/", local.parsed["node"].repo)[0]}
   imagePrefix: calico-
 EOm
 

--- a/images/cass-config-builder/tests/main.tf
+++ b/images/cass-config-builder/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -25,7 +25,7 @@ resource "imagetest_harness_k3s" "this" {
       }
     ]
     envs = {
-      "IMAGE_NAME" = data.oci_string.ref.id
+      "IMAGE_NAME" = var.digest
     }
   }
 }

--- a/images/cass-operator/tests/main.tf
+++ b/images/cass-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -25,9 +25,9 @@ resource "imagetest_harness_k3s" "this" {
       }
     ]
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = local.parsed.repo
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/cassandra-medusa/tests/main.tf
+++ b/images/cassandra-medusa/tests/main.tf
@@ -11,7 +11,7 @@ variable "digest" {
 
 resource "random_pet" "suffix" {}
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -28,11 +28,11 @@ resource "imagetest_harness_k3s" "this" {
     ]
     envs = {
       "NAMESPACE"              = "k8s-medusa-${random_pet.suffix.id}"
-      "IMAGE_REGISTRY"         = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY"       = split("/", data.oci_string.ref.repo)[0]
-      "NAME"                   = split("/", data.oci_string.ref.repo)[1]
+      "IMAGE_REGISTRY"         = local.parsed.registry
+      "IMAGE_REPOSITORY"       = split("/", local.parsed.repo)[0]
+      "NAME"                   = split("/", local.parsed.repo)[1]
       "K8SSANDRA_CLUSTER_NAME" = "foo-${random_pet.suffix.id}"
-      "IMAGE_TAG"              = data.oci_string.ref.pseudo_tag
+      "IMAGE_TAG"              = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/cassandra-reaper/tests/main.tf
+++ b/images/cassandra-reaper/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -27,9 +27,9 @@ resource "imagetest_harness_k3s" "this" {
       }
     ]
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = split("/", data.oci_string.ref.repo)[0]
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = split("/", local.parsed.repo)[0]
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/cassandra/tests/main.tf
+++ b/images/cassandra/tests/main.tf
@@ -12,7 +12,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -74,7 +74,7 @@ resource "kubernetes_stateful_set" "cassandra" {
       spec {
         container {
           name  = "cassandra"
-          image = "${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+          image = "${local.parsed.registry_repo}:${local.parsed.pseudo_tag}"
 
           port {
             name           = "intra-node"

--- a/images/cert-exporter/tests/main.tf
+++ b/images/cert-exporter/tests/main.tf
@@ -14,9 +14,7 @@ data "oci_exec_test" "test_help_cmd" {
   script = "docker run --rm $IMAGE_NAME --help"
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -36,8 +34,8 @@ resource "helm_release" "test_helm_deploy" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/cert-manager-webhook-pdns/tests/main.tf
+++ b/images/cert-manager-webhook-pdns/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "help" {
   digest = var.digest
@@ -48,8 +48,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/cert-manager/tests/main.tf
+++ b/images/cert-manager/tests/main.tf
@@ -15,10 +15,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -42,25 +39,25 @@ module "install" {
   values = {
     installCRDs = true
     image = {
-      repository = data.oci_string.ref["controller"].registry_repo
-      tag        = data.oci_string.ref["controller"].pseudo_tag
+      repository = local.parsed["controller"].registry_repo
+      tag        = local.parsed["controller"].pseudo_tag
     }
     acmesolver = {
       image = {
-        repository = data.oci_string.ref["acmesolver"].registry_repo
-        tag        = data.oci_string.ref["acmesolver"].pseudo_tag
+        repository = local.parsed["acmesolver"].registry_repo
+        tag        = local.parsed["acmesolver"].pseudo_tag
       }
     }
     cainjector = {
       image = {
-        repository = data.oci_string.ref["cainjector"].registry_repo
-        tag        = data.oci_string.ref["cainjector"].pseudo_tag
+        repository = local.parsed["cainjector"].registry_repo
+        tag        = local.parsed["cainjector"].pseudo_tag
       }
     }
     webhook = {
       image = {
-        repository = data.oci_string.ref["webhook"].registry_repo
-        tag        = data.oci_string.ref["webhook"].pseudo_tag
+        repository = local.parsed["webhook"].registry_repo
+        tag        = local.parsed["webhook"].pseudo_tag
       }
     }
   }

--- a/images/chromium/tests/main.tf
+++ b/images/chromium/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "smoke" {
   digest = var.digest

--- a/images/cluster-autoscaler/tests/main.tf
+++ b/images/cluster-autoscaler/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -29,8 +29,8 @@ module "helm" {
     cloudProvider = "clusterapi"
     global = {
       image = {
-        tag        = data.oci_string.ref.pseudo_tag
-        repository = data.oci_string.ref.registry_repo
+        tag        = local.parsed.pseudo_tag
+        repository = local.parsed.registry_repo
       }
     }
     autoDiscovery = {

--- a/images/cluster-proportional-autoscaler/tests/main.tf
+++ b/images/cluster-proportional-autoscaler/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 resource "helm_release" "cluster-proportional-autoscaler" {
@@ -35,8 +35,8 @@ resource "helm_release" "cluster-proportional-autoscaler" {
     }
 
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/configmap-reload/tests/main.tf
+++ b/images/configmap-reload/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "version" {
   digest = var.digest

--- a/images/cortex/tests/main.tf
+++ b/images/cortex/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -36,8 +36,8 @@ module "helm" {
 
   values = {
     image = {
-      tag        = data.oci_string.ref.pseudo_tag
-      repository = data.oci_string.ref.registry_repo
+      tag        = local.parsed.pseudo_tag
+      repository = local.parsed.registry_repo
     },
     config = {
       blocks_storage = {

--- a/images/crossplane/tests/main.tf
+++ b/images/crossplane/tests/main.tf
@@ -12,10 +12,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -29,8 +26,8 @@ module "helm_crossplane" {
 
   values = {
     image = {
-      repository = data.oci_string.ref["crossplane"].registry_repo
-      tag        = data.oci_string.ref["crossplane"].pseudo_tag
+      repository = local.parsed["crossplane"].registry_repo
+      tag        = local.parsed["crossplane"].pseudo_tag
     }
   }
 }

--- a/images/dask-gateway/tests/main.tf
+++ b/images/dask-gateway/tests/main.tf
@@ -13,10 +13,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -36,20 +33,20 @@ module "helm" {
   values = {
     gateway = {
       image = {
-        tag  = data.oci_string.ref["dask-gateway-server"].pseudo_tag
-        name = data.oci_string.ref["dask-gateway-server"].registry_repo
+        tag  = local.parsed["dask-gateway-server"].pseudo_tag
+        name = local.parsed["dask-gateway-server"].registry_repo
       }
       backend = {
         image = {
-          tag  = data.oci_string.ref["dask-gateway"].pseudo_tag
-          name = data.oci_string.ref["dask-gateway"].registry_repo
+          tag  = local.parsed["dask-gateway"].pseudo_tag
+          name = local.parsed["dask-gateway"].registry_repo
         }
       }
     }
     controller = {
       image = {
-        tag  = data.oci_string.ref["dask-gateway-server"].pseudo_tag
-        name = data.oci_string.ref["dask-gateway-server"].registry_repo
+        tag  = local.parsed["dask-gateway-server"].pseudo_tag
+        name = local.parsed["dask-gateway-server"].registry_repo
       }
     }
   }

--- a/images/datadog-agent/tests/main.tf
+++ b/images/datadog-agent/tests/main.tf
@@ -17,10 +17,7 @@ variable "namespace" {
   default = "datadog-agent-system"
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -49,15 +46,15 @@ module "helm" {
   values = {
     agents = {
       image = {
-        repository    = data.oci_string.ref["agent"].registry_repo
-        tag           = data.oci_string.ref["agent"].pseudo_tag
+        repository    = local.parsed["agent"].registry_repo
+        tag           = local.parsed["agent"].pseudo_tag
         doNotCheckTag = true # pseudo_tag
       }
     }
     clusterAgent = {
       image = {
-        repository    = data.oci_string.ref["cluster-agent"].registry_repo
-        tag           = data.oci_string.ref["cluster-agent"].pseudo_tag
+        repository    = local.parsed["cluster-agent"].registry_repo
+        tag           = local.parsed["cluster-agent"].pseudo_tag
         doNotCheckTag = true # pseudo_tag
       }
     }

--- a/images/docker-selenium/tests/main.tf
+++ b/images/docker-selenium/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "smoke" {
   digest = var.digest

--- a/images/doppler-kubernetes-operator/tests/main.tf
+++ b/images/doppler-kubernetes-operator/tests/main.tf
@@ -10,7 +10,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_id" "id" { byte_length = 4 }
 
@@ -45,9 +45,9 @@ module "helm" {
 
   values = {
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      tag        = data.oci_string.ref.pseudo_tag
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/dragonfly/tests/main.tf
+++ b/images/dragonfly/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -25,8 +25,8 @@ resource "helm_release" "dragonfly" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/dynamic-localpv-provisioner/tests/main.tf
+++ b/images/dynamic-localpv-provisioner/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "dynamic-localpv-provisioner" {
   name = "dynamic-localpv-provisioner"
@@ -19,9 +19,9 @@ resource "helm_release" "dynamic-localpv-provisioner" {
   values = [jsonencode({
     localpv = {
       image = {
-        registry   = join("", [data.oci_string.ref.registry, "/"])
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = join("", [local.parsed.registry, "/"])
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   })]

--- a/images/eck-operator/tests/main.tf
+++ b/images/eck-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -37,8 +37,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/envoy-ratelimit/tests/main.tf
+++ b/images/envoy-ratelimit/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 # TODO: Convert this to imagetest_harness_container when ready
 data "oci_exec_test" "runs" {
@@ -51,8 +51,8 @@ module "helm_ratelimit" {
       # Needed to pick up the right redis endpoint
       fullnameOverride = "ratelimit"
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   }

--- a/images/external-dns/tests/main.tf
+++ b/images/external-dns/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "e2e" {
   digest      = var.digest
@@ -17,11 +17,11 @@ data "oci_exec_test" "e2e" {
 
   env {
     name  = "IMAGE_TAG"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 
   env {
     name  = "IMAGE_REGISTRY_REPO"
-    value = data.oci_string.ref.registry_repo
+    value = local.parsed.registry_repo
   }
 }

--- a/images/external-secrets/tests/main.tf
+++ b/images/external-secrets/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 # TODO: Convert this to imagetest_harness_container when ready
 data "oci_exec_test" "version" {
@@ -47,21 +45,21 @@ module "helm" {
     installCRDs = true
 
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
 
     webhook = {
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     }
 
     certController = {
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   }

--- a/images/falco-no-driver/tests/main.tf
+++ b/images/falco-no-driver/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "helm-install" {
   digest = var.digest
@@ -16,14 +16,14 @@ data "oci_exec_test" "helm-install" {
 
   env {
     name  = "IMAGE_REGISTRY"
-    value = data.oci_string.ref.registry
+    value = local.parsed.registry
   }
   env {
     name  = "IMAGE_REPOSITORY"
-    value = data.oci_string.ref.repo
+    value = local.parsed.repo
   }
   env {
     name  = "IMAGE_TAG"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }

--- a/images/falcosidekick/tests/main.tf
+++ b/images/falcosidekick/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -23,9 +23,9 @@ resource "helm_release" "helm" {
     jsonencode({
       containerName = "falcosidekick"
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
   })]
 }

--- a/images/filebeat/tests/main.tf
+++ b/images/filebeat/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -39,8 +39,8 @@ module "helm" {
   ]
 
   values = {
-    image    = data.oci_string.ref.registry_repo
-    imageTag = data.oci_string.ref.pseudo_tag
+    image    = local.parsed.registry_repo
+    imageTag = local.parsed.pseudo_tag
   }
 }
 

--- a/images/fluent-bit/tests/main.tf
+++ b/images/fluent-bit/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "version" {
   digest = var.digest
@@ -35,8 +35,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
 
     # the helm chart rewrites the entrypoint to /fluent-bit/bin/fluent-bit so we explicitly set it to the path in our image

--- a/images/flux/tests/main.tf
+++ b/images/flux/tests/main.tf
@@ -18,10 +18,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 resource "helm_release" "flux" {
   name             = "flux"
@@ -33,32 +30,32 @@ resource "helm_release" "flux" {
   values = [
     jsonencode({
       cli = {
-        image = data.oci_string.ref["cli"].registry_repo
-        tag   = data.oci_string.ref["cli"].pseudo_tag
+        image = local.parsed["cli"].registry_repo
+        tag   = local.parsed["cli"].pseudo_tag
       }
       helmController = {
-        image = data.oci_string.ref["helm-controller"].registry_repo
-        tag   = data.oci_string.ref["helm-controller"].pseudo_tag
+        image = local.parsed["helm-controller"].registry_repo
+        tag   = local.parsed["helm-controller"].pseudo_tag
       }
       kustomizeController = {
-        image = data.oci_string.ref["kustomize-controller"].registry_repo
-        tag   = data.oci_string.ref["kustomize-controller"].pseudo_tag
+        image = local.parsed["kustomize-controller"].registry_repo
+        tag   = local.parsed["kustomize-controller"].pseudo_tag
       }
       notificationController = {
-        image = data.oci_string.ref["notification-controller"].registry_repo
-        tag   = data.oci_string.ref["notification-controller"].pseudo_tag
+        image = local.parsed["notification-controller"].registry_repo
+        tag   = local.parsed["notification-controller"].pseudo_tag
       }
       sourceController = {
-        image = data.oci_string.ref["source-controller"].registry_repo
-        tag   = data.oci_string.ref["source-controller"].pseudo_tag
+        image = local.parsed["source-controller"].registry_repo
+        tag   = local.parsed["source-controller"].pseudo_tag
       }
       imageAutomationController = {
-        image = data.oci_string.ref["image-automation-controller"].registry_repo
-        tag   = data.oci_string.ref["image-automation-controller"].pseudo_tag
+        image = local.parsed["image-automation-controller"].registry_repo
+        tag   = local.parsed["image-automation-controller"].pseudo_tag
       }
       imageReflectorController = {
-        image = data.oci_string.ref["image-reflector-controller"].registry_repo
-        tag   = data.oci_string.ref["image-reflector-controller"].pseudo_tag
+        image = local.parsed["image-reflector-controller"].registry_repo
+        tag   = local.parsed["image-reflector-controller"].pseudo_tag
       }
     })
   ]

--- a/images/gatekeeper/tests/main.tf
+++ b/images/gatekeeper/tests/main.tf
@@ -19,9 +19,7 @@ variable "skip_crds" {
   default     = false
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -46,8 +44,8 @@ resource "helm_release" "gatekeeper" {
       }
     }
     image = {
-      repository = data.oci_string.ref.registry_repo
-      release    = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      release    = local.parsed.pseudo_tag
     }
     validatingWebhookCheckIgnoreFailurePolicy = "Ignore"
   })]

--- a/images/gha-runner-scale-set-controller/tests/main.tf
+++ b/images/gha-runner-scale-set-controller/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -37,8 +35,8 @@ module "helm" {
   values = {
 
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
 
   }

--- a/images/gitlab/tests/main.tf
+++ b/images/gitlab/tests/main.tf
@@ -16,10 +16,7 @@ variable "digests" {
 
 resource "random_pet" "suffix" {}
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 resource "helm_release" "gitlab" {
   name = "gitlab"
@@ -39,14 +36,14 @@ resource "helm_release" "gitlab" {
     gitlab = {
       kas = {
         image = {
-          tag        = data.oci_string.ref["kas"].pseudo_tag
-          repository = data.oci_string.ref["kas"].registry_repo
+          tag        = local.parsed["kas"].pseudo_tag
+          repository = local.parsed["kas"].registry_repo
         }
       }
       gitlab-exporter = {
         image = {
-          tag        = data.oci_string.ref["exporter"].pseudo_tag
-          repository = data.oci_string.ref["exporter"].registry_repo
+          tag        = local.parsed["exporter"].pseudo_tag
+          repository = local.parsed["exporter"].registry_repo
         }
         extraEnv = {
           CONFIG_FILENAME = "gitlab-exporter.yml"
@@ -54,8 +51,8 @@ resource "helm_release" "gitlab" {
       }
       gitlab-pages = {
         image = {
-          tag        = data.oci_string.ref["pages"].pseudo_tag
-          repository = data.oci_string.ref["pages"].registry_repo
+          tag        = local.parsed["pages"].pseudo_tag
+          repository = local.parsed["pages"].registry_repo
         }
         resources = {
           requests = {
@@ -81,8 +78,8 @@ resource "helm_release" "gitlab" {
         minReplicas = 1
         maxReplicas = 1
         image = {
-          tag        = data.oci_string.ref["shell"].pseudo_tag
-          repository = data.oci_string.ref["shell"].registry_repo
+          tag        = local.parsed["shell"].pseudo_tag
+          repository = local.parsed["shell"].registry_repo
         }
       }
     }

--- a/images/go-ipfs/tests/main.tf
+++ b/images/go-ipfs/tests/main.tf
@@ -19,8 +19,6 @@ data "oci_exec_test" "docker-test" {
   working_dir = path.module
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}

--- a/images/gptscript/tests/main.tf
+++ b/images/gptscript/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "smoke" {
   digest = var.digest

--- a/images/gpu-feature-discovery/tests/main.tf
+++ b/images/gpu-feature-discovery/tests/main.tf
@@ -13,7 +13,7 @@ variable "name" {
   default = "gpu-feature-discovery"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -40,8 +40,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/grafana-agent-operator/tests/main.tf
+++ b/images/grafana-agent-operator/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "manifest" {
   digest      = var.digest
@@ -29,9 +29,9 @@ resource "helm_release" "operator" {
   values = [
     jsonencode({
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
     })
   ]

--- a/images/grafana-mimir/tests/main.tf
+++ b/images/grafana-mimir/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -40,8 +40,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/grafana-operator/tests/main.tf
+++ b/images/grafana-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -23,8 +23,8 @@ resource "imagetest_harness_k3s" "this" {
       destination = "/tests"
     }]
     envs = {
-      "IMAGE_NAME" = data.oci_string.ref.registry_repo
-      "IMAGE_TAG"  = data.oci_string.ref.pseudo_tag
+      "IMAGE_NAME" = local.parsed.registry_repo
+      "IMAGE_TAG"  = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/grafana/tests/main.tf
+++ b/images/grafana/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_id" "hex" { byte_length = 4 }
 
@@ -23,9 +23,9 @@ resource "helm_release" "helm_test" {
 
   values = [jsonencode({
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      tag        = data.oci_string.ref.pseudo_tag
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/haproxy-ingress/tests/main.tf
+++ b/images/haproxy-ingress/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "haproxy-ingress" {
   name = "haproxy-ingress"
@@ -23,8 +23,8 @@ resource "helm_release" "haproxy-ingress" {
   values = [jsonencode({
     controller = {
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   })]

--- a/images/haproxy/tests/main.tf
+++ b/images/haproxy/tests/main.tf
@@ -8,9 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -33,8 +31,8 @@ resource "helm_release" "redis-ha" {
         enabled          = true
         hardAntiAffinity = false
         image = {
-          repository = data.oci_string.ref.registry_repo
-          tag        = data.oci_string.ref.pseudo_tag
+          repository = local.parsed.registry_repo
+          tag        = local.parsed.pseudo_tag
         }
         containerSecurityContext = {
           capabilities = { add = ["NET_BIND_SERVICE"] }

--- a/images/harbor/tests/main.tf
+++ b/images/harbor/tests/main.tf
@@ -17,10 +17,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -49,39 +46,39 @@ module "helm" {
   values = {
     core = {
       image = {
-        repository = data.oci_string.ref["core"].registry_repo
-        tag        = data.oci_string.ref["core"].pseudo_tag
+        repository = local.parsed["core"].registry_repo
+        tag        = local.parsed["core"].pseudo_tag
       }
     }
     jobservice = {
       image = {
-        repository = data.oci_string.ref["jobservice"].registry_repo
-        tag        = data.oci_string.ref["jobservice"].pseudo_tag
+        repository = local.parsed["jobservice"].registry_repo
+        tag        = local.parsed["jobservice"].pseudo_tag
       }
     }
     portal = {
       image = {
-        repository = data.oci_string.ref["portal"].registry_repo
-        tag        = data.oci_string.ref["portal"].pseudo_tag
+        repository = local.parsed["portal"].registry_repo
+        tag        = local.parsed["portal"].pseudo_tag
       }
     }
     registry = {
       registry = {
         image = {
-          repository = data.oci_string.ref["registry"].registry_repo
-          tag        = data.oci_string.ref["registry"].pseudo_tag
+          repository = local.parsed["registry"].registry_repo
+          tag        = local.parsed["registry"].pseudo_tag
         }
       }
       registryctl = {
         image = {
-          repository = data.oci_string.ref["registryctl"].registry_repo
-          tag        = data.oci_string.ref["registryctl"].pseudo_tag
+          repository = local.parsed["registryctl"].registry_repo
+          tag        = local.parsed["registryctl"].pseudo_tag
         }
       }
       trivy = {
         image = {
-          repository = data.oci_string.ref["trivy-adapter"].registry_repo
-          tag        = data.oci_string.ref["trivy-adapter"].pseudo_tag
+          repository = local.parsed["trivy-adapter"].registry_repo
+          tag        = local.parsed["trivy-adapter"].pseudo_tag
         }
       }
     }

--- a/images/influxdb/tests/main.tf
+++ b/images/influxdb/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -25,8 +25,8 @@ resource "helm_release" "influxdb" {
 
   values = [jsonencode({
     image = {
-      tag        = data.oci_string.ref.pseudo_tag
-      repository = data.oci_string.ref.registry_repo
+      tag        = local.parsed.pseudo_tag
+      repository = local.parsed.registry_repo
     }
   })]
 }

--- a/images/ingress-nginx-controller/tests/main.tf
+++ b/images/ingress-nginx-controller/tests/main.tf
@@ -14,7 +14,7 @@ variable "ingress_class" {
   default     = "nginx"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -44,9 +44,9 @@ module "helm" {
   values = {
     controller = {
       image = {
-        image    = data.oci_string.ref.repo
-        registry = data.oci_string.ref.registry
-        digest   = data.oci_string.ref.digest
+        image    = local.parsed.repo
+        registry = local.parsed.registry
+        digest   = local.parsed.digest
       }
       ingressClass = var.ingress_class
       ingressClassResource = {

--- a/images/jellyfin/tests/main.tf
+++ b/images/jellyfin/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "smoke" {
   digest = var.digest

--- a/images/jenkins/tests/main.tf
+++ b/images/jenkins/tests/main.tf
@@ -13,7 +13,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -52,9 +52,9 @@ module "helm_controller" {
         }
       }
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   }

--- a/images/jitsucom-bulker/tests/main.tf
+++ b/images/jitsucom-bulker/tests/main.tf
@@ -14,10 +14,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 variable "namespace" {
   default = "jitsucom-bulker"
@@ -52,20 +49,20 @@ module "helm" {
   values = {
     bulker = {
       image = {
-        repository = data.oci_string.ref["bulker"].registry_repo
-        tag        = data.oci_string.ref["bulker"].pseudo_tag
+        repository = local.parsed["bulker"].registry_repo
+        tag        = local.parsed["bulker"].pseudo_tag
       }
     }
     ingest = {
       image = {
-        repository = data.oci_string.ref["ingest"].registry_repo
-        tag        = data.oci_string.ref["ingest"].pseudo_tag
+        repository = local.parsed["ingest"].registry_repo
+        tag        = local.parsed["ingest"].pseudo_tag
       }
     }
     syncctl = {
       image = {
-        repository = data.oci_string.ref["syncctl"].registry_repo
-        tag        = data.oci_string.ref["syncctl"].pseudo_tag
+        repository = local.parsed["syncctl"].registry_repo
+        tag        = local.parsed["syncctl"].pseudo_tag
       }
     }
     tokenGenerator = {

--- a/images/k8s-sidecar/tests/main.tf
+++ b/images/k8s-sidecar/tests/main.tf
@@ -14,7 +14,7 @@ data "oci_exec_test" "runs" {
   script = "${path.module}/01-runs.sh"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -28,15 +28,15 @@ resource "helm_release" "k8s-sidecar" {
 
   set {
     name  = "grafana.sidecar.image.registry"
-    value = data.oci_string.ref.registry
+    value = local.parsed.registry
   }
   set {
     name  = "grafana.sidecar.image.repository"
-    value = data.oci_string.ref.repo
+    value = local.parsed.repo
   }
   set {
     name  = "grafana.sidecar.image.tag"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }
 

--- a/images/k8sgpt-operator/tests/main.tf
+++ b/images/k8sgpt-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "k8sgpt-operator" {
   name = "k8sgpt-operator"
@@ -21,8 +21,8 @@ resource "helm_release" "k8sgpt-operator" {
   values = [jsonencode({
     manager = {
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   })]

--- a/images/k8ssandra-operator/tests/main.tf
+++ b/images/k8ssandra-operator/tests/main.tf
@@ -13,9 +13,7 @@ variable "name" {
   default = "k8ssandra-operator"
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -43,9 +41,9 @@ module "helm_k8ssandra" {
 
   values = {
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      tag        = data.oci_string.ref.pseudo_tag
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/kafka/tests/main.tf
+++ b/images/kafka/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -21,9 +21,9 @@ resource "helm_release" "bitnami" {
 
   values = [jsonencode({
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      digest     = data.oci_string.ref.digest
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      digest     = local.parsed.digest
     }
     controller = {
       containerSecurityContext = {

--- a/images/keda/tests/main.tf
+++ b/images/keda/tests/main.tf
@@ -18,10 +18,7 @@ variable "name" {
   default = "keda"
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -51,16 +48,16 @@ module "install" {
   values = {
     image = {
       keda = {
-        repository = data.oci_string.ref["keda"].registry_repo
-        tag        = data.oci_string.ref["keda"].pseudo_tag
+        repository = local.parsed["keda"].registry_repo
+        tag        = local.parsed["keda"].pseudo_tag
       }
       metricsApiServer = {
-        repository = data.oci_string.ref["keda-adapter"].registry_repo
-        tag        = data.oci_string.ref["keda-adapter"].pseudo_tag
+        repository = local.parsed["keda-adapter"].registry_repo
+        tag        = local.parsed["keda-adapter"].pseudo_tag
       }
       webhooks = {
-        repository = data.oci_string.ref["keda-admission-webhooks"].registry_repo
-        tag        = data.oci_string.ref["keda-admission-webhooks"].pseudo_tag
+        repository = local.parsed["keda-admission-webhooks"].registry_repo
+        tag        = local.parsed["keda-admission-webhooks"].pseudo_tag
       }
     }
   }

--- a/images/keycloak/tests/main.tf
+++ b/images/keycloak/tests/main.tf
@@ -22,9 +22,7 @@ data "oci_exec_test" "help" {
   digest = var.digest
   script = "docker run --rm $IMAGE_NAME --help"
 }
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -36,8 +34,8 @@ resource "helm_release" "test" {
   values = [jsonencode({
     image = {
       registry   = ""
-      repository = data.oci_string.ref.registry_repo,
-      digest     = data.oci_string.ref.digest
+      repository = local.parsed.registry_repo,
+      digest     = local.parsed.digest
     },
     args = var.args
   })]

--- a/images/kor/tests/main.tf
+++ b/images/kor/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "helm-install" {
   digest = var.digest
@@ -16,10 +16,10 @@ data "oci_exec_test" "helm-install" {
 
   env {
     name  = "IMAGE_REGISTRY_REPO"
-    value = data.oci_string.ref.registry_repo
+    value = local.parsed.registry_repo
   }
   env {
     name  = "IMAGE_TAG"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }

--- a/images/kube-fluentd-operator/tests/main.tf
+++ b/images/kube-fluentd-operator/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -38,8 +36,8 @@ module "helm" {
       create = true
     },
     image = {
-      repository = data.oci_string.ref.registry_repo,
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo,
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/kube-logging-operator-fluentd/tests/main.tf
+++ b/images/kube-logging-operator-fluentd/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -49,10 +49,10 @@ data "oci_exec_test" "check-logging-operator" {
     value = helm_release.log-generator.namespace
     }, {
     name  = "FLUENTD_REPOSITORY"
-    value = data.oci_string.ref.registry_repo
+    value = local.parsed.registry_repo
     }, {
     name  = "FLUENTD_TAG"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }]
 }
 

--- a/images/kube-logging-operator/tests/main.tf
+++ b/images/kube-logging-operator/tests/main.tf
@@ -10,7 +10,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_id" "id" { byte_length = 4 }
 
@@ -24,8 +24,8 @@ resource "helm_release" "kube-logging-operator" {
   values = [
     <<EOF
 image:
-  repository: "${data.oci_string.ref.registry_repo}"
-  tag: "${data.oci_string.ref.pseudo_tag}"
+  repository: "${local.parsed.registry_repo}"
+  tag: "${local.parsed.pseudo_tag}"
 EOF
   ]
 }

--- a/images/kube-state-metrics/tests/main.tf
+++ b/images/kube-state-metrics/tests/main.tf
@@ -10,7 +10,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -26,9 +26,9 @@ resource "helm_release" "kube-state-metrics" {
   values = [
     jsonencode({
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
     }),
   ]

--- a/images/kube-vip/tests/main.tf
+++ b/images/kube-vip/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -27,9 +25,9 @@ resource "imagetest_harness_k3s" "this" {
       }
     ]
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = local.parsed.repo
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
   }
 

--- a/images/kube-webhook-certgen/tests/main.tf
+++ b/images/kube-webhook-certgen/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -31,9 +31,9 @@ module "helm" {
       admissionWebhooks = {
         patch = {
           image = {
-            registry   = data.oci_string.ref.registry
-            repository = data.oci_string.ref.repo
-            tag        = data.oci_string.ref.pseudo_tag
+            registry   = local.parsed.registry
+            repository = local.parsed.repo
+            tag        = local.parsed.pseudo_tag
           }
         }
       }

--- a/images/kubeflow-centraldashboard/tests/main.tf
+++ b/images/kubeflow-centraldashboard/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digests to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "runs" {
   digest      = var.digest
@@ -20,10 +18,10 @@ data "oci_exec_test" "runs" {
 
   env {
     name  = "IMAGE_REGISTRY_REPO"
-    value = data.oci_string.ref.registry_repo
+    value = local.parsed.registry_repo
   }
   env {
     name  = "IMAGE_TAG"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }

--- a/images/kubeflow-katib/tests/main.tf
+++ b/images/kubeflow-katib/tests/main.tf
@@ -21,10 +21,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "oci_exec_test" "smoke" {
   digest = var.digests["controller"] # This doesn't actually matter here, just pass it something valid
@@ -32,101 +29,101 @@ data "oci_exec_test" "smoke" {
 
   env {
     name  = "IMAGE_REPOSITORY_CONTROLLER"
-    value = data.oci_string.ref["controller"].registry_repo
+    value = local.parsed["controller"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_CONTROLLER_TAG"
-    value = data.oci_string.ref["controller"].pseudo_tag
+    value = local.parsed["controller"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_DB_MANAGER"
-    value = data.oci_string.ref["db-manager"].registry_repo
+    value = local.parsed["db-manager"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_DB_MANAGER_TAG"
-    value = data.oci_string.ref["db-manager"].pseudo_tag
+    value = local.parsed["db-manager"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_EARLYSTOPPING"
-    value = data.oci_string.ref["earlystopping"].registry_repo
+    value = local.parsed["earlystopping"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_EARLYSTOPPING_TAG"
-    value = data.oci_string.ref["earlystopping"].pseudo_tag
+    value = local.parsed["earlystopping"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_FILE_METRICSCOLLECTOR"
-    value = data.oci_string.ref["file-metricscollector"].registry_repo
+    value = local.parsed["file-metricscollector"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_FILE_METRICSCOLLECTOR_TAG"
-    value = data.oci_string.ref["file-metricscollector"].pseudo_tag
+    value = local.parsed["file-metricscollector"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_GOPTUNA"
-    value = data.oci_string.ref["suggestion-goptuna"].registry_repo
+    value = local.parsed["suggestion-goptuna"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_GOPTUNA_TAG"
-    value = data.oci_string.ref["suggestion-goptuna"].pseudo_tag
+    value = local.parsed["suggestion-goptuna"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_HYPERBAND"
-    value = data.oci_string.ref["suggestion-hyperband"].registry_repo
+    value = local.parsed["suggestion-hyperband"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_HYPERBAND_TAG"
-    value = data.oci_string.ref["suggestion-hyperband"].pseudo_tag
+    value = local.parsed["suggestion-hyperband"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_HYPEROPT"
-    value = data.oci_string.ref["suggestion-hyperopt"].registry_repo
+    value = local.parsed["suggestion-hyperopt"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_HYPEROPT_TAG"
-    value = data.oci_string.ref["suggestion-hyperopt"].pseudo_tag
+    value = local.parsed["suggestion-hyperopt"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_NAS_DARTS"
-    value = data.oci_string.ref["suggestion-nas-darts"].registry_repo
+    value = local.parsed["suggestion-nas-darts"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_NAS_DARTS_TAG"
-    value = data.oci_string.ref["suggestion-nas-darts"].pseudo_tag
+    value = local.parsed["suggestion-nas-darts"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_OPTUNA"
-    value = data.oci_string.ref["suggestion-optuna"].registry_repo
+    value = local.parsed["suggestion-optuna"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_OPTUNA_TAG"
-    value = data.oci_string.ref["suggestion-optuna"].pseudo_tag
+    value = local.parsed["suggestion-optuna"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_PBT"
-    value = data.oci_string.ref["suggestion-pbt"].registry_repo
+    value = local.parsed["suggestion-pbt"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_PBT_TAG"
-    value = data.oci_string.ref["suggestion-pbt"].pseudo_tag
+    value = local.parsed["suggestion-pbt"].pseudo_tag
   }
 
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_SKOPT"
-    value = data.oci_string.ref["suggestion-skopt"].registry_repo
+    value = local.parsed["suggestion-skopt"].registry_repo
   }
   env {
     name  = "IMAGE_REPOSITORY_SUGGESTION_SKOPT_TAG"
-    value = data.oci_string.ref["suggestion-skopt"].pseudo_tag
+    value = local.parsed["suggestion-skopt"].pseudo_tag
   }
 }
 

--- a/images/kubeflow-pipelines/tests/main.tf
+++ b/images/kubeflow-pipelines/tests/main.tf
@@ -20,10 +20,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -54,29 +51,29 @@ resources:
   - github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$KUBEFLOW_PIPELINES_VERSION
 images:
   - name: gcr.io/ml-pipeline/api-server
-    newName: ${data.oci_string.ref["api-server"].registry_repo}
-    newTag: ${data.oci_string.ref["api-server"].pseudo_tag}
+    newName: ${local.parsed["api-server"].registry_repo}
+    newTag: ${local.parsed["api-server"].pseudo_tag}
   - name: gcr.io/ml-pipeline/cache-deployer
-    newName: ${data.oci_string.ref["cache-deployer"].registry_repo}
-    newTag: ${data.oci_string.ref["cache-deployer"].pseudo_tag}
+    newName: ${local.parsed["cache-deployer"].registry_repo}
+    newTag: ${local.parsed["cache-deployer"].pseudo_tag}
   - name: gcr.io/ml-pipeline/cache-server
-    newName: ${data.oci_string.ref["cache-server"].registry_repo}
-    newTag: ${data.oci_string.ref["cache-server"].pseudo_tag}
+    newName: ${local.parsed["cache-server"].registry_repo}
+    newTag: ${local.parsed["cache-server"].pseudo_tag}
   - name: gcr.io/ml-pipeline/metadata-writer
-    newName: ${data.oci_string.ref["metadata-writer"].registry_repo}
-    newTag: ${data.oci_string.ref["metadata-writer"].pseudo_tag}
+    newName: ${local.parsed["metadata-writer"].registry_repo}
+    newTag: ${local.parsed["metadata-writer"].pseudo_tag}
   - name: gcr.io/ml-pipeline/persistenceagent
-    newName: ${data.oci_string.ref["persistenceagent"].registry_repo}
-    newTag: ${data.oci_string.ref["persistenceagent"].pseudo_tag}
+    newName: ${local.parsed["persistenceagent"].registry_repo}
+    newTag: ${local.parsed["persistenceagent"].pseudo_tag}
   - name: gcr.io/ml-pipeline/scheduledworkflow
-    newName: ${data.oci_string.ref["scheduledworkflow"].registry_repo}
-    newTag: ${data.oci_string.ref["scheduledworkflow"].pseudo_tag}
+    newName: ${local.parsed["scheduledworkflow"].registry_repo}
+    newTag: ${local.parsed["scheduledworkflow"].pseudo_tag}
   - name: gcr.io/ml-pipeline/frontend
-    newName: ${data.oci_string.ref["frontend"].registry_repo}
-    newTag: ${data.oci_string.ref["frontend"].pseudo_tag}
+    newName: ${local.parsed["frontend"].registry_repo}
+    newTag: ${local.parsed["frontend"].pseudo_tag}
   - name: gcr.io/ml-pipeline/metadata-envoy
-    newName: ${data.oci_string.ref["metadata-envoy"].registry_repo}
-    newTag: ${data.oci_string.ref["metadata-envoy"].pseudo_tag}
+    newName: ${local.parsed["metadata-envoy"].registry_repo}
+    newTag: ${local.parsed["metadata-envoy"].pseudo_tag}
 EOm
       EOF
     },

--- a/images/kubeflow/tests/main.tf
+++ b/images/kubeflow/tests/main.tf
@@ -13,10 +13,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -35,10 +32,10 @@ resource "imagetest_feature" "basic" {
       name = "Test",
       cmd = templatefile("${path.module}/test.sh.tpl",
         {
-          jupyter_registry_repo = data.oci_string.ref["jupyter-web-app"].registry_repo,
-          jupyter_tag           = data.oci_string.ref["jupyter-web-app"].pseudo_tag,
-          volumes_registry_repo = data.oci_string.ref["volumes-web-app"].registry_repo,
-          volumes_tag           = data.oci_string.ref["volumes-web-app"].pseudo_tag,
+          jupyter_registry_repo = local.parsed["jupyter-web-app"].registry_repo,
+          jupyter_tag           = local.parsed["jupyter-web-app"].pseudo_tag,
+          volumes_registry_repo = local.parsed["volumes-web-app"].registry_repo,
+          volumes_tag           = local.parsed["volumes-web-app"].pseudo_tag,
         }
       )
     },

--- a/images/kuberay-operator/tests/main.tf
+++ b/images/kuberay-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -23,8 +23,8 @@ resource "helm_release" "kuberay-operator" {
   values = [
     jsonencode({
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     }),
   ]

--- a/images/kubernetes-autoscaler-addon-resizer/tests/main.tf
+++ b/images/kubernetes-autoscaler-addon-resizer/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -28,7 +28,7 @@ resource "imagetest_feature" "basic" {
       name = "Deploy"
       cmd  = <<EOF
  kubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/master/addon-resizer/deploy/example.yaml
- kubectl set image deployment/nanny-v1 pod-nanny="${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+ kubectl set image deployment/nanny-v1 pod-nanny="${local.parsed.registry_repo}:${local.parsed.pseudo_tag}"
        EOF
     },
     {

--- a/images/kubernetes-dashboard/tests/main.tf
+++ b/images/kubernetes-dashboard/tests/main.tf
@@ -13,10 +13,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 resource "helm_release" "kubernetes-dashboard" {
   name = "kubernetes-dashboard"
@@ -32,13 +29,13 @@ resource "helm_release" "kubernetes-dashboard" {
 
   values = [jsonencode({
     image = {
-      tag        = data.oci_string.ref["dashboard"].pseudo_tag
-      repository = data.oci_string.ref["dashboard"].registry_repo
+      tag        = local.parsed["dashboard"].pseudo_tag
+      repository = local.parsed["dashboard"].registry_repo
     }
     metricsScraper = {
       image = {
-        tag        = data.oci_string.ref["metrics-scraper"].pseudo_tag
-        repository = data.oci_string.ref["metrics-scraper"].registry_repo
+        tag        = local.parsed["metrics-scraper"].pseudo_tag
+        repository = local.parsed["metrics-scraper"].registry_repo
       }
       enabled = true
     }

--- a/images/kubernetes-dns-node-cache/tests/main.tf
+++ b/images/kubernetes-dns-node-cache/tests/main.tf
@@ -10,9 +10,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -37,8 +35,8 @@ module "helm" {
   name   = "node-local-dns"
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
     config = {
       localDns = "0.0.0.0"

--- a/images/kubernetes-event-exporter/tests/main.tf
+++ b/images/kubernetes-event-exporter/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -22,9 +22,9 @@ resource "helm_release" "kubernetes-event-exporter" {
   values = [jsonencode({
     containerName = "kubernetes-event-exporter"
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      digest     = data.oci_string.ref.digest
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      digest     = local.parsed.digest
     }
   })]
 }

--- a/images/kubewatch/tests/main.tf
+++ b/images/kubewatch/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "kubewatch" {
   name = "kubewatch"
@@ -25,9 +23,9 @@ resource "helm_release" "kubewatch" {
   values = [
     jsonencode({
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
     }),
   ]

--- a/images/kyverno-policy-reporter/tests/main.tf
+++ b/images/kyverno-policy-reporter/tests/main.tf
@@ -19,10 +19,7 @@ variable "chart-version" {
   default     = ""
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -45,9 +42,9 @@ module "policy_reporter_helm" {
 
   values = {
     image = {
-      registry   = data.oci_string.ref["reporter"].registry
-      repository = data.oci_string.ref["reporter"].repo
-      tag        = data.oci_string.ref["reporter"].pseudo_tag
+      registry   = local.parsed["reporter"].registry
+      repository = local.parsed["reporter"].repo
+      tag        = local.parsed["reporter"].pseudo_tag
     }
 
     ui = {
@@ -56,18 +53,18 @@ module "policy_reporter_helm" {
         kyverno = true
       }
       image = {
-        registry   = data.oci_string.ref["ui"].registry
-        repository = data.oci_string.ref["ui"].repo
-        tag        = data.oci_string.ref["ui"].pseudo_tag
+        registry   = local.parsed["ui"].registry
+        repository = local.parsed["ui"].repo
+        tag        = local.parsed["ui"].pseudo_tag
       }
     }
 
     kyvernoPlugin = {
       enabled = true
       image = {
-        registry   = data.oci_string.ref["plugin"].registry
-        repository = data.oci_string.ref["plugin"].repo
-        tag        = data.oci_string.ref["plugin"].pseudo_tag
+        registry   = local.parsed["plugin"].registry
+        repository = local.parsed["plugin"].repo
+        tag        = local.parsed["plugin"].pseudo_tag
       }
     }
   }

--- a/images/kyverno/tests/main.tf
+++ b/images/kyverno/tests/main.tf
@@ -17,10 +17,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -37,43 +34,43 @@ module "helm" {
     admissionController = {
       container = {
         image = {
-          registry   = data.oci_string.ref["admission"].registry
-          repository = data.oci_string.ref["admission"].repo
-          tag        = data.oci_string.ref["admission"].pseudo_tag
+          registry   = local.parsed["admission"].registry
+          repository = local.parsed["admission"].repo
+          tag        = local.parsed["admission"].pseudo_tag
         }
       }
       initContainer = {
         image = {
-          registry   = data.oci_string.ref["init"].registry
-          repository = data.oci_string.ref["init"].repo
-          tag        = data.oci_string.ref["init"].pseudo_tag
+          registry   = local.parsed["init"].registry
+          repository = local.parsed["init"].repo
+          tag        = local.parsed["init"].pseudo_tag
         }
       }
     }
     backgroundController = {
       container = {
         image = {
-          registry = data.oci_string.ref["background"].registry
-          registry = data.oci_string.ref["background"].repo
-          tag      = data.oci_string.ref["background"].pseudo_tag
+          registry = local.parsed["background"].registry
+          registry = local.parsed["background"].repo
+          tag      = local.parsed["background"].pseudo_tag
         }
       }
     }
     cleanupController = {
       container = {
         image = {
-          registry = data.oci_string.ref["cleanup"].registry
-          registry = data.oci_string.ref["cleanup"].repo
-          tag      = data.oci_string.ref["cleanup"].pseudo_tag
+          registry = local.parsed["cleanup"].registry
+          registry = local.parsed["cleanup"].repo
+          tag      = local.parsed["cleanup"].pseudo_tag
         }
       }
     }
     reportsController = {
       container = {
         image = {
-          registry = data.oci_string.ref["reports"].registry
-          registry = data.oci_string.ref["reports"].repo
-          tag      = data.oci_string.ref["reports"].pseudo_tag
+          registry = local.parsed["reports"].registry
+          registry = local.parsed["reports"].repo
+          tag      = local.parsed["reports"].pseudo_tag
         }
       }
     }

--- a/images/local-volume-node-cleanup/main.tf
+++ b/images/local-volume-node-cleanup/main.tf
@@ -31,15 +31,13 @@ module "local-volume-node-cleanup" {
   main_package = each.key
 }
 
-data "oci_ref" "local-volume-provisioner" {
-  ref = "cgr.dev/chainguard/local-volume-provisioner:latest"
-}
+locals { provisioner = provider::oci::get("cgr.dev/chainguard/local-volume-provisioner:latest") }
 
 module "test" {
   for_each = toset(local.components)
   source   = "./tests"
   digests = {
-    local-volume-provisioner  = data.oci_ref.local-volume-provisioner.id
+    local-volume-provisioner  = local.provisioner.full_ref
     local-volume-node-cleanup = module.local-volume-node-cleanup[each.key].image_ref
   }
 }

--- a/images/local-volume-node-cleanup/tests/main.tf
+++ b/images/local-volume-node-cleanup/tests/main.tf
@@ -13,10 +13,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -45,7 +42,7 @@ resource "imagetest_feature" "basic" {
       cmd  = <<EOF
       kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/deployment/kubernetes/example/default_example_storageclass.yaml
       kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/deployment/kubernetes/example/default_example_provisioner_generated.yaml
-      kubectl set image daemonset/local-volume-provisioner provisioner="${data.oci_string.ref["local-volume-provisioner"].registry_repo}:${data.oci_string.ref["local-volume-provisioner"].pseudo_tag}"
+      kubectl set image daemonset/local-volume-provisioner provisioner="${local.parsed["local-volume-provisioner"].registry_repo}:${local.parsed["local-volume-provisioner"].pseudo_tag}"
       EOF
     },
     {
@@ -59,7 +56,7 @@ resource "imagetest_feature" "basic" {
       cmd  = <<EOF
         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/deployment/kubernetes/example/node-cleanup-controller/rbac.yaml
         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/deployment/kubernetes/example/node-cleanup-controller/deployment.yaml
-        kubectl set image deployment/local-volume-node-cleanup-controller local-volume-node-cleanup-controller="${data.oci_string.ref["local-volume-node-cleanup"].registry_repo}:${data.oci_string.ref["local-volume-node-cleanup"].pseudo_tag}"
+        kubectl set image deployment/local-volume-node-cleanup-controller local-volume-node-cleanup-controller="${local.parsed["local-volume-node-cleanup"].registry_repo}:${local.parsed["local-volume-node-cleanup"].pseudo_tag}"
         kubectl patch deployment local-volume-node-cleanup-controller --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/0", "value":"--storageclass-names=fast-disks"}]'
       EOF
     },

--- a/images/local-volume-provisioner/tests/main.tf
+++ b/images/local-volume-provisioner/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -29,7 +29,7 @@ resource "imagetest_feature" "basic" {
       cmd  = <<EOF
       kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/deployment/kubernetes/example/default_example_storageclass.yaml
       kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-storage-local-static-provisioner/master/deployment/kubernetes/example/default_example_provisioner_generated.yaml
-      kubectl set image daemonset/local-volume-provisioner provisioner="${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+      kubectl set image daemonset/local-volume-provisioner provisioner="${local.parsed.registry_repo}:${local.parsed.pseudo_tag}"
       EOF
     },
     {

--- a/images/logstash-oss-with-opensearch-output-plugin/tests/main.tf
+++ b/images/logstash-oss-with-opensearch-output-plugin/tests/main.tf
@@ -10,9 +10,7 @@ variable "digest" {
   description = "The image digests to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_password" "random" {
   length           = 64
@@ -42,8 +40,8 @@ module "helm_logstash" {
   repo   = "https://helm.elastic.co"
   name   = "logstash"
   values = {
-    image           = data.oci_string.ref.registry_repo
-    imageTag        = data.oci_string.ref.pseudo_tag
+    image           = local.parsed.registry_repo
+    imageTag        = local.parsed.pseudo_tag
     imagePullPolicy = "Always"
     logstashConfig = {
       "logstash.yml" = <<eof

--- a/images/loki/tests/main.tf
+++ b/images/loki/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -32,9 +32,9 @@ module "helm" {
         replication_factor = 1
       }
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
       storage = {
         type = "filesystem"
@@ -59,9 +59,9 @@ module "helm" {
       persistence = {
         size = "1Gi"
       }
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      tag        = data.oci_string.ref.pseudo_tag
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      tag        = local.parsed.pseudo_tag
     }
     backend = {
       replicas = 0

--- a/images/management-api-for-apache-cassandra/tests/main.tf
+++ b/images/management-api-for-apache-cassandra/tests/main.tf
@@ -12,7 +12,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -74,7 +74,7 @@ resource "kubernetes_stateful_set" "cassandra" {
       spec {
         container {
           name  = "cassandra"
-          image = "${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+          image = "${local.parsed.registry_repo}:${local.parsed.pseudo_tag}"
 
           port {
             name           = "intra-node"

--- a/images/memcached-exporter-bitnami/tests/main.tf
+++ b/images/memcached-exporter-bitnami/tests/main.tf
@@ -13,11 +13,9 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME --version"
 }
 
-data "oci_ref" "memcached" {
-  ref = "cgr.dev/chainguard/memcached:latest"
-}
+locals { memcached = provider::oci::get("cgr.dev/chainguard/memcached:latest") }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "memcached-exporter-bitnami" {
   name       = "memcached-exporter"
@@ -28,14 +26,14 @@ resource "helm_release" "memcached-exporter-bitnami" {
     image = {
       registry   = "cgr.dev"
       repository = "chainguard/memcached"
-      digest     = data.oci_ref.memcached.digest
+      digest     = local.memcached.full_ref
     }
     metrics = {
       enabled = true
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        digest     = data.oci_string.ref.digest
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        digest     = local.parsed.digest
       }
     }
   })]

--- a/images/memcached/tests/main.tf
+++ b/images/memcached/tests/main.tf
@@ -14,7 +14,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME --version"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -31,9 +31,9 @@ module "helm" {
 
   values = {
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      digest     = data.oci_string.ref.digest
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      digest     = local.parsed.digest
     }
   }
 }

--- a/images/metacontroller/tests/main.tf
+++ b/images/metacontroller/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "metacontroller" {
   name       = "metacontroller"
@@ -18,8 +18,8 @@ resource "helm_release" "metacontroller" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/metallb/tests/main.tf
+++ b/images/metallb/tests/main.tf
@@ -13,10 +13,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -31,14 +28,14 @@ module "helm_metallb" {
   values = {
     controller = {
       image = {
-        repository = data.oci_string.ref["controller"].registry_repo
-        tag        = data.oci_string.ref["controller"].pseudo_tag
+        repository = local.parsed["controller"].registry_repo
+        tag        = local.parsed["controller"].pseudo_tag
       }
     }
     speaker = {
       image = {
-        repository = data.oci_string.ref["speaker"].registry_repo
-        tag        = data.oci_string.ref["speaker"].pseudo_tag
+        repository = local.parsed["speaker"].registry_repo
+        tag        = local.parsed["speaker"].pseudo_tag
       }
       frr = {
         enabled = false

--- a/images/metrics-server/tests/main.tf
+++ b/images/metrics-server/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "run" {
   digest = var.digest
@@ -27,8 +27,8 @@ resource "helm_release" "metrics-server" {
 
   values = [jsonencode({
     image = {
-      tag        = data.oci_string.ref.pseudo_tag
-      repository = data.oci_string.ref.registry_repo
+      tag        = local.parsed.pseudo_tag
+      repository = local.parsed.registry_repo
     }
     args = ["--kubelet-insecure-tls"]
   })]

--- a/images/minio/tests/main.tf
+++ b/images/minio/tests/main.tf
@@ -18,10 +18,7 @@ variable "check-dev" {
   description = "Whether to check for dev extensions"
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 

--- a/images/multus-cni/tests/values.yaml
+++ b/images/multus-cni/tests/values.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: kube-multus
         # crio support requires multus:latest for now. support 3.3 or later.
-        image: "${data.oci_string.ref}"
+        image: "${local.parsed}"
         command: ["/entrypoint.sh"]
         args:
         - "--cni-version=0.3.1"

--- a/images/neuvector-prometheus-exporter/tests/main.tf
+++ b/images/neuvector-prometheus-exporter/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -62,7 +62,7 @@ resource "imagetest_feature" "basic" {
     {
       name = "Set image"
       cmd  = <<EOF
-kubectl set image -n neuvector deployment/neuvector-prometheus-exporter-pod neuvector-prometheus-exporter-pod="${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+kubectl set image -n neuvector deployment/neuvector-prometheus-exporter-pod neuvector-prometheus-exporter-pod="${local.parsed.registry_repo}:${local.parsed.pseudo_tag}"
        EOF
     },
     {

--- a/images/newrelic-fluent-bit-output/tests/main.tf
+++ b/images/newrelic-fluent-bit-output/tests/main.tf
@@ -12,9 +12,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -36,8 +34,8 @@ resource "helm_release" "nri-bundle" {
         enabled = true
         image = {
           # `registry` doesn't exist here, it isn't consistent with the rest of the subcharts
-          repository = data.oci_string.ref.registry_repo
-          tag        = data.oci_string.ref.pseudo_tag
+          repository = local.parsed.registry_repo
+          tag        = local.parsed.pseudo_tag
         }
       }
 

--- a/images/newrelic-infrastructure-bundle/tests/main.tf
+++ b/images/newrelic-infrastructure-bundle/tests/main.tf
@@ -12,9 +12,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -49,9 +47,9 @@ resource "helm_release" "nri-bundle" {
         }
         images = {
           agent = {
-            registry   = data.oci_string.ref.registry
-            repository = data.oci_string.ref.repo
-            tag        = data.oci_string.ref.pseudo_tag
+            registry   = local.parsed.registry
+            repository = local.parsed.repo
+            tag        = local.parsed.pseudo_tag
           }
         }
       }

--- a/images/newrelic-k8s-events-forwarder/tests/main.tf
+++ b/images/newrelic-k8s-events-forwarder/tests/main.tf
@@ -12,9 +12,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -62,9 +60,9 @@ resource "helm_release" "nri-bundle" {
         }
         images = {
           forwarder = {
-            registry   = data.oci_string.ref.registry
-            repository = data.oci_string.ref.repo
-            tag        = data.oci_string.ref.pseudo_tag
+            registry   = local.parsed.registry
+            repository = local.parsed.repo
+            tag        = local.parsed.pseudo_tag
           }
         }
       }
@@ -73,9 +71,9 @@ resource "helm_release" "nri-bundle" {
         enabled = true
         images = {
           agent = {
-            registry   = data.oci_string.ref.registry
-            repository = data.oci_string.ref.repo
-            tag        = data.oci_string.ref.pseudo_tag
+            registry   = local.parsed.registry
+            repository = local.parsed.repo
+            tag        = local.parsed.pseudo_tag
           }
         }
       }

--- a/images/newrelic-kube-events/tests/main.tf
+++ b/images/newrelic-kube-events/tests/main.tf
@@ -12,9 +12,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -36,9 +34,9 @@ resource "helm_release" "nri-bundle" {
         enabled = true
         images = {
           integration = {
-            registry   = data.oci_string.ref.registry
-            repository = data.oci_string.ref.repo
-            tag        = data.oci_string.ref.pseudo_tag
+            registry   = local.parsed.registry
+            repository = local.parsed.repo
+            tag        = local.parsed.pseudo_tag
           }
         }
       }

--- a/images/newrelic-kubernetes/tests/main.tf
+++ b/images/newrelic-kubernetes/tests/main.tf
@@ -12,9 +12,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -49,9 +47,9 @@ resource "helm_release" "nri-bundle" {
         }
         images = {
           integration = {
-            registry   = data.oci_string.ref.registry
-            repository = data.oci_string.ref.repo
-            tag        = data.oci_string.ref.pseudo_tag
+            registry   = local.parsed.registry
+            repository = local.parsed.repo
+            tag        = local.parsed.pseudo_tag
           }
         }
       }

--- a/images/newrelic-prometheus-configurator/tests/main.tf
+++ b/images/newrelic-prometheus-configurator/tests/main.tf
@@ -12,9 +12,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -40,9 +38,9 @@ module "nri_bundle_install" {
       enabled = true
       images = {
         configurator = {
-          registry   = data.oci_string.ref.registry
-          repository = data.oci_string.ref.repo
-          tag        = data.oci_string.ref.pseudo_tag
+          registry   = local.parsed.registry
+          repository = local.parsed.repo
+          tag        = local.parsed.pseudo_tag
         }
         prometheus = {
           registry   = "cgr.dev"

--- a/images/newrelic-prometheus/tests/main.tf
+++ b/images/newrelic-prometheus/tests/main.tf
@@ -12,9 +12,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -35,9 +33,9 @@ resource "helm_release" "nri-bundle" {
       nri-prometheus = {
         enabled = true
         image = {
-          registry   = data.oci_string.ref.registry
-          repository = data.oci_string.ref.repo
-          tag        = data.oci_string.ref.pseudo_tag
+          registry   = local.parsed.registry
+          repository = local.parsed.repo
+          tag        = local.parsed.pseudo_tag
         }
       }
 

--- a/images/node-feature-discovery/tests/main.tf
+++ b/images/node-feature-discovery/tests/main.tf
@@ -8,9 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -23,8 +21,8 @@ resource "helm_release" "test_helm_deploy" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/node-problem-detector/tests/main.tf
+++ b/images/node-problem-detector/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "node-problem-detector" {
   name             = "node-problem-detector"
@@ -19,8 +19,8 @@ resource "helm_release" "node-problem-detector" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/nodetaint/tests/main.tf
+++ b/images/nodetaint/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "helm" {
   digest = var.digest
@@ -16,14 +16,14 @@ data "oci_exec_test" "helm" {
 
   env {
     name  = "IMAGE_REGISTRY"
-    value = data.oci_string.ref.registry
+    value = local.parsed.registry
   }
   env {
     name  = "IMAGE_REPOSITORY"
-    value = data.oci_string.ref.repo
+    value = local.parsed.repo
   }
   env {
     name  = "IMAGE_TAG"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }

--- a/images/nvidia-container-toolkit/tests/main.tf
+++ b/images/nvidia-container-toolkit/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 # TODO: Convert this to imagetest_harness_container when ready
 data "oci_exec_test" "runs" {

--- a/images/nvidia-device-plugin/tests/main.tf
+++ b/images/nvidia-device-plugin/tests/main.tf
@@ -13,7 +13,7 @@ variable "name" {
   default = "nvidia-device-plugin"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -40,7 +40,7 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
+      repository = local.parsed.registry_repo
       tag        = "unused@${element(split("@", var.digest), 1)}"
     }
   }

--- a/images/opensearch-dashboards/tests/main.tf
+++ b/images/opensearch-dashboards/tests/main.tf
@@ -10,9 +10,7 @@ variable "digest" {
   description = "The image digests to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -61,8 +59,8 @@ module "helm_opensearch_dashboards" {
       failureThreshold    = 30
     }
     image = {
-      repository = "${data.oci_string.ref.registry_repo}"
-      tag        = "${data.oci_string.ref.pseudo_tag}"
+      repository = "${local.parsed.registry_repo}"
+      tag        = "${local.parsed.pseudo_tag}"
     }
   }
 }

--- a/images/opensearch/tests/main.tf
+++ b/images/opensearch/tests/main.tf
@@ -10,9 +10,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -32,8 +30,8 @@ module "helm_opensearch" {
     singleNode   = true
     majorVersion = "2"
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
     config = {
       "opensearch.yml" = <<EOF

--- a/images/opentelemetry-collector-contrib/tests/main.tf
+++ b/images/opentelemetry-collector-contrib/tests/main.tf
@@ -10,7 +10,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -41,8 +41,8 @@ module "helm-otelc-deploy" {
       create : false
     }
     image = {
-      digest     = data.oci_string.ref.digest
-      repository = data.oci_string.ref.registry_repo
+      digest     = local.parsed.digest
+      repository = local.parsed.registry_repo
     }
     # Enable everything testable for a deployment based install
     presets = {
@@ -102,8 +102,8 @@ module "helm-otelc-daemonset" {
       kubeletMetrics       = { enabled = true }
     }
     image = {
-      digest     = data.oci_string.ref.digest
-      repository = data.oci_string.ref.registry_repo
+      digest     = local.parsed.digest
+      repository = local.parsed.registry_repo
     }
     command = {
       extraArgs = [

--- a/images/opentelemetry-collector/tests/main.tf
+++ b/images/opentelemetry-collector/tests/main.tf
@@ -10,7 +10,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -41,8 +41,8 @@ module "helm-otelc-deploy" {
       create : false
     }
     image = {
-      digest     = data.oci_string.ref.digest
-      repository = data.oci_string.ref.registry_repo
+      digest     = local.parsed.digest
+      repository = local.parsed.registry_repo
     }
     # Enable everything testable for a deployment based install
     presets = {
@@ -102,8 +102,8 @@ module "helm-otelc-daemonset" {
       kubeletMetrics       = { enabled = true }
     }
     image = {
-      digest     = data.oci_string.ref.digest
-      repository = data.oci_string.ref.registry_repo
+      digest     = local.parsed.digest
+      repository = local.parsed.registry_repo
     }
     command = {
       extraArgs = [

--- a/images/php-fpm_exporter/tests/main.tf
+++ b/images/php-fpm_exporter/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "smoke" {
   digest = var.digest # This doesn't actually matter here, just pass it something valid

--- a/images/postgres-helm-compat/tests/main.tf
+++ b/images/postgres-helm-compat/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 // We rely on base image ("postgresql") tests and just just run the helm test here
 
@@ -25,15 +25,15 @@ resource "helm_release" "bitnami" {
   // Point the chart at our Postgres image
   set {
     name  = "image.registry"
-    value = data.oci_string.ref.registry
+    value = local.parsed.registry
   }
   set {
     name  = "image.repository"
-    value = data.oci_string.ref.repo
+    value = local.parsed.repo
   }
   set {
     name  = "image.digest"
-    value = data.oci_string.ref.digest
+    value = local.parsed.digest
   }
 
   set {
@@ -87,7 +87,7 @@ resource "kubernetes_job" "test_tls" {
         }
         container {
           name  = "client"
-          image = data.oci_string.ref.id
+          image = var.digest
           security_context {
             allow_privilege_escalation = false
             capabilities {

--- a/images/postgres-operator/tests/main.tf
+++ b/images/postgres-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -44,9 +44,9 @@ module "helm" {
   chart     = "postgres-operator"
   values = {
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      tag        = data.oci_string.ref.pseudo_tag
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/postgres/tests/main.tf
+++ b/images/postgres/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "query" {
   digest = var.digest

--- a/images/prometheus-adapter/tests/main.tf
+++ b/images/prometheus-adapter/tests/main.tf
@@ -8,9 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "test" {
   name       = "prometheus-adapter"
@@ -19,8 +17,8 @@ resource "helm_release" "test" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/prometheus-alertmanager/tests/main.tf
+++ b/images/prometheus-alertmanager/tests/main.tf
@@ -19,9 +19,7 @@ data "oci_exec_test" "docker-test" {
   working_dir = path.module
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -32,8 +30,8 @@ resource "random_pet" "suffix" {}
 
 #   values = [jsonencode({
 #     image = {
-#       repository = data.oci_string.ref.registry_repo
-#       tag        = data.oci_string.ref.pseudo_tag
+#       repository = local.parsed.registry_repo
+#       tag        = local.parsed.pseudo_tag
 #     }
 #   })]
 # }

--- a/images/prometheus-blackbox-exporter/tests/main.tf
+++ b/images/prometheus-blackbox-exporter/tests/main.tf
@@ -5,7 +5,7 @@ terraform {
   }
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 variable "digest" {
   description = "The image digest to run tests over."
@@ -41,9 +41,9 @@ module "helm" {
 
   values = {
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      tag        = data.oci_string.ref.pseudo_tag
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/prometheus-cloudwatch-exporter/tests/main.tf
+++ b/images/prometheus-cloudwatch-exporter/tests/main.tf
@@ -8,9 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "cloudwatch-runs" {
   digest      = var.digest
@@ -30,11 +28,11 @@ resource "helm_release" "test" {
 
   set {
     name  = "image.repository"
-    value = data.oci_string.ref.registry_repo
+    value = local.parsed.registry_repo
   }
   set {
     name  = "image.tag"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }
 

--- a/images/prometheus-config-reloader/tests/main.tf
+++ b/images/prometheus-config-reloader/tests/main.tf
@@ -10,9 +10,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -39,9 +37,9 @@ module "helm" {
     prometheusOperator = {
       prometheusConfigReloader = {
         image = {
-          registry   = data.oci_string.ref.registry
-          repository = data.oci_string.ref.repo
-          tag        = data.oci_string.ref.pseudo_tag
+          registry   = local.parsed.registry
+          repository = local.parsed.repo
+          tag        = local.parsed.pseudo_tag
         }
       }
     }

--- a/images/prometheus-elasticsearch-exporter/tests/main.tf
+++ b/images/prometheus-elasticsearch-exporter/tests/main.tf
@@ -13,9 +13,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME --version"
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_id" "hex" { byte_length = 4 }
 
@@ -29,8 +27,8 @@ resource "helm_release" "test" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/prometheus-logstash-exporter/tests/main.tf
+++ b/images/prometheus-logstash-exporter/tests/main.tf
@@ -10,9 +10,7 @@ variable "digest" {
   description = "The image digests to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -93,8 +91,8 @@ module "helm_logstash_exporter" {
       }
     }
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
       pullPolicy = "Always"
     }
   }

--- a/images/prometheus-mongodb-exporter/tests/main.tf
+++ b/images/prometheus-mongodb-exporter/tests/main.tf
@@ -8,9 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -21,8 +19,8 @@ resource "helm_release" "test" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/prometheus-node-exporter/tests/main.tf
+++ b/images/prometheus-node-exporter/tests/main.tf
@@ -14,9 +14,7 @@ data "oci_exec_test" "version" {
 }
 
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_id" "hex" { byte_length = 4 }
 
@@ -41,9 +39,9 @@ resource "helm_release" "bitnami" {
         }
       }
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        digest     = data.oci_string.ref.digest
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        digest     = local.parsed.digest
       }
   })]
 }

--- a/images/prometheus-operator/tests/main.tf
+++ b/images/prometheus-operator/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -26,15 +24,15 @@ resource "helm_release" "kube-prometheus-stack" {
   // operator
   set {
     name  = "prometheusOperator.image.registry"
-    value = data.oci_string.ref.registry
+    value = local.parsed.registry
   }
   set {
     name  = "prometheusOperator.image.repository"
-    value = data.oci_string.ref.repo
+    value = local.parsed.repo
   }
   set {
     name  = "prometheusOperator.image.tag"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }
 

--- a/images/prometheus-postgres-exporter/tests/main.tf
+++ b/images/prometheus-postgres-exporter/tests/main.tf
@@ -13,7 +13,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME --version"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -34,9 +34,9 @@ resource "helm_release" "bitnami" {
     metrics = {
       enabled = true
       image = {
-        registry   = data.oci_string.ref.registry
-        repository = data.oci_string.ref.repo
-        tag        = data.oci_string.ref.pseudo_tag
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
       }
     }
   })]

--- a/images/prometheus-pushgateway-bitnami/tests/main.tf
+++ b/images/prometheus-pushgateway-bitnami/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "healthy" {
   digest = var.digest
@@ -30,8 +28,8 @@ resource "helm_release" "prometheus_community_pushgateway" {
   values = [
     jsonencode({
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
       service = {
         type = "ClusterIP"

--- a/images/prometheus-redis-exporter/tests/main.tf
+++ b/images/prometheus-redis-exporter/tests/main.tf
@@ -19,9 +19,7 @@ data "oci_exec_test" "redis-runs" {
   working_dir = path.module
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -32,8 +30,8 @@ resource "helm_release" "test" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/prometheus-statsd-exporter/tests/main.tf
+++ b/images/prometheus-statsd-exporter/tests/main.tf
@@ -13,9 +13,7 @@ data "oci_exec_test" "version" {
   script = "docker run --rm $IMAGE_NAME --version"
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -26,8 +24,8 @@ resource "helm_release" "test" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/promtail/tests/main.tf
+++ b/images/promtail/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "promtail" {
   name = "promtail"
@@ -19,9 +19,9 @@ resource "helm_release" "promtail" {
 
   values = [jsonencode({
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      tag        = data.oci_string.ref.pseudo_tag
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/proxysql/tests/main.tf
+++ b/images/proxysql/tests/main.tf
@@ -14,7 +14,7 @@ variable "digest" {
 # [metadata.labels: Invalid value: "unused@sha256:d92268eff1c19eba6c809303294c5041d98f793746d5f5a0212519391fce3b22": must be no more than 63 characters
 # https://github.com/dysnix/charts/blob/main/dysnix/proxysql/templates/_helpers.tpl?rgh-link-date=2023-07-06T13%3A57%3A36Z#L41
 
-# data "oci_string" "ref" { input = var.digest }
+# locals { parsed = provider::oci::parse(var.digest) }
 
 # resource "helm_release" "proxysql" {
 #   name = "proxysql"
@@ -27,9 +27,9 @@ variable "digest" {
 
 #   values = [jsonencode({
 #     image = {
-#       registry   = data.oci_string.ref.registry
-#       repository = data.oci_string.ref.repo
-#       tag        = data.oci_string.ref.pseudo_tag
+#       registry   = local.parsed.registry
+#       repository = local.parsed.repo
+#       tag        = local.parsed.pseudo_tag
 #     }
 #   })]
 # }

--- a/images/pytorch-cuda12/tests/main.tf
+++ b/images/pytorch-cuda12/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -39,9 +39,9 @@ module "helm" {
   values = {
     containerName = "pytorch"
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      digest     = data.oci_string.ref.digest
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      digest     = local.parsed.digest
     }
     containerSecurityContext = {
       runAsUser                = 0

--- a/images/qdrant/tests/main.tf
+++ b/images/qdrant/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -23,8 +23,8 @@ resource "helm_release" "helm" {
   values = [
     jsonencode({
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
       readinessProbe = {
         enabled = false

--- a/images/rabbitmq-messaging-topology-operator/tests/main.tf
+++ b/images/rabbitmq-messaging-topology-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -43,8 +43,8 @@ resources:
 
 images:
 - name: rabbitmqoperator/messaging-topology-operator
-  newName: ${data.oci_string.ref.registry_repo}
-  newTag: ${data.oci_string.ref.pseudo_tag}
+  newName: ${local.parsed.registry_repo}
+  newTag: ${local.parsed.pseudo_tag}
 kust
 
 kustomize build . | kubectl apply -f -

--- a/images/redis-bitnami/tests/main.tf
+++ b/images/redis-bitnami/tests/main.tf
@@ -15,10 +15,7 @@ variable "digests" {
 }
 
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 resource "random_pet" "suffix" {}
 
@@ -32,17 +29,17 @@ resource "helm_release" "redis" {
   values = [
     jsonencode({
       image = {
-        registry   = data.oci_string.ref["server"].registry
-        repository = data.oci_string.ref["server"].repo
-        digest     = data.oci_string.ref["server"].digest
+        registry   = local.parsed["server"].registry
+        repository = local.parsed["server"].repo
+        digest     = local.parsed["server"].digest
       }
 
       sentinel = {
         enabled = true
         image = {
-          registry   = data.oci_string.ref["sentinel"].registry
-          repository = data.oci_string.ref["sentinel"].repo
-          digest     = data.oci_string.ref["sentinel"].digest
+          registry   = local.parsed["sentinel"].registry
+          repository = local.parsed["sentinel"].repo
+          digest     = local.parsed["sentinel"].digest
         }
       }
     })

--- a/images/redis-sentinel/tests/main.tf
+++ b/images/redis-sentinel/tests/main.tf
@@ -9,4 +9,4 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }

--- a/images/rstudio/tests/main.tf
+++ b/images/rstudio/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "smoke" {
   digest = var.digest

--- a/images/sigstore-policy-controller/tests/main.tf
+++ b/images/sigstore-policy-controller/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "digest" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -43,8 +41,8 @@ module "helm" {
   values = {
     webhook = {
       image = {
-        repository = data.oci_string.digest.registry_repo
-        version    = data.oci_string.digest.digest
+        repository = local.parsed.registry_repo
+        version    = local.parsed.digest
       }
     }
   }

--- a/images/sigstore-scaffolding/tests/cosign-test.tf
+++ b/images/sigstore-scaffolding/tests/cosign-test.tf
@@ -33,7 +33,7 @@ resource "kubernetes_job_v1" "keyless_sign_verify" {
 
         init_container {
           name        = "initialize"
-          image       = data.oci_string.images["cosign-cli"].id
+          image       = local.fetched["cosign-cli"].full_ref
           working_dir = "/workspace"
           args = [
             "initialize",
@@ -52,7 +52,7 @@ resource "kubernetes_job_v1" "keyless_sign_verify" {
 
         init_container {
           name        = "sign"
-          image       = data.oci_string.images["cosign-cli"].id
+          image       = local.fetched["cosign-cli"].full_ref
           working_dir = "/workspace"
           args = [
             "sign-blob", "/etc/os-release",
@@ -79,7 +79,7 @@ resource "kubernetes_job_v1" "keyless_sign_verify" {
 
         container {
           name        = "verify"
-          image       = data.oci_string.images["cosign-cli"].id
+          image       = local.fetched["cosign-cli"].full_ref
           working_dir = "/workspace"
           args = [
             "verify-blob", "/etc/os-release",

--- a/images/sigstore-scaffolding/tests/rekor-test.tf
+++ b/images/sigstore-scaffolding/tests/rekor-test.tf
@@ -33,7 +33,7 @@ resource "kubernetes_job_v1" "check_rekor" {
         }
         container {
           name  = "check-rekor"
-          image = data.oci_string.images["rekor-cli"].id
+          image = local.fetched["rekor-cli"].full_ref
           args = [
             "upload",
             "--rekor_server=http://rekor-server.rekor-${random_pet.suffix.id}.svc",

--- a/images/sigstore-scaffolding/tests/tsa-test.tf
+++ b/images/sigstore-scaffolding/tests/tsa-test.tf
@@ -33,7 +33,7 @@ resource "kubernetes_job_v1" "tsa_sign_verify" {
 
         init_container {
           name        = "initialize"
-          image       = data.oci_string.images["cosign-cli"].id
+          image       = local.fetched["cosign-cli"].full_ref
           working_dir = "/workspace"
           args = [
             "initialize",
@@ -52,7 +52,7 @@ resource "kubernetes_job_v1" "tsa_sign_verify" {
 
         init_container {
           name        = "tsa-certchain"
-          image       = data.oci_string.images["curl"].id
+          image       = local.fetched["curl"].full_ref
           working_dir = "/workspace"
           args = [
             "-Lo", "/workspace/tsa-cert-chain.pem",
@@ -66,7 +66,7 @@ resource "kubernetes_job_v1" "tsa_sign_verify" {
 
         init_container {
           name        = "sign"
-          image       = data.oci_string.images["cosign-cli"].id
+          image       = local.fetched["cosign-cli"].full_ref
           working_dir = "/workspace"
           args = [
             "sign-blob", "/etc/os-release",
@@ -95,7 +95,7 @@ resource "kubernetes_job_v1" "tsa_sign_verify" {
 
         container {
           name        = "verify"
-          image       = data.oci_string.images["cosign-cli"].id
+          image       = local.fetched["cosign-cli"].full_ref
           working_dir = "/workspace"
           args = [
             "verify-blob", "/etc/os-release",

--- a/images/sigstore-scaffolding/tests/values.tf
+++ b/images/sigstore-scaffolding/tests/values.tf
@@ -11,15 +11,15 @@ locals {
     server:
       fullnameOverride: fulcio-server
       image:
-        registry: ${data.oci_string.images["fulcio-server"].registry}
-        repository: ${data.oci_string.images["fulcio-server"].repo}
-        version: ${data.oci_string.images["fulcio-server"].digest}
+        registry: ${local.parsed["fulcio-server"].registry}
+        repository: ${local.parsed["fulcio-server"].repo}
+        version: ${local.parsed["fulcio-server"].digest}
     createcerts:
       fullnameOverride: fulcio-createcerts
       image:
-        registry: ${data.oci_string.images["fulcio-createcerts"].registry}
-        repository: ${data.oci_string.images["fulcio-createcerts"].repo}
-        version: ${data.oci_string.images["fulcio-createcerts"].digest}
+        registry: ${local.parsed["fulcio-createcerts"].registry}
+        repository: ${local.parsed["fulcio-createcerts"].repo}
+        version: ${local.parsed["fulcio-createcerts"].digest}
     ctlog:
       enabled: false
       createctconfig:
@@ -37,26 +37,26 @@ locals {
       fullnameOverride: ctlog-createcerts
     createctconfig:
       image:
-        registry: ${data.oci_string.images["ctlog-createctconfig"].registry}
-        repository: ${data.oci_string.images["ctlog-createctconfig"].repo}
-        version: ${data.oci_string.images["ctlog-createctconfig"].digest}
+        registry: ${local.parsed["ctlog-createctconfig"].registry}
+        repository: ${local.parsed["ctlog-createctconfig"].repo}
+        version: ${local.parsed["ctlog-createctconfig"].digest}
       initContainerImage:
         curl:
-          registry: ${data.oci_string.images["curl"].registry}
-          repository: ${data.oci_string.images["curl"].repo}
-          version: ${data.oci_string.images["curl"].digest}
+          registry: ${local.parsed["curl"].registry}
+          repository: ${local.parsed["curl"].repo}
+          version: ${local.parsed["curl"].digest}
     createtree:
       fullnameOverride: ctlog-createtree
       displayName: ctlog-tree
       image:
-        registry: ${data.oci_string.images["trillian-createtree"].registry}
-        repository: ${data.oci_string.images["trillian-createtree"].repo}
-        version: ${data.oci_string.images["trillian-createtree"].digest}
+        registry: ${local.parsed["trillian-createtree"].registry}
+        repository: ${local.parsed["trillian-createtree"].repo}
+        version: ${local.parsed["trillian-createtree"].digest}
     server:
       image:
-        registry: ${data.oci_string.images["ctlog-server"].registry}
-        repository: ${data.oci_string.images["ctlog-server"].repo}
-        version: ${data.oci_string.images["ctlog-server"].digest}
+        registry: ${local.parsed["ctlog-server"].registry}
+        repository: ${local.parsed["ctlog-server"].repo}
+        version: ${local.parsed["ctlog-server"].digest}
 
   # Rekor
   rekor:
@@ -68,31 +68,31 @@ locals {
     fullnameOverride: rekor
     initContainerImage:
       curl:
-        registry: ${data.oci_string.images["curl"].registry}
-        repository: ${data.oci_string.images["curl"].repo}
-        version: ${data.oci_string.images["curl"].digest}
+        registry: ${local.parsed["curl"].registry}
+        repository: ${local.parsed["curl"].repo}
+        version: ${local.parsed["curl"].digest}
     backfillredis:
       image:
-        registry: ${data.oci_string.images["backfill-redis"].registry}
-        repository: ${data.oci_string.images["backfill-redis"].repo}
-        version: ${data.oci_string.images["backfill-redis"].digest}
+        registry: ${local.parsed["backfill-redis"].registry}
+        repository: ${local.parsed["backfill-redis"].repo}
+        version: ${local.parsed["backfill-redis"].digest}
     createtree:
       image:
-        registry: ${data.oci_string.images["trillian-createtree"].registry}
-        repository: ${data.oci_string.images["trillian-createtree"].repo}
-        version: ${data.oci_string.images["trillian-createtree"].digest}
+        registry: ${local.parsed["trillian-createtree"].registry}
+        repository: ${local.parsed["trillian-createtree"].repo}
+        version: ${local.parsed["trillian-createtree"].digest}
     server:
       fullnameOverride: rekor-server
       image:
-        registry: ${data.oci_string.images["rekor-server"].registry}
-        repository: ${data.oci_string.images["rekor-server"].repo}
-        version: ${data.oci_string.images["rekor-server"].digest}
+        registry: ${local.parsed["rekor-server"].registry}
+        repository: ${local.parsed["rekor-server"].repo}
+        version: ${local.parsed["rekor-server"].digest}
     redis:
       fullnameOverride: rekor-redis
       image:
-        registry: ${data.oci_string.images["redis"].registry}
-        repository: ${data.oci_string.images["redis"].repo}
-        version: ${data.oci_string.images["redis"].digest}
+        registry: ${local.parsed["redis"].registry}
+        repository: ${local.parsed["redis"].repo}
+        version: ${local.parsed["redis"].digest}
     trillian:
       enabled: false
 
@@ -106,39 +106,39 @@ locals {
     fullnameOverride: trillian
     createdb:
       image:
-        registry: ${data.oci_string.images["trillian-createdb"].registry}
-        repository: ${data.oci_string.images["trillian-createdb"].repo}
-        version: ${data.oci_string.images["trillian-createdb"].digest}
+        registry: ${local.parsed["trillian-createdb"].registry}
+        repository: ${local.parsed["trillian-createdb"].repo}
+        version: ${local.parsed["trillian-createdb"].digest}
     mysql:
       image:
-        registry: ${data.oci_string.images["mysql"].registry}
-        repository: ${data.oci_string.images["mysql"].repo}
-        version: ${data.oci_string.images["mysql"].digest}
+        registry: ${local.parsed["mysql"].registry}
+        repository: ${local.parsed["mysql"].repo}
+        version: ${local.parsed["mysql"].digest}
     initContainerImage:
       curl:
-        registry: ${data.oci_string.images["curl"].registry}
-        repository: ${data.oci_string.images["curl"].repo}
-        version: ${data.oci_string.images["curl"].digest}
+        registry: ${local.parsed["curl"].registry}
+        repository: ${local.parsed["curl"].repo}
+        version: ${local.parsed["curl"].digest}
       netcat:
-        registry: ${data.oci_string.images["netcat"].registry}
-        repository: ${data.oci_string.images["netcat"].repo}
-        version: ${data.oci_string.images["netcat"].digest}
+        registry: ${local.parsed["netcat"].registry}
+        repository: ${local.parsed["netcat"].repo}
+        version: ${local.parsed["netcat"].digest}
     logServer:
       name: trillian-logserver
       fullnameOverride: trillian-logserver
       portHTTP: 8090
       portRPC: 8091
       image:
-        registry: ${data.oci_string.images["logserver"].registry}
-        repository: ${data.oci_string.images["logserver"].repo}
-        version: ${data.oci_string.images["logserver"].digest}
+        registry: ${local.parsed["logserver"].registry}
+        repository: ${local.parsed["logserver"].repo}
+        version: ${local.parsed["logserver"].digest}
     logSigner:
       name: trillian-logsigner
       fullnameOverride: trillian-logsigner
       image:
-        registry: ${data.oci_string.images["logsigner"].registry}
-        repository: ${data.oci_string.images["logsigner"].repo}
-        version: ${data.oci_string.images["logsigner"].digest}
+        registry: ${local.parsed["logsigner"].registry}
+        repository: ${local.parsed["logsigner"].repo}
+        version: ${local.parsed["logsigner"].digest}
     mysql:
       fullnameOverride: trillian-mysql
 
@@ -150,9 +150,9 @@ locals {
     forceNamespace: tuf-system
     fullnameOverride: tuf
     deployment:
-      registry: ${data.oci_string.images["tuf-server"].registry}
-      repository: ${data.oci_string.images["tuf-server"].repo}
-      version: ${data.oci_string.images["tuf-server"].digest}
+      registry: ${local.parsed["tuf-server"].registry}
+      repository: ${local.parsed["tuf-server"].repo}
+      version: ${local.parsed["tuf-server"].digest}
 
     secrets:
       rekor:
@@ -187,8 +187,8 @@ locals {
         signer: memory
         creds: "dummycredentials" # TODO: priyawadhwa: the upstream chart requires this, priya to remove the requirement upstream
       image:
-        registry: ${data.oci_string.images["tsa-server"].registry}
-        repository: ${data.oci_string.images["tsa-server"].repo}
-        version: ${data.oci_string.images["tsa-server"].digest}
+        registry: ${local.parsed["tsa-server"].registry}
+        repository: ${local.parsed["tsa-server"].repo}
+        version: ${local.parsed["tsa-server"].digest}
   EOF
 }

--- a/images/smarter-device-manager/tests/main.tf
+++ b/images/smarter-device-manager/tests/main.tf
@@ -8,9 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "server" {
   digest = var.digest
@@ -26,8 +24,8 @@ resource "helm_release" "test" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/spark-operator/tests/main.tf
+++ b/images/spark-operator/tests/main.tf
@@ -9,9 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" {
-  input = var.digest
-}
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -31,7 +29,7 @@ resource "imagetest_harness_k3s" "k3s" {
 
     envs = {
       "NAMESPACE" : "spark"
-      "IMAGE" : "${data.oci_string.ref.registry_repo}:${data.oci_string.ref.pseudo_tag}"
+      "IMAGE" : "${local.parsed.registry_repo}:${local.parsed.pseudo_tag}"
     }
   }
 }
@@ -61,8 +59,8 @@ module "helm-spark-operator" {
   values = {
     image = {
       registry   = ""
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     },
   }
 }

--- a/images/spire/tests/main.tf
+++ b/images/spire/tests/main.tf
@@ -14,10 +14,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -46,9 +43,9 @@ module "spire" {
     spire-server = {
       enabled = true
       image = {
-        registry   = data.oci_string.ref["server"].registry
-        repository = data.oci_string.ref["server"].repo
-        tag        = data.oci_string.ref["server"].pseudo_tag
+        registry   = local.parsed["server"].registry
+        repository = local.parsed["server"].repo
+        tag        = local.parsed["server"].pseudo_tag
       }
       tools = {
         kubectl = {
@@ -63,9 +60,9 @@ module "spire" {
     spire-agent = {
       enabled = true
       image = {
-        registry   = data.oci_string.ref["agent"].registry
-        repository = data.oci_string.ref["agent"].repo
-        tag        = data.oci_string.ref["agent"].pseudo_tag
+        registry   = local.parsed["agent"].registry
+        repository = local.parsed["agent"].repo
+        tag        = local.parsed["agent"].pseudo_tag
       }
       tools = {
         kubectl = {
@@ -80,9 +77,9 @@ module "spire" {
     spiffe-oidc-discovery-provider = {
       enabled = true
       image = {
-        registry   = data.oci_string.ref["oidc-discovery-provider"].registry
-        repository = data.oci_string.ref["oidc-discovery-provider"].repo
-        tag        = data.oci_string.ref["oidc-discovery-provider"].pseudo_tag
+        registry   = local.parsed["oidc-discovery-provider"].registry
+        repository = local.parsed["oidc-discovery-provider"].repo
+        tag        = local.parsed["oidc-discovery-provider"].pseudo_tag
       }
       config = {
         acme = {

--- a/images/sqlpad/tests/main.tf
+++ b/images/sqlpad/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 # TODO: Convert to imagetest_harness_container when available
 data "oci_exec_test" "manifest" {
@@ -40,8 +40,8 @@ module "helm" {
   name   = "sqlpad"
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/stakater-reloader/tests/main.tf
+++ b/images/stakater-reloader/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -26,8 +26,8 @@ resource "helm_release" "stakater-reloader" {
     reloader = {
       deployment = {
         image = {
-          tag  = data.oci_string.ref.pseudo_tag
-          name = data.oci_string.ref.registry_repo
+          tag  = local.parsed.pseudo_tag
+          name = local.parsed.registry_repo
         }
       }
     }

--- a/images/statsd/tests/main.tf
+++ b/images/statsd/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -22,8 +22,8 @@ resource "helm_release" "helm" {
   values = [
     jsonencode({
       image = {
-        repository = data.oci_string.ref.registry_repo
-        tag        = data.oci_string.ref.pseudo_tag
+        repository = local.parsed.registry_repo
+        tag        = local.parsed.pseudo_tag
       }
     })
   ]

--- a/images/step-ca/tests/main.tf
+++ b/images/step-ca/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The digest of the image"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 variable "target_repository" {
   description = "The docker repo name"
@@ -23,9 +23,9 @@ resource "imagetest_harness_k3s" "this" {
 
   sandbox = {
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = local.parsed.repo
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
     mounts = [
       {
@@ -47,8 +47,8 @@ module "helm" {
   values = {
     command = ["/usr/bin/step-ca"]
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 

--- a/images/step-issuer/tests/main.tf
+++ b/images/step-issuer/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The digest of the image"
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 
 variable "target_repository" {
@@ -24,9 +24,9 @@ resource "imagetest_harness_k3s" "this" {
 
   sandbox = {
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = local.parsed.repo
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
   }
 }
@@ -41,8 +41,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/superset/tests/main.tf
+++ b/images/superset/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -38,8 +38,8 @@ module "helm" {
   namespace = "superset"
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
     extraSecretEnv = {
       SUPERSET_SECRET_KEY = "G8t0QRXk8Hn2mmDaSDbAG0aMt+85ZURBbnT5+9Gqs1KlOaXjaa5LsbBT"

--- a/images/telegraf/tests/main.tf
+++ b/images/telegraf/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 
@@ -25,8 +25,8 @@ resource "helm_release" "telegraf" {
   values = [
     jsonencode({
       image = {
-        repo = data.oci_string.ref.registry_repo
-        tag  = data.oci_string.ref.pseudo_tag
+        repo = local.parsed.registry_repo
+        tag  = local.parsed.pseudo_tag
       }
     }),
   ]

--- a/images/tempo/tests/main.tf
+++ b/images/tempo/tests/main.tf
@@ -10,7 +10,7 @@ variable "digest" {
   type        = string
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -29,8 +29,8 @@ module "helm" {
 
   values = {
     tempo = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/temporal-server/tests/main.tf
+++ b/images/temporal-server/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -25,8 +25,8 @@ resource "imagetest_harness_k3s" "this" {
       }
     ]
     envs = {
-      "IMAGE_REGISTRY_REPO" = data.oci_string.ref.registry_repo
-      "IMAGE_TAG"           = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY_REPO" = local.parsed.registry_repo
+      "IMAGE_TAG"           = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/thanos-operator/tests/main.tf
+++ b/images/thanos-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "helm_release" "thanos-operator" {
   name             = "thanos-operator"
@@ -19,8 +19,8 @@ resource "helm_release" "thanos-operator" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   })]
 }

--- a/images/tigera-operator/tests/main.tf
+++ b/images/tigera-operator/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -24,9 +24,9 @@ module "helm" {
 
   values = {
     tigeraOperator = {
-      registry = data.oci_string.ref.registry
-      image    = data.oci_string.ref.repo
-      version  = data.oci_string.ref.pseudo_tag
+      registry = local.parsed.registry
+      image    = local.parsed.repo
+      version  = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/trino/tests/main.tf
+++ b/images/trino/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "help" {
   digest = var.digest
@@ -34,8 +34,8 @@ module "helm" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
     server = {
       workers = 1

--- a/images/trust-manager/tests/main.tf
+++ b/images/trust-manager/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -39,8 +39,8 @@ module "trust-manager" {
 
   values = {
     image = {
-      repository = data.oci_string.ref.registry_repo
-      tag        = data.oci_string.ref.pseudo_tag
+      repository = local.parsed.registry_repo
+      tag        = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/vault/tests/main.tf
+++ b/images/vault/tests/main.tf
@@ -13,10 +13,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -36,18 +33,18 @@ module "helm" {
   values = {
     injector = {
       agentImage = {
-        repository = data.oci_string.ref["vault"].registry_repo
-        tag        = data.oci_string.ref["vault"].pseudo_tag
+        repository = local.parsed["vault"].registry_repo
+        tag        = local.parsed["vault"].pseudo_tag
       }
       image = {
-        repository = data.oci_string.ref["vault-k8s"].registry_repo
-        tag        = data.oci_string.ref["vault-k8s"].pseudo_tag
+        repository = local.parsed["vault-k8s"].registry_repo
+        tag        = local.parsed["vault-k8s"].pseudo_tag
       }
     }
     server = {
       image = {
-        repository = data.oci_string.ref["vault"].registry_repo
-        tag        = data.oci_string.ref["vault"].pseudo_tag
+        repository = local.parsed["vault"].registry_repo
+        tag        = local.parsed["vault"].pseudo_tag
       }
     }
   }

--- a/images/vector/tests/main.tf
+++ b/images/vector/tests/main.tf
@@ -8,7 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_id" "hex" { byte_length = 4 }
 
@@ -22,9 +22,9 @@ resource "helm_release" "vector" {
 
   values = [jsonencode({
     image = {
-      repository = data.oci_string.ref.registry_repo
+      repository = local.parsed.registry_repo
       tag        = "latest"
-      sha        = trimprefix(data.oci_string.ref.digest, "sha256:")
+      sha        = trimprefix(local.parsed.digest, "sha256:")
     }
   })]
 }

--- a/images/velero-plugin-for-aws/main.tf
+++ b/images/velero-plugin-for-aws/main.tf
@@ -29,14 +29,12 @@ module "velero-plugin-for-aws" {
   main_package = each.key
 }
 
-data "oci_ref" "velero" {
-  ref = "cgr.dev/chainguard/velero:latest"
-}
+locals { velero = provider::oci::get("cgr.dev/chainguard/velero:latest") }
 
 module "test" {
   source = "./tests"
   digests = {
-    velero                = data.oci_ref.velero.id
+    velero                = local.velero.full_ref
     velero-plugin-for-aws = module.velero-plugin-for-aws["velero-plugin-for-aws"].image_ref
   }
 }

--- a/images/velero-plugin-for-aws/tests/main.tf
+++ b/images/velero-plugin-for-aws/tests/main.tf
@@ -18,10 +18,7 @@ variable "init_container_name" {
   default     = "testing-velero-plugin-for-aws:unused"
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -31,13 +28,13 @@ resource "imagetest_harness_k3s" "this" {
 
   sandbox = {
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref["velero-plugin-for-aws"].registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref["velero-plugin-for-aws"].repo
-      "IMAGE_TAG"        = data.oci_string.ref["velero-plugin-for-aws"].pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed["velero-plugin-for-aws"].registry
+      "IMAGE_REPOSITORY" = local.parsed["velero-plugin-for-aws"].repo
+      "IMAGE_TAG"        = local.parsed["velero-plugin-for-aws"].pseudo_tag
 
-      "VELERO_IMAGE_REGISTRY"   = data.oci_string.ref["velero"].registry
-      "VELERO_IMAGE_REPOSITORY" = data.oci_string.ref["velero"].repo
-      "VELERO_IMAGE_TAG"        = data.oci_string.ref["velero"].pseudo_tag
+      "VELERO_IMAGE_REGISTRY"   = local.parsed["velero"].registry
+      "VELERO_IMAGE_REPOSITORY" = local.parsed["velero"].repo
+      "VELERO_IMAGE_TAG"        = local.parsed["velero"].pseudo_tag
 
       "INIT_CONTAINER_NAME" = var.init_container_name
     }

--- a/images/velero-plugin-for-csi/main.tf
+++ b/images/velero-plugin-for-csi/main.tf
@@ -29,19 +29,16 @@ module "velero-plugin-for-csi" {
   main_package = each.key
 }
 
-data "oci_ref" "velero" {
-  ref = "cgr.dev/chainguard/velero:latest"
-}
-
-data "oci_ref" "velero-plugin-for-aws" {
-  ref = "cgr.dev/chainguard/velero-plugin-for-aws:latest"
+locals {
+  velero                = provider::oci::get("cgr.dev/chainguard/velero:latest")
+  velero-plugin-for-aws = provider::oci::get("cgr.dev/chainguard/velero-plugin-for-aws:latest")
 }
 
 module "test" {
   source = "./tests"
   digests = {
-    velero                = data.oci_ref.velero.id
-    velero-plugin-for-aws = data.oci_ref.velero-plugin-for-aws.id
+    velero                = local.velero.full_ref
+    velero-plugin-for-aws = local.velero-plugin-for-aws.full_ref
     velero-plugin-for-csi = module.velero-plugin-for-csi["velero-plugin-for-csi"].image_ref
   }
 }

--- a/images/velero-plugin-for-csi/tests/main.tf
+++ b/images/velero-plugin-for-csi/tests/main.tf
@@ -22,10 +22,7 @@ variable "init_container_names" {
   }
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -35,17 +32,17 @@ resource "imagetest_harness_k3s" "this" {
 
   sandbox = {
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref["velero-plugin-for-csi"].registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref["velero-plugin-for-csi"].repo
-      "IMAGE_TAG"        = data.oci_string.ref["velero-plugin-for-csi"].pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed["velero-plugin-for-csi"].registry
+      "IMAGE_REPOSITORY" = local.parsed["velero-plugin-for-csi"].repo
+      "IMAGE_TAG"        = local.parsed["velero-plugin-for-csi"].pseudo_tag
 
-      "AWS_IMAGE_REGISTRY"   = data.oci_string.ref["velero-plugin-for-aws"].registry
-      "AWS_IMAGE_REPOSITORY" = data.oci_string.ref["velero-plugin-for-aws"].repo
-      "AWS_IMAGE_TAG"        = data.oci_string.ref["velero-plugin-for-aws"].pseudo_tag
+      "AWS_IMAGE_REGISTRY"   = local.parsed["velero-plugin-for-aws"].registry
+      "AWS_IMAGE_REPOSITORY" = local.parsed["velero-plugin-for-aws"].repo
+      "AWS_IMAGE_TAG"        = local.parsed["velero-plugin-for-aws"].pseudo_tag
 
-      "VELERO_IMAGE_REGISTRY"   = data.oci_string.ref["velero"].registry
-      "VELERO_IMAGE_REPOSITORY" = data.oci_string.ref["velero"].repo
-      "VELERO_IMAGE_TAG"        = data.oci_string.ref["velero"].pseudo_tag
+      "VELERO_IMAGE_REGISTRY"   = local.parsed["velero"].registry
+      "VELERO_IMAGE_REPOSITORY" = local.parsed["velero"].repo
+      "VELERO_IMAGE_TAG"        = local.parsed["velero"].pseudo_tag
 
       "CSI_INIT_CONTAINER_NAME" = var.init_container_names["velero-plugin-for-csi"]
       "AWS_INIT_CONTAINER_NAME" = var.init_container_names["velero-plugin-for-aws"]

--- a/images/velero-restore-helper/tests/main.tf
+++ b/images/velero-restore-helper/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digests to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -19,9 +19,9 @@ resource "imagetest_harness_k3s" "this" {
 
   sandbox = {
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = local.parsed.repo
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
     mounts = [
       {

--- a/images/velero/tests/main.tf
+++ b/images/velero/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digests to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "imagetest_inventory" "this" {}
 
@@ -19,9 +19,9 @@ resource "imagetest_harness_k3s" "this" {
 
   sandbox = {
     envs = {
-      "IMAGE_REGISTRY"   = data.oci_string.ref.registry
-      "IMAGE_REPOSITORY" = data.oci_string.ref.repo
-      "IMAGE_TAG"        = data.oci_string.ref.pseudo_tag
+      "IMAGE_REGISTRY"   = local.parsed.registry
+      "IMAGE_REPOSITORY" = local.parsed.repo
+      "IMAGE_TAG"        = local.parsed.pseudo_tag
     }
     mounts = [
       {

--- a/images/vertical-pod-autoscaler/tests/main.tf
+++ b/images/vertical-pod-autoscaler/tests/main.tf
@@ -14,10 +14,7 @@ variable "digests" {
   })
 }
 
-data "oci_string" "ref" {
-  for_each = var.digests
-  input    = each.value
-}
+locals { parsed = { for k, v in var.digests : k => provider::oci::parse(v) } }
 
 data "imagetest_inventory" "this" {}
 
@@ -38,23 +35,23 @@ module "install" {
     installCRDs = "true"
     admissionController = {
       image = {
-        registry   = data.oci_string.ref["admission-controller"].registry
-        repository = data.oci_string.ref["admission-controller"].repo
-        tag        = data.oci_string.ref["admission-controller"].pseudo_tag
+        registry   = local.parsed["admission-controller"].registry
+        repository = local.parsed["admission-controller"].repo
+        tag        = local.parsed["admission-controller"].pseudo_tag
       }
     }
     recommender = {
       image = {
-        registry   = data.oci_string.ref["recommender"].registry
-        repository = data.oci_string.ref["recommender"].repo
-        tag        = data.oci_string.ref["recommender"].pseudo_tag
+        registry   = local.parsed["recommender"].registry
+        repository = local.parsed["recommender"].repo
+        tag        = local.parsed["recommender"].pseudo_tag
       }
     }
     updater = {
       image = {
-        registry   = data.oci_string.ref["updater"].registry
-        repository = data.oci_string.ref["updater"].repo
-        tag        = data.oci_string.ref["updater"].pseudo_tag
+        registry   = local.parsed["updater"].registry
+        repository = local.parsed["updater"].repo
+        tag        = local.parsed["updater"].pseudo_tag
       }
     }
     // Also use our already-released kubectl image too.

--- a/images/wave/tests/main.tf
+++ b/images/wave/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "version" {
   digest = var.digest
@@ -42,8 +42,8 @@ module "helm" {
 
   values = {
     image = {
-      name = data.oci_string.ref.registry_repo
-      tag  = data.oci_string.ref.pseudo_tag
+      name = local.parsed.registry_repo
+      tag  = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/weaviate/tests/main.tf
+++ b/images/weaviate/tests/main.tf
@@ -9,7 +9,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 data "oci_exec_test" "help" {
   digest = var.digest
@@ -30,15 +30,15 @@ resource "helm_release" "weaviate" {
   # dummy tag and the digest to test.
   set {
     name  = "image.registry"
-    value = data.oci_string.ref.registry
+    value = local.parsed.registry
   }
   set {
     name  = "image.repo"
-    value = data.oci_string.ref.repo
+    value = local.parsed.repo
   }
   set {
     name  = "image.tag"
-    value = data.oci_string.ref.pseudo_tag
+    value = local.parsed.pseudo_tag
   }
 }
 

--- a/images/zookeeper/tests/main.tf
+++ b/images/zookeeper/tests/main.tf
@@ -15,7 +15,7 @@ variable "digest" {
 #   working_dir = path.module
 # }
 
-data "oci_string" "ref" { input = var.digest }
+locals { parsed = provider::oci::parse(var.digest) }
 
 resource "random_pet" "suffix" {}
 resource "helm_release" "bitnami" {
@@ -27,9 +27,9 @@ resource "helm_release" "bitnami" {
 
   values = [jsonencode({
     image = {
-      registry   = data.oci_string.ref.registry
-      repository = data.oci_string.ref.repo
-      digest     = data.oci_string.ref.digest
+      registry   = local.parsed.registry
+      repository = local.parsed.repo
+      digest     = local.parsed.digest
     }
     command = ["/opt/bitnami/scripts/zookeeper/entrypoint.sh"]
     args    = ["/opt/bitnami/scripts/zookeeper/run.sh"]

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     oci = {
       source  = "chainguard-dev/oci"
-      version = "0.0.12"
+      version = "0.0.13"
     }
     chainguard = {
       source  = "chainguard-dev/chainguard"

--- a/tflib/tagger/main.tf
+++ b/tflib/tagger/main.tf
@@ -15,13 +15,10 @@ variable "exclude" {
   description = "The set of tags to exclude."
 }
 
-data "oci_string" "repos" {
-  for_each = var.tags
-  input    = each.value
-}
+locals { parsed = { for k, v in var.tags : k => provider::oci::parse(v) } }
 
 locals {
-  repos = toset([for k, v in data.oci_string.repos : "${v.registry}/${v.repo}"])
+  repos = toset([for k, v in local.parsed : "${v.registry}/${v.repo}"])
 }
 
 resource "oci_tag" "this" {


### PR DESCRIPTION
This exercises the changes in https://github.com/chainguard-dev/terraform-provider-oci/pull/131 released in tf-oci 0.0.13

This change requires TF 1.8, and updates our CI to use this version.