### PR TITLE
nemo: disable SBOM check

### DIFF
--- a/images/nemo/main.tf
+++ b/images/nemo/main.tf
@@ -15,8 +15,8 @@ module "nemo" {
   name              = basename(path.module)
   target_repository = var.target_repository
   config            = module.config.config
-
-  build-dev = true
+  check-sbom        = false // Contains a package with non-SPDX license
+  build-dev         = true
 }
 
 # TODO: These tests pass however we're running into CI issues related to disk space,


### PR DESCRIPTION
This currently fails the NTIA SBOM check with

```
  Unrecognized license reference: PROPRIETARY. license_expression must only use IDs from the license list or extracted licensing info, but is: PROPRIETARY
```

Disabling the test for now so the image can still get updates.