### PR TITLE
Fix nvidia-container-toolkit testing.md link

### DIFF
--- a/images/nvidia-container-toolkit/README.md
+++ b/images/nvidia-container-toolkit/README.md
@@ -48,6 +48,6 @@ helm upgrade --install gpu-operator nvidia/gpu-operator \
 > You need GPU nodes to run the operator as it will schedule Deployments and DaemonSets on nodes with GPUs.
 
 > [!NOTE]
-> If you want to learn more about how we are testing this image, please refer to the [TESTING.md](./TESTING.md) file.
+> If you want to learn more about how we are testing this image, please refer to the [TESTING.md](https://github.com/chainguard-images/images/blob/main/images/nvidia-container-toolkit/TESTING.md) file.
 
 <!--body:end-->


### PR DESCRIPTION
Fixes a relative `TESTING.md` link when presented in the directory overview.