### PR TITLE
fixes in cassandra image

### DIFF
--- a/images/cassandra/config/main.tf
+++ b/images/cassandra/config/main.tf
@@ -15,10 +15,19 @@ variable "environment" {
   default     = {}
 }
 
+variable "extra_paths" {
+  description = "Additional paths to configure in the image."
+  default     = []
+}
+
+locals { decoded = yamldecode(file("${path.module}/template.apko.yaml")) }
+
 data "apko_config" "this" {
   config_contents = yamlencode(merge(
-    yamldecode(file("${path.module}/template.apko.yaml")),
-    { environment = var.environment },
+    local.decoded,
+    { environment = merge(local.decoded.environment, var.environment)
+      paths       = concat(local.decoded.paths, var.extra_paths)
+    }
   ))
   extra_packages = var.extra_packages
 }

--- a/images/cassandra/config/template.apko.yaml
+++ b/images/cassandra/config/template.apko.yaml
@@ -20,6 +20,8 @@ entrypoint:
 environment:
   LANG: en_US.UTF-8
   CASSANDRA_HOME: /opt/cassandra
+  CASSANDRA_CONF: /opt/cassandra/conf
+  CASSANDRA_LOGS_DIR: /opt/cassandra/logs
   PATH: /usr/sbin:/sbin:/usr/bin:/bin:/opt/cassandra/bin/
 
 paths:
@@ -30,6 +32,18 @@ paths:
     gid: 999
     recursive: true
   - path: /opt/cassandra
+    type: directory
+    permissions: 0o777
+    uid: 999
+    gid: 999
+    recursive: true
+  - path: /opt/cassandra/logs
+    type: directory
+    permissions: 0o777
+    uid: 999
+    gid: 999
+    recursive: true
+  - path: /opt/cassandra/conf
     type: directory
     permissions: 0o777
     uid: 999


### PR DESCRIPTION
nodetool doesn't work on our Cassandra image.

```
Upstream :
CONTAINER_ID=$(docker run -d cassandra:latest)
# Wait a few minutes until Cassandra fully starts...

docker exec -it $CONTAINER_ID nodetool status
Datacenter: datacenter1
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address     Load        Tokens  Owns (effective)  Host ID                               Rack
UN  172.17.0.3  104.34 KiB  16      100.0%            d1e04976-9d2b-4854-96e0-cad35cf3bde2  rack1
```

```
Chainguard 'cassandra' image :
docker exec -it 106306b84660 nodetool status
grep: /usr/bin/../conf/jvm-clients.options: No such file or directory
grep: /usr/bin/../conf/jvm11-clients.options: No such file or directory
Error opening zip file or JAR manifest missing : /usr/bin/../lib/jamm-0.3.2.jar
Error occurred during initialization of VM
agent library failed to init: instrument
```

This was happening probably due to environment variables not being set correctly due to them not being parsed rightly, this PR fixes this and now even our image works fine with this change:

```bash
bash-5.2$ nodetool --status
nodetool: Found unexpected parameters: [--status]
See 'nodetool help' or 'nodetool help <command>'.
bash-5.2$ nodetool status
Datacenter: datacenter1
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load        Tokens  Owns (effective)  Host ID                               Rack 
UN  127.0.0.1  104.37 KiB  16      100.0%            453fbd4a-5dd0-4090-98e5-7bfa250b1795  rack1
```