### PR TITLE
chore(kafka): Don't include JVM in extra packages

### DIFF
--- a/images/kafka/config/main.tf
+++ b/images/kafka/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install (e.g. kafka)."
-  default     = ["kafka", "openjdk-11-default-jvm"]
+  default     = ["kafka"]
 }
 
 variable "environment" {


### PR DESCRIPTION
Set as a package runtime dependency instead