### PR TITLE
bincapz: fix test

### DIFF
--- a/images/bincapz/tests/main.tf
+++ b/images/bincapz/tests/main.tf
@@ -8,12 +8,7 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-data "oci_exec_test" "help" {
-  digest = var.digest
-  script = "docker run --rm $IMAGE_NAME -help"
-}
-
 data "oci_exec_test" "test-bincapz" {
   digest = var.digest
-  script = "docker run --rm $IMAGE_NAME /usr/bin/bincapz | grep -Ei 'RISK|DESCRIPTION|EVIDENCE'"
+  script = "docker run --rm $IMAGE_NAME --ignore-self=false /usr/bin/bincapz | tee /dev/stderr | grep -Ei 'RISK|DESCRIPTION|EVIDENCE'"
 }


### PR DESCRIPTION
bincapz ignores itself now, which means the test erroneously passed, which failed. 🫠 