### PR TITLE
temporarily disable alpine git image builds to unblock

### DIFF
--- a/images/git/alpine.tf
+++ b/images/git/alpine.tf
@@ -1,3 +1,4 @@
+/*
 module "alpine" {
   for_each           = local.accounts
   source             = "./config"
@@ -30,3 +31,4 @@ module "test-latest-alpine-dev" {
   digest    = module.latest-alpine[each.key].dev_ref
   check-dev = true
 }
+*/

--- a/images/git/main.tf
+++ b/images/git/main.tf
@@ -19,18 +19,20 @@ module "tagger" {
   source = "../../tflib/tagger"
 
   depends_on = [
-    module.test-latest-alpine,
-    module.test-latest-alpine-dev,
+    //module.test-latest-alpine,
+    //module.test-latest-alpine-dev,
     module.test-latest-wolfi,
     module.test-latest-wolfi-dev,
   ]
 
   tags = merge(
+    /*
     // Alpine-based tags.
     { "latest" = module.latest-alpine["nonroot"].image_ref },
     { "latest-dev" = module.latest-alpine["nonroot"].dev_ref },
     { "latest-root" = module.latest-alpine["root"].image_ref },
     { "latest-root-dev" = module.latest-alpine["root"].dev_ref },
+     */
 
     // Wolfi-based tags:
     { "latest-glibc" = module.latest-wolfi["nonroot"].image_ref },


### PR DESCRIPTION
The Alpine-based `git` image variant is currently broken

```
resolving apk packages: solving "git-lfs" constraint: could not find package that provides git-lfs in indexes
```

https://github.com/chainguard-images/images/actions/runs/9098882464/job/25010161552#step:13:43

This fails at planning time, which means all images that share its release shard (e.g., go) are also not being rebuilt.

This temporarily stops the Alpine-based `git` image build, so that the rest of the shard can get updates.