### PR TITLE
upload imagetest-logs directory

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -199,6 +199,13 @@ jobs:
         cluster-type: k3d
         namespace-resources: deploy,ds,sts,pods
 
+    - name: Upload imagetest logs
+      if: always()
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v3
+      with:
+        name: "mega-module-${{ matrix.shard.index }}-imagetest-logs"
+        path: imagetest
+
   presubmit-roundup:
     needs: build-the-world
     runs-on: ubuntu-latest

--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -148,6 +148,11 @@ jobs:
         # simpler.
         cat >> main_override.tf <<EOF
         provider "imagetest" {
+          log = {
+            file = {
+              directory = "imagetest-logs"
+            }
+          }
           harnesses = {
             k3s = {
               networks = {
@@ -204,7 +209,7 @@ jobs:
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v3
       with:
         name: "mega-module-${{ matrix.shard.index }}-imagetest-logs"
-        path: imagetest
+        path: imagetest-logs
 
   presubmit-roundup:
     needs: build-the-world

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v3
         with:
           name: "mega-module-${{ matrix.shard.index }}-imagetest-logs"
-          path: imagetest
+          path: imagetest-logs
 
       - uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907 # v2.3.0
         if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,14 +7,14 @@ on:
       - withdrawn-images.txt
       - withdrawn-repos.txt
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       only:
-        description: 'Specific image name to build'
+        description: "Specific image name to build"
         type: string
         required: false
-        default: ''
+        default: ""
 
 concurrency: release
 
@@ -34,7 +34,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-
 
       - id: shard
         name: Shard
@@ -87,7 +86,7 @@ jobs:
       - uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           egress-policy: audit
-          
+
       # In some cases, we run out of disk space during tests, so this hack frees up approx 25G.
       # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
       - name: Free up runner disk space
@@ -95,7 +94,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3
         with:
-          terraform_version: '1.6.*'
+          terraform_version: "1.6.*"
           terraform_wrapper: false
 
       - uses: chainguard-dev/actions/setup-chainctl@538d1927b846546b620784754c33e2a1db86e217 # main
@@ -149,6 +148,13 @@ jobs:
         with:
           name: "mega-module-${{ matrix.shard.index }}.tf.json"
           path: /tmp/mega-module.tf.json
+
+      - name: Upload imagetest logs
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v3
+        with:
+          name: "mega-module-${{ matrix.shard.index }}-imagetest-logs"
+          path: imagetest
 
       - uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907 # v2.3.0
         if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ sbom-*.cdx
 
 # macOS
 .DS_Store
+
+imagetest-logs/

--- a/images/cert-manager/main.tf
+++ b/images/cert-manager/main.tf
@@ -39,6 +39,7 @@ module "config" {
   source   = "./config"
   name     = each.value.component
   suffix   = each.value.suffix
+
 }
 
 module "versioned" {

--- a/images/cert-manager/main.tf
+++ b/images/cert-manager/main.tf
@@ -39,7 +39,6 @@ module "config" {
   source   = "./config"
   name     = each.value.component
   suffix   = each.value.suffix
-
 }
 
 module "versioned" {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,13 @@ terraform {
   backend "inmem" {}
 }
 
-provider "imagetest" {}
+provider "imagetest" {
+  log = {
+    file = {
+      directory = "imagetest-logs"
+    }
+  }
+}
 
 variable "target_repository" {
   type        = string


### PR DESCRIPTION
uses the new file based logging for `imagetest` to output and upload `imagetest` based logs.

this bypasses the strict logging required by terraform providers by dumping them to a file, which we'll postprocess with various downstream tooling