### PR TITLE
change this to a cmd to match how upstream expects things

### DIFF
--- a/images/datadog-agent/config/agent/latest.apko.yaml
+++ b/images/datadog-agent/config/agent/latest.apko.yaml
@@ -38,8 +38,7 @@ volumes:
   - /var/run/s6
   - /var/log/datadog
 
-entrypoint:
-  command: /bin/entrypoint.sh
+cmd: "/bin/entrypoint.sh"
 
 environment:
   # https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/Dockerfile#L112


### PR DESCRIPTION
the `/bin/entrypoint.sh` makes all sorts of assumptions that expect the entrypoint to be a `CMD` and not an `ENTRYPOINT`