### PR TITLE
show plan for each module before building

### DIFF
--- a/.github/workflows/presubmit-build.yaml
+++ b/.github/workflows/presubmit-build.yaml
@@ -181,7 +181,12 @@ jobs:
         targets=""
         for image in ${{ matrix.shard.images }}; do
           targets+=' -target='module."${image}"''
+
+          echo "::group::Plan for ${image}"
+          terraform plan -target=module."${image}"
+          echo "::endgroup::"
         done
+
         terraform apply ${targets} -auto-approve --parallelism=$(nproc) -json | tee /tmp/mega-module.tf.json | jq -r '.["@message"]'
 
     - name: Collect TF diagnostics

--- a/images/crane/main.tf
+++ b/images/crane/main.tf
@@ -7,8 +7,6 @@ module "versions" {
   source  = "../../tflib/versions"
 }
 
-# TODO: add a diff to test
-
 module "config" {
   for_each       = module.versions.versions
   source         = "./config"

--- a/images/crane/main.tf
+++ b/images/crane/main.tf
@@ -7,6 +7,8 @@ module "versions" {
   source  = "../../tflib/versions"
 }
 
+# TODO: add a diff to test
+
 module "config" {
   for_each       = module.versions.versions
   source         = "./config"


### PR DESCRIPTION
The way we `terraform apply -json` means the otherwise useful plan output is suppressed, which loses helpful debugging information. For each module we build, we'll first do a `tf plan` in a collapsed section.

Example: https://github.com/chainguard-images/images/actions/runs/9339594424/job/25704189217?pr=2784#step:11:3310