### PR TITLE
Deprecate the k8s-diag step to push usage of imagetest

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -199,10 +199,8 @@ jobs:
 
     - name: Collect diagnostics and upload
       if: ${{ failure() }}
-      uses: chainguard-dev/actions/k8s-diag@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
-      with:
-        cluster-type: k3d
-        namespace-resources: deploy,ds,sts,pods
+      run: |
+        echo 'This step is deprecated. Please use the imagetest provider and reference the imagetest logs'
 
     - name: Upload imagetest logs
       if: always()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,11 +131,8 @@ jobs:
 
       - name: Collect K8s diagnostics and upload
         if: ${{ failure() }}
-        uses: chainguard-dev/actions/k8s-diag@ba1a9c9ffe799736883d58f31caff18d85b2800e # main
-        with:
-          artifact-name: "k8s-test-harness-${{ matrix.shard.index }}-logs"
-          cluster-type: k3d
-          namespace-resources: deploy,ds,sts,pods
+        run: |
+          echo 'This step is deprecated. Please use the imagetest provider and reference the imagetest logs'
 
       - name: Upload terraform logs
         if: always()


### PR DESCRIPTION
Our `k8s-diag` step has been failing for two weeks now and nobody has yelled about it. We started collecting logs from `imagetest` and the ultimate goal is to get all k8s tests on `imagetest`. I'm proposing we remove the `k8s-diag` step as a way of investing even more in `imagetest`