### PR TITLE
fix(jenkins): use correct compat package

### DIFF
--- a/images/jenkins/main.tf
+++ b/images/jenkins/main.tf
@@ -10,7 +10,7 @@ module "versions" {
 module "config" {
   for_each       = module.versions.versions
   source         = "./config"
-  extra_packages = [each.key, replace(each.key, "jenkins", "jenkins-compat"), "openjdk-17-default-jvm"]
+  extra_packages = [each.key, "jenkins-compat", "openjdk-17-default-jvm"]
 }
 
 module "versioned" {


### PR DESCRIPTION
Jenkins does not have a version streamed compat package. Change the `extra_packages` directive to stop trying to translate the package name into a version-streamed version of it.