### PR TITLE
withdraw jitsucom-bulker-* repos

### DIFF
--- a/withdrawn-repos.txt
+++ b/withdrawn-repos.txt
@@ -17,3 +17,8 @@ kubeflow-pipelines
 
 # remove the sdk to avoid daily scanning and CVE triage actions
 sdk
+
+# renamed to jitsucom-bulker, jitsucom-ingest, jistucom-syncctl
+jitsucom-bulker-bulker
+jitsucom-bulker-ingest
+jitsucom-bulker-syncctl


### PR DESCRIPTION
These tags were withdrawn in withdrawn-images.txt, but the repos still exist, and shouldn't.