### PR TITLE
harbor: drop trivy package dep (included in apk)

### DIFF
--- a/images/harbor/main.tf
+++ b/images/harbor/main.tf
@@ -23,7 +23,7 @@ locals {
     }, {
     "core" : ["harbor"]
     }, {
-    "trivy-adapter" : ["harbor-scanner-trivy", "trivy"]
+    "trivy-adapter" : ["harbor-scanner-trivy"]
   })
 
   repositories = {


### PR DESCRIPTION
harbor-scanner-trivy binary execs trivy binary, thus dependency was
added on the apk level. Thus one doesn't need to specify trivy
dependency anymore.

Related:
- https://github.com/wolfi-dev/os/pull/21243

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
