### PR TITLE
adds keycloak-compat in keycloak image

### DIFF
--- a/images/keycloak/config/main.tf
+++ b/images/keycloak/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install"
-  default     = ["keycloak"]
+  default     = ["keycloak", "keycloak-compat"]
 }
 
 variable "environment" {


### PR DESCRIPTION
Will probably fix this https://github.com/chainguard-images/images/issues/451 as the `keycloak-compat` package handles the hardcoded stuff in `/opt/keycloak/bin`
