### PR TITLE
zig: new zig changed project bootstrap command

### DIFF
--- a/images/zig/tests/build-image.sh
+++ b/images/zig/tests/build-image.sh
@@ -12,7 +12,7 @@ FROM ${IMAGE_NAME} AS build
 
 WORKDIR /build
 
-RUN zig init-exe && \
+RUN zig init && \
     zig build
 
 FROM scratch


### PR DESCRIPTION
init-exe now fails with command does not exist, seems to have been renamed to just init.
