### PR TITLE
check-sbom: default to false again :(

### DIFF
--- a/tflib/publisher/main.tf
+++ b/tflib/publisher/main.tf
@@ -55,7 +55,7 @@ variable "update-repo" {
 
 variable "check-sbom" {
   type        = bool
-  default     = true
+  default     = false // TODO(jason): Change this to true
   description = "Whether to run the NTIA conformance checker over the images we produce prior to attesting the SBOMs."
 }
 


### PR DESCRIPTION
Undoes #2727 

Image builds seem to fail to install `spdx-tools-java`, and don't notify Slack as expected.