### PR TITLE
cassandra-medusa: make grpc-health-probe configurable

### DIFF
--- a/images/cassandra-medusa/config/main.tf
+++ b/images/cassandra-medusa/config/main.tf
@@ -9,6 +9,7 @@ variable "extra_packages" {
   default = [
     "py3-cassandra-medusa",
     "py3-cassandra-medusa-compat",
+    "grpc-health-probe",
   ]
 }
 


### PR DESCRIPTION
This makes grpc-health-probe an image build option