### PR TITLE
don't cleanup disk space on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,14 +87,9 @@ jobs:
         with:
           egress-policy: audit
 
-      # In some cases, we run out of disk space during tests, so this hack frees up approx 25G.
-      # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-      - name: Free up runner disk space
-        uses: ublue-os/remove-unwanted-software@517622d6452028f266b7ba4cc9a123b5f58a6b53 # v7
-
       - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3
         with:
-          terraform_version: '1.8.*'
+          terraform_version: "1.8.*"
           terraform_wrapper: false
 
       - uses: chainguard-dev/setup-chainctl@58c1184bfdcf53576831252e68198d8df26f3e1b # v0.1.0


### PR DESCRIPTION
when this was introduced we'd see typical savings of ~25G, nowadays this is more like ~3G ([ref](https://github.com/chainguard-images/images/actions/runs/9209338848/job/25333708323#step:5:1449)).

More problematic, this takes much longer (~7m!) on the larger 64c runners postsubmit uses due to all the additional cruft not present on the presubmit runners.

While we probably still need this for presubmit, where space is at a premium on the smaller runners, in postsubmit where the 64c machines have [~2Tb](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#specifications-for-general-larger-runners) disks I'm arguing this isn't worth it anymore.