### PR TITLE
pytorch-cuda12: disable check-sbom for now

### DIFF
--- a/images/pytorch-cuda12/main.tf
+++ b/images/pytorch-cuda12/main.tf
@@ -19,6 +19,7 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.config.config
   build-dev         = true
+  check-sbom        = false # TODO(pnasrat): Re-enable SBOM check after license corrected
 }
 
 module "test" {


### PR DESCRIPTION
Turning off per #2727 due to proprietary license to be fixed 

>  Unrecognized license reference: PROPRIETARY. license_expression must only use IDs from the license list or extracted licensing info, but is: PROPRIETARY