### PR TITLE
calico: allow customizing images with extra_packages

### DIFF
--- a/images/calico/configs/latest.apiserver.apko.yaml
+++ b/images/calico/configs/latest.apiserver.apko.yaml
@@ -1,6 +1,5 @@
 contents:
-  packages:
-    - calico-apiserver
+  packages: []
 
 accounts:
   groups:

--- a/images/calico/configs/latest.calicoctl.apko.yaml
+++ b/images/calico/configs/latest.calicoctl.apko.yaml
@@ -1,6 +1,5 @@
 contents:
-  packages:
-    - calicoctl
+  packages: []
 
 accounts:
   groups:

--- a/images/calico/configs/latest.cni.apko.yaml
+++ b/images/calico/configs/latest.cni.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - calico-cni
     - calico-cni-compat
 
 accounts:

--- a/images/calico/configs/latest.csi.apko.yaml
+++ b/images/calico/configs/latest.csi.apko.yaml
@@ -1,6 +1,5 @@
 contents:
-  packages:
-    - calico-pod2daemon
+  packages: []
 
 accounts:
   groups:

--- a/images/calico/configs/latest.kube-controllers.apko.yaml
+++ b/images/calico/configs/latest.kube-controllers.apko.yaml
@@ -1,6 +1,5 @@
 contents:
-  packages:
-    - calico-kube-controllers
+  packages: []
 
 accounts:
   groups:

--- a/images/calico/configs/latest.node-driver-registrar.apko.yaml
+++ b/images/calico/configs/latest.node-driver-registrar.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - kubernetes-csi-node-driver-registrar
     - kubernetes-csi-node-driver-registrar-compat
 
 accounts:

--- a/images/calico/configs/latest.node.apko.yaml
+++ b/images/calico/configs/latest.node.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - calico-node
     - busybox
 
 accounts:

--- a/images/calico/configs/latest.pod2daemon.apko.yaml
+++ b/images/calico/configs/latest.pod2daemon.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - calico-pod2daemon
     - calico-pod2daemon-flexvol-compat
     - busybox
 

--- a/images/calico/configs/latest.typha.apko.yaml
+++ b/images/calico/configs/latest.typha.apko.yaml
@@ -1,6 +1,5 @@
 contents:
   packages:
-    - calico-typhad
     - tini
 
 accounts:

--- a/images/calico/configs/main.tf
+++ b/images/calico/configs/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    apko = { source = "chainguard-dev/apko" }
+  }
+}
+
+variable "component" { type = string }
+
+locals {
+  // This lets us set per-package default packages, which can be overridden by
+  // var.extra_packages on a per-component basis.
+  packages = var.extra_packages != [] ? var.extra_packages : [{
+    calicoctl             = "calicoctl"
+    node                  = "calico-node"
+    kube-controllers      = "calico-kube-controllers"
+    cni                   = "calico-cni"
+    csi                   = "calico-pod2daemon"
+    typha                 = "calico-typhad"
+    pod2daemon            = "calico-pod2daemon"
+    node-driver-registrar = "kubernetes-csi-node-driver-registrar"
+    apiserver             = "calico-apiserver"
+  }[var.component]]
+}
+
+variable "extra_packages" {
+  type    = list(string)
+  default = []
+}
+
+data "apko_config" "config" {
+  config_contents = file("${path.module}/latest.${var.component}.apko.yaml")
+  extra_packages  = local.packages
+}
+
+output "config" { value = jsonencode(data.apko_config.config.config) }

--- a/images/calico/main.tf
+++ b/images/calico/main.tf
@@ -42,13 +42,19 @@ variable "target_repository" {
   description = "The docker repo into which the image and attestations should be published."
 }
 
+module "config" {
+  source    = "./configs"
+  for_each  = local.components
+  component = each.key
+}
+
 module "latest" {
   for_each = local.components
   source   = "../../tflib/publisher"
 
   name              = basename(path.module)
   target_repository = local.repositories[each.key]
-  config            = file("${path.module}/configs/latest.${each.key}.apko.yaml")
+  config            = module.config[each.key].config
 }
 
 module "test-latest" {


### PR DESCRIPTION
This lets other invokers of this module specify their own extra_packages on a per-component basis.

For the public image, this should have no effect on behavior.