### PR TITLE
Bump calico version for tigera-operator test

### DIFF
--- a/images/tigera-operator/tests/helm/main.tf
+++ b/images/tigera-operator/tests/helm/main.tf
@@ -5,7 +5,7 @@ variable "values" {
 }
 
 variable "tigera_version" {
-  default = "3.27.0"
+  default = "3.28.0"
 }
 
 module "helm" {


### PR DESCRIPTION
The latest tigera-operator seems to need the latest calico version