### PR TITLE
Add warning of upcoming changes to images.

### DIFF
--- a/images/busybox/README.md
+++ b/images/busybox/README.md
@@ -26,6 +26,16 @@ docker pull cgr.dev/chainguard/busybox:latest
 <!--getting:end-->
 
 <!--body:start-->
+## Upcoming Changes
+
+On July 15, 2024 the `busybox:latest` image will move from a Alpine base to a Wolfi base,
+in-line with all other images in our registry. We do not expect this to cause breakages, but
+encourage all users to test and verify the new version.
+
+You can test today by migrating to the `cgr.dev/chainguard/busybox:latest-glibc` image. From July 15, the `:latest` and `:latest-glibc` will point to the same image.
+
+Full details are in [this blog post](https://www.chainguard.dev/unchained/changes-to-static-git-and-busybox-developer-images-2).
+
 ## Usage
 
 Chainguard offers two different variations of the `busybox` Image. Both contain the BusyBox software but are built against different variants of `libc`:

--- a/images/git/README.md
+++ b/images/git/README.md
@@ -32,6 +32,31 @@ Note that there is also glibc version of this Image available:
 docker pull cgr.dev/chainguard/git:latest-glibc
 ```
 
+## Upcoming Changes
+
+On July 15, 2024 several images in this repository will move from a Alpine base to a Wolfi base,
+in-line with all other images in our registry. We do not expect this to cause breakages, but
+encourage all users to test and verify the new versions.
+
+The affected tags are:
+
+ - `latest`
+ - `latest-root` 
+ - `latest-dev` 
+ - `latest-root-dev`
+
+You can test today by migrating to one of the following images:
+
+ - `latest-glibc`
+ - `latest-glibc-root` 
+ - `latest-glibc-dev` 
+ - `latest-glibc-root-dev`
+
+From July 15 the `glibc` tag and the corresponding tag without `glibc` will point to the same
+images.
+
+Full details are in [this blog post](https://www.chainguard.dev/unchained/changes-to-static-git-and-busybox-developer-images-2).
+
 ## Usage
 
 Chainguard's Git Image allows you to run ordinary Git commands in CI/CD pipelines and also locally via Docker.

--- a/images/static/README.md
+++ b/images/static/README.md
@@ -26,6 +26,16 @@ docker pull cgr.dev/chainguard/static:latest
 <!--getting:end-->
 
 <!--body:start-->
+## Upcoming Changes
+
+On July 15, 2024 the `static:latest` image will move from a Alpine base to a Wolfi base,
+in-line with all other images in our registry. We do not expect this to cause breakages, but
+encourage all users to test and verify the new version.
+
+You can test today by migrating to the `cgr.dev/chainguard/static:latest-glibc` image. From July 15, the `:latest` and `:latest-glibc` will point to the same image.
+
+Full details are in [this blog post](https://www.chainguard.dev/unchained/changes-to-static-git-and-busybox-developer-images-2).
+
 ## Usage
 
 Chainguard's static Images are meant to be used as a base image only and are not intended to be run directly.


### PR DESCRIPTION
Adds a warning to the git, busybox and static images about upcoming changes.

Fixes https://github.com/chainguard-dev/internal/issues/3821