### PR TITLE
Expand test coverage, README update

### DIFF
--- a/images/keycloak-operator/tests/keycloak-test.sh
+++ b/images/keycloak-operator/tests/keycloak-test.sh
@@ -620,7 +620,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: RELATED_IMAGE_KEYCLOAK
-              value: cgr.dev/chainguard/keycloak:latest
+              value: ${KEYCLOAK_IMAGE}
           image: ${IMAGE_NAME}
           imagePullPolicy: Always
           livenessProbe:

--- a/images/keycloak-operator/tests/main.tf
+++ b/images/keycloak-operator/tests/main.tf
@@ -9,6 +9,11 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
+variable "keycloak-image" {
+  description = "The keycloak image to test with the keycloak operator."
+  default     = "cgr.dev/chainguard/keycloak:latest"
+}
+
 data "imagetest_inventory" "this" {}
 
 resource "imagetest_harness_k3s" "this" {
@@ -23,7 +28,8 @@ resource "imagetest_harness_k3s" "this" {
       }
     ]
     envs = {
-      "IMAGE_NAME" = var.digest
+      "IMAGE_NAME"     = var.digest
+      "KEYCLOAK_IMAGE" = var.keycloak-image
     }
   }
 }

--- a/images/keycloak/README.md
+++ b/images/keycloak/README.md
@@ -46,22 +46,10 @@ To launch a production instance of Keycloak, refer to the examples in the
 [following documentation](https://github.com/keycloak/keycloak/blob/main/docs/guides/server/containers.adoc),
 as this is dependent on environment-specific settings and customizations.
 
-### Helm
+### Kubernetes operator
 
-To launch a development instance of keycloak in k8s using the following
-[helm chart](https://github.com/bitnami/charts/tree/main/bitnami/keycloak):
-
-```bash
-helm install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
-  --set image.registry=cgr.dev \
-  --set image.repository=chainguard/keycloak \
-  --set image.tag=latest \
-  --set "args={start-dev}"
-```
-
-Refer to the [keycloak](https://github.com/keycloak/keycloak/blob/main/docs/guides/server/containers.adoc)
-and [helm chart](https://github.com/bitnami/charts/tree/main/bitnami/keycloak)
-documentation for more detail.
+To deploy Keycloak leveraging the Keycloak operator, refer to the documentation
+for our [Keycloak operator image](https://images.chainguard.dev/directory/image/keycloak-operator).
 
 ### Customizing the image
 


### PR DESCRIPTION
Expand Keycloak test coverage. Update README to refer to our keycloak-operator instead of previous helm chart - which was not fully compatible.