### PR TITLE
ensure jenkins works with plugins

### DIFF
--- a/images/jenkins/config/main.tf
+++ b/images/jenkins/config/main.tf
@@ -6,7 +6,7 @@ terraform {
 
 variable "extra_packages" {
   description = "The additional packages to install."
-  default     = ["jenkins", "openjdk-17-default-jvm", "jenkins-compat"]
+  default     = ["jenkins", "openjdk-17-default-jvm", "jenkins-compat", "jenkins-docker"]
 }
 
 variable "environment" {

--- a/images/jenkins/config/template.apko.yaml
+++ b/images/jenkins/config/template.apko.yaml
@@ -1,35 +1,44 @@
 contents:
   packages:
-    # jenkins and openjdk provided by extra_packages
+    # jenkins, jenkins-docker, and openjdk provided by extra_packages
 
 accounts:
   groups:
     - groupname: jenkins
-      gid: 65532
+      gid: 1000
   users:
     - username: jenkins
-      uid: 65532
-  run-as: 65532
-
-work-dir: /app
+      gid: 1000
+      uid: 1000
+      homedir: "/var/jenkins_home"
+  # Match upstream
+  run-as: 1000
 
 entrypoint:
-  command: jenkins.sh
+  command: "tini -- /usr/local/bin/jenkins.sh"
 
 environment:
   LANG: en_US.UTF-8
   JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   JENKINS_HOME: /var/jenkins_home
+  REF: /usr/share/jenkins/ref
+  JENKINS_UC: https://updates.jenkins.io
+  JENKINS_UC_EXPERIMENTAL: https://updates.jenkins.io/experimental
+  JENKINS_INCREMENTALS_REPO_MIRROR: https://repo.jenkins-ci.org/incrementals
+  COPY_REFERENCE_FILE_LOG: /var/jenkins_home/copy_reference_file.log
+
+volumes:
+  - "/var/jenkins_home"
 
 paths:
   - path: /var/jenkins_home
     type: directory
-    uid: 65532
-    gid: 65532
+    uid: 1000
+    gid: 1000
     permissions: 0o755
   - path: /usr/share/jenkins
     type: directory
-    uid: 65532
-    gid: 65532
+    uid: 1000
+    gid: 1000
     permissions: 0o755
     recursive: true

--- a/images/jenkins/main.tf
+++ b/images/jenkins/main.tf
@@ -10,7 +10,7 @@ module "versions" {
 module "config" {
   for_each       = module.versions.versions
   source         = "./config"
-  extra_packages = [each.key, "jenkins-compat", "openjdk-17-default-jvm"]
+  extra_packages = [each.key, "jenkins-compat", "jenkins-docker", "jenkins-plugin-manager", "openjdk-17-default-jvm"]
 }
 
 module "versioned" {

--- a/images/jenkins/tests/controller/main.tf
+++ b/images/jenkins/tests/controller/main.tf
@@ -10,10 +10,6 @@ variable "values" {
     controller = {
       javaOpts    = ""
       jenkinsOpts = ""
-      admin = {
-        createSecret = false
-      }
-      installPlugins = false
       sidecars = {
         configAutoReload = {
           enabled = false

--- a/images/jenkins/tests/hello-world.sh
+++ b/images/jenkins/tests/hello-world.sh
@@ -1,34 +1,48 @@
 #!/bin/sh
 
-# set -euo pipefail
+set -exo
 
 apk add curl openjdk-21-jre-base
 
 export JAVA_HOME=/usr/lib/jvm/java-21-openjdk/
 
-kubectl port-forward -n jenkins svc/jenkins 8080:8080&
-sleep 5 # wait for port-forward to settle
+JENKINS_ADMIN_PASSWORD=$(kubectl get secret --namespace jenkins jenkins -o jsonpath="{.data.jenkins-admin-password}" | base64 -d)
+JENKINS_ADMIN_USER=$(kubectl get secret --namespace jenkins jenkins -o jsonpath="{.data.jenkins-admin-user}" | base64 -d)
+JENKINS_URL="http://localhost:8080"
+
+kubectl port-forward -n jenkins svc/jenkins 8080:8080 &
+
+until curl -s --head --request GET "${JENKINS_URL}/login" | grep "200 OK" >/dev/null; do
+	sleep 1
+done
+
 curl -s -O "http://localhost:8080/jnlpJars/jenkins-cli.jar"
 mv jenkins-cli.jar /tmp/
 
-# define a job
-cat /tests/hello-world.xml | \
+# Define a job
+cat /tests/hello-world.xml |
 	$JAVA_HOME/bin/java \
+		-jar /tmp/jenkins-cli.jar \
+		-s ${JENKINS_URL} \
+		-auth ${JENKINS_ADMIN_USER}:${JENKINS_ADMIN_PASSWORD} \
+		create-job "Hello world"
+
+# Run the job and wait for it to complete
+BUILD_NUMBER=$($JAVA_HOME/bin/java \
 	-jar /tmp/jenkins-cli.jar \
-	-s http://127.0.0.1:8080 \
-	create-job "Hello world"
+	-s ${JENKINS_URL} \
+	-auth ${JENKINS_ADMIN_USER}:${JENKINS_ADMIN_PASSWORD} \
+	build "Hello world" -s)
 
-sleep 5 # wait for port-forward to settle
-
-# run the job
-$JAVA_HOME/bin/java \
+# Check job success
+BUILD_STATUS=$($JAVA_HOME/bin/java \
 	-jar /tmp/jenkins-cli.jar \
-	-s http://127.0.0.1:8080 build "Hello world"
+	-s ${JENKINS_URL} \
+	-auth ${JENKINS_ADMIN_USER}:${JENKINS_ADMIN_PASSWORD} \
+	console "Hello world" | grep 'Finished: SUCCESS')
 
-sleep 5 # wait for port-forward to settle
-
-# check job success
-STATUS=`$JAVA_HOME/bin/java \
-	-jar /tmp/jenkins-cli.jar \
-	-s http://127.0.0.1:8080 console "Hello world" |grep 'Finished: SUCCESS'`
-
+if [ -n "$BUILD_STATUS" ]; then
+	echo "Job succeeded"
+else
+	echo "Job failed"
+fi

--- a/images/jenkins/tests/main.tf
+++ b/images/jenkins/tests/main.tf
@@ -40,9 +40,8 @@ module "helm_controller" {
     create_namespace = true
 
     controller = {
-      javaOpts       = ""
-      jenkinsOpts    = ""
-      installPlugins = false
+      javaOpts    = ""
+      jenkinsOpts = ""
       admin = {
         createSecret = false
       }

--- a/images/jenkins/tests/main.tf
+++ b/images/jenkins/tests/main.tf
@@ -42,9 +42,6 @@ module "helm_controller" {
     controller = {
       javaOpts    = ""
       jenkinsOpts = ""
-      admin = {
-        createSecret = false
-      }
       sidecars = {
         configAutoReload = {
           enabled = false


### PR DESCRIPTION
I'm about the furthest thing from a jenkins knower, but apparently plugins are important.

This is ensure the scripts/dependencies needed for initializing, supporting, and downloading plugins are available in the image.

Most importantly, it ensures we're compatible with the upstream default helm chart installation. Previously, if you tried to install a vanilla jenkins installation we would bomb out for various plugin reasons.