### PR TITLE
deconflict multiple lokis

### DIFF
--- a/images/loki/config/template.apko.yaml
+++ b/images/loki/config/template.apko.yaml
@@ -5,12 +5,13 @@ contents:
 accounts:
   groups:
     - groupname: loki
-      gid: 65532
+      gid: 10001
   users:
     - username: loki
-      uid: 65532
-      gid: 65532
-  run-as: 65532
+      uid: 10001
+      gid: 10001
+  # Match the default UID/GID of the upstream image and helm chart
+  run-as: 10001
 
 entrypoint:
   command: /usr/bin/loki
@@ -20,16 +21,19 @@ cmd: -config.file=/etc/loki/local-config.yaml
 paths:
   - path: /loki
     type: directory
-    uid: 65532
-    gid: 65532
+    uid: 10001
+    gid: 10001
     permissions: 0o755
+    recursive: true
   - path: /loki/rules
     type: directory
-    uid: 65532
-    gid: 65532
+    uid: 10001
+    gid: 10001
     permissions: 0o755
+    recursive: true
   - path: /loki/rules-temp
     type: directory
-    uid: 65532
-    gid: 65532
+    uid: 10001
+    gid: 10001
     permissions: 0o755
+    recursive: true

--- a/images/loki/tests/main.tf
+++ b/images/loki/tests/main.tf
@@ -57,11 +57,33 @@ module "helm" {
     singleBinary = {
       replicas = 1
       persistence = {
-        size = "1Gi"
+        # Disable in favor of a temp emptyDir for testing
+        enabled = false
       }
-      registry   = local.parsed.registry
-      repository = local.parsed.repo
-      tag        = local.parsed.pseudo_tag
+      image = {
+        registry   = local.parsed.registry
+        repository = local.parsed.repo
+        tag        = local.parsed.pseudo_tag
+      }
+      # Without these extra mounts and the persistence disable, the chart 
+      # creates host path mounts that conflict with multiple instances of
+      # loki, even across multiple clusters on the same machine. These are
+      # added in the chart instead of the image to mimic upstream's behavior.
+      extraVolumeMounts = [
+        {
+          name      = "temp"
+          mountPath = "/var/loki"
+        }
+      ]
+      extraVolumes = [
+        {
+          name     = "temp"
+          emptyDir = {}
+        }
+      ]
+    }
+    gateway = {
+      eanbled = false
     }
     backend = {
       replicas = 0


### PR DESCRIPTION
also changes the uid to match upstream to avoid the various "permission errors" that were popping up