### PR TITLE
Fix the shard output echo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Shard Results
-        run: echo ${{ steps.shard.outputs.matrix }}
+        run: echo '${{ steps.shard.outputs.matrix }}'
 
     outputs:
       # This is of the format [{"index": 0, "images": "a b c"}, {"index": 1, "images": "d e f"}, ...]


### PR DESCRIPTION
This `echo` was echoing the bare json which was something like `echo [{"index":"0","blah":"foo bar "},{"index":"1","bleh": "baz jon"}]`. The curly braces stacked next to each other computes the permutation of all the values inside the curly brackets. We just want it to print the json string