### PR TITLE
github: switch setup-chainctl to non-deprecated location

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
           terraform_version: '1.8.*'
           terraform_wrapper: false
 
-      - uses: chainguard-dev/actions/setup-chainctl@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
+      - uses: chainguard-dev/setup-chainctl@58c1184bfdcf53576831252e68198d8df26f3e1b # v0.1.0
         with:
           # This allows chainguard-images/images-private to publish images to cgr.dev/chainguard-private
           # We maintain this identity here:

--- a/.github/workflows/withdraw-images.yaml
+++ b/.github/workflows/withdraw-images.yaml
@@ -21,7 +21,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - uses: chainguard-dev/actions/setup-chainctl@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
+      - uses: chainguard-dev/setup-chainctl@58c1184bfdcf53576831252e68198d8df26f3e1b # v0.1.0
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3

--- a/.github/workflows/withdraw-repos.yaml
+++ b/.github/workflows/withdraw-repos.yaml
@@ -21,7 +21,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - uses: chainguard-dev/actions/setup-chainctl@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
+      - uses: chainguard-dev/setup-chainctl@58c1184bfdcf53576831252e68198d8df26f3e1b # v0.1.0
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
       - run: |


### PR DESCRIPTION
As per warnings this will break in August 2024.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
