### PR TITLE
pytorch: fix cudnn LD_LIBRARY_PATH

### DIFF
--- a/images/pytorch-cuda12/config/main.tf
+++ b/images/pytorch-cuda12/config/main.tf
@@ -41,7 +41,7 @@ output "config" {
     environment = merge({
       "PATH" : "/work:/usr/share/torchvision/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin",
       "CUDA_VERSION" : "12.3",
-      "LD_LIBRARY_PATH" : "/usr/local/cuda-12.3/lib:/usr/local/cudnn-8.9",
+      "LD_LIBRARY_PATH" : "/usr/local/cuda-12.3/lib:/usr/local/cudnn-8.9/lib64",
     }, var.environment)
     entrypoint = {
       command = "/bin/bash"


### PR DESCRIPTION
Fixes thinko  (libs in lib64)