### PR TITLE
pytorch-cuda12: Add LD_LIBRARY_PATH and workdir

### DIFF
--- a/images/pytorch-cuda12/config/main.tf
+++ b/images/pytorch-cuda12/config/main.tf
@@ -39,11 +39,14 @@ output "config" {
     }
     accounts = module.accts.block
     environment = merge({
-      "PATH" : "/usr/share/torchvision/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "PATH" : "/work:/usr/share/torchvision/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin",
+      "CUDA_VERSION" : "12.3",
+      "LD_LIBRARY_PATH" : "/usr/local/cuda-12.3/lib:/usr/local/cudnn-8.9",
     }, var.environment)
     entrypoint = {
       command = "/bin/bash"
     }
-    archs = ["x86_64"]
+    archs    = ["x86_64"]
+    work-dir = "/work"
   })
 }


### PR DESCRIPTION
Set some defaults to use the installed nvidia cudnn