### PR TITLE
github: upgrade chainguard-dev actions commit

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -135,7 +135,7 @@ jobs:
     - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
     - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
 
-    - uses: chainguard-dev/actions/setup-k3d@538d1927b846546b620784754c33e2a1db86e217 # main
+    - uses: chainguard-dev/actions/setup-k3d@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
       with:
         k3s-image: cgr.dev/chainguard/k3s:latest@sha256:1dd18987ffa4b383cf969c20c534d4fcb667e6a0801d41917c99a2c34c192557
 
@@ -186,7 +186,7 @@ jobs:
 
     - name: Collect TF diagnostics
       if: ${{ always() }}
-      uses: chainguard-dev/actions/terraform-diag@538d1927b846546b620784754c33e2a1db86e217 # main
+      uses: chainguard-dev/actions/terraform-diag@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
       with:
         json-file: /tmp/mega-module.tf.json
 
@@ -199,7 +199,7 @@ jobs:
 
     - name: Collect diagnostics and upload
       if: ${{ failure() }}
-      uses: chainguard-dev/actions/k8s-diag@538d1927b846546b620784754c33e2a1db86e217 # main
+      uses: chainguard-dev/actions/k8s-diag@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
       with:
         cluster-type: k3d
         namespace-resources: deploy,ds,sts,pods

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,14 +97,14 @@ jobs:
           terraform_version: '1.8.*'
           terraform_wrapper: false
 
-      - uses: chainguard-dev/actions/setup-chainctl@538d1927b846546b620784754c33e2a1db86e217 # main
+      - uses: chainguard-dev/actions/setup-chainctl@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
         with:
           # This allows chainguard-images/images-private to publish images to cgr.dev/chainguard-private
           # We maintain this identity here:
           # https://github.com/chainguard-dev/mono/blob/main/env/chainguard-images/iac/images-pusher.tf
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
 
-      - uses: chainguard-dev/actions/setup-k3d@538d1927b846546b620784754c33e2a1db86e217 # main
+      - uses: chainguard-dev/actions/setup-k3d@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
         with:
           k3s-image: cgr.dev/chainguard/k3s:latest@sha256:1dd18987ffa4b383cf969c20c534d4fcb667e6a0801d41917c99a2c34c192557
 
@@ -130,13 +130,13 @@ jobs:
       - name: Collect TF diagnostics
         if: ${{ always() }}
         id: tf-diag
-        uses: chainguard-dev/actions/terraform-diag@538d1927b846546b620784754c33e2a1db86e217 # main
+        uses: chainguard-dev/actions/terraform-diag@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
         with:
           json-file: /tmp/mega-module.tf.json
 
       - name: Collect K8s diagnostics and upload
         if: ${{ failure() }}
-        uses: chainguard-dev/actions/k8s-diag@538d1927b846546b620784754c33e2a1db86e217 # main
+        uses: chainguard-dev/actions/k8s-diag@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
         with:
           artifact-name: "k8s-test-harness-${{ matrix.shard.index }}-logs"
           cluster-type: k3d

--- a/.github/workflows/withdraw-images.yaml
+++ b/.github/workflows/withdraw-images.yaml
@@ -21,7 +21,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4
-      - uses: chainguard-dev/actions/setup-chainctl@538d1927b846546b620784754c33e2a1db86e217 # main
+      - uses: chainguard-dev/actions/setup-chainctl@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3

--- a/.github/workflows/withdraw-repos.yaml
+++ b/.github/workflows/withdraw-repos.yaml
@@ -21,7 +21,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4
-      - uses: chainguard-dev/actions/setup-chainctl@538d1927b846546b620784754c33e2a1db86e217 # main
+      - uses: chainguard-dev/actions/setup-chainctl@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
       - run: |


### PR DESCRIPTION
This brings in the following changes:

ba1a9c9 (HEAD -> main, upstream/main, upstream/HEAD) update action to use new c>
77965ce Bump tj-actions/changed-files from 44.3.0 to 44.4.0 (#429)
25a26c8 upgrade arifact actions to v4 (#432)
b71790d update ci tests (#431)
4a4a027 bump kind to v0.23.0 add 1.30 k8s / remove 1.23/24 and updates kindest/>
3d3cb8d Bump step-security/harden-runner from 2.7.0 to 2.7.1 (#425)
73d51cb Bump actions/setup-go from 5.0.0 to 5.0.1 in /boilerplate (#426)
1105f78 Bump actions/setup-go from 5.0.0 to 5.0.1 (#427)
67c8811 Bump actions/checkout from 4.1.3 to 4.1.5 (#428)
97bd985 deprecate setup-chainctl in favor of the other repo (#399)
8799517 Bump actions/upload-artifact from 4.3.2 to 4.3.3 in /kind-diag (#422)
4995b58 Update README.md (#423)
bcf69bc Bump actions/upload-artifact from 4.3.1 to 4.3.2 in /kind-diag (#419)
7576b91 Bump tj-actions/changed-files from 44.0.1 to 44.3.0 (#420)
9bad65a Bump actions/checkout from 4.1.2 to 4.1.3 (#421)
270ade7 Bump tj-actions/changed-files from 44.0.0 to 44.0.1 (#415)
2cadca1 Bump actions/checkout from 4.1.1 to 4.1.2 (#406)
4f1d9b7 Bump reviewdog/action-setup from 1.2.1 to 1.3.0 in /boilerplate (#405)
d052d8b Bump reviewdog/action-setup from 1.2.1 to 1.3.0 in /donotsubmit (#407)
0e99253 Don't triple-wrap logs, just upload as zip (#410)
48e6493 Bump tj-actions/changed-files from 43.0.1 to 44.0.0 (#413)
7071df0 update changed-files (#412)

Given there are no releases of chainguard-dev actions, and bots do not
bump commit ids, maybe we should switch back to tracking @main like we
used to.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
