### PR TITLE
default check-sbom: true

### DIFF
--- a/images/docker-selenium/main.tf
+++ b/images/docker-selenium/main.tf
@@ -19,6 +19,13 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.config.config
   build-dev         = true
+
+  /*
+  Unrecognized license reference: custom. license_expression must only use IDs from the license list or extracted licensing info, but is: custom
+  Unrecognized license reference: LicenseRef-ubuntu-font. license_expression must only use IDs from the license list or extracted licensing info, but is: LicenseRef-ubuntu-font
+  Components missing an supplier: libxxf86vm,libdaemon,fftw-single-libs,libxv
+  */
+  check-sbom = false # TODO(jason): Re-enable SBOM check
 }
 
 module "test" {

--- a/images/eck-operator/main.tf
+++ b/images/eck-operator/main.tf
@@ -27,6 +27,13 @@ module "eck-operator" {
 
   build-dev    = true
   main_package = each.key
+
+  /*
+  Unrecognized license reference: Elastic License 2.0. license_expression must only use IDs from the license list or extracted licensing info, but is: Elastic License 2.0
+  Unrecognized license reference: Elastic License 2.0. license_expression must only use IDs from the license list or extracted licensing info, but is: Elastic License 2.0
+  No components with missing information.
+  */
+  check-sbom = false # TODO(jason): Re-enable SBOM check
 }
 
 module "test" {

--- a/images/local-volume-provisioner/main.tf
+++ b/images/local-volume-provisioner/main.tf
@@ -29,6 +29,11 @@ module "local-volume-provisioner" {
 
   build-dev    = true
   main_package = each.key
+
+  /*
+  Components missing an supplier: gawk
+  */
+  check-sbom = false # TODO(jason): Re-enable SBOM check
 }
 
 module "test" {

--- a/images/nvidia-container-toolkit/main.tf
+++ b/images/nvidia-container-toolkit/main.tf
@@ -16,6 +16,11 @@ module "nvidia-container-toolkit" {
   target_repository = var.target_repository
   config            = module.config.config
   build-dev         = true
+
+  /*
+  Unrecognized license reference: PROPRIETARY. license_expression must only use IDs from the license list or extracted licensing info, but is: PROPRIETARY
+  */
+  check-sbom = false # TODO(jason): Re-enable SBOM check
 }
 
 module "test" {

--- a/images/opensearch-dashboards/main.tf
+++ b/images/opensearch-dashboards/main.tf
@@ -16,6 +16,11 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.latest-config.config
   build-dev         = true
+
+  /*
+    Unrecognized license reference: custom. license_expression must only use IDs from the license list or extracted licensing info, but is: custom
+  */
+  check-sbom = false # TODO(jason): Re-enable SBOM check
 }
 
 module "test-latest" {

--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -55,7 +55,7 @@ variable "update-repo" {
 
 variable "check-sbom" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to run the NTIA conformance checker over the images we produce prior to attesting the SBOMs."
 }
 
@@ -91,7 +91,7 @@ locals {
 
 module "this" {
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.11"
+  version = "0.0.13"
 
   target_repository = var.target_repository
   config            = yamlencode(local.updated_config)
@@ -104,7 +104,7 @@ module "this" {
 module "this-dev" {
   count   = local.build-dev ? 1 : 0
   source  = "chainguard-dev/apko/publisher"
-  version = "0.0.11"
+  version = "0.0.13"
 
   target_repository = var.target_repository
 


### PR DESCRIPTION
Spot-checking failed tests, they seem to be pre-existing test flakes/failures, and not related to this new check.

If there are any images with invalid SBOMs for any reason, we can unblock with `check-sbom = false` for that image, and address it later.