### PR TITLE
cassandra-medusa use shorter names

### DIFF
--- a/images/cassandra-medusa/tests/main.tf
+++ b/images/cassandra-medusa/tests/main.tf
@@ -34,7 +34,7 @@ resource "imagetest_harness_k3s" "this" {
       "IMAGE_REPOSITORY"       = split("/", local.parsed.repo)[0]
       "NAME"                   = split("/", local.parsed.repo)[1]
       "K8SSANDRA_CLUSTER_NAME" = "foo-${random_id.suffix.hex}"
-      "IMAGE_TAG"              = "latest"
+      "IMAGE_TAG"              = split(":", local.parsed.pseudo_tag)[1]
     }
   }
 }

--- a/images/cassandra-medusa/tests/main.tf
+++ b/images/cassandra-medusa/tests/main.tf
@@ -34,7 +34,7 @@ resource "imagetest_harness_k3s" "this" {
       "IMAGE_REPOSITORY"       = split("/", local.parsed.repo)[0]
       "NAME"                   = split("/", local.parsed.repo)[1]
       "K8SSANDRA_CLUSTER_NAME" = "foo-${random_id.suffix.hex}"
-      "IMAGE_TAG"              = split(":", local.parsed.pseudo_tag)[1]
+      "IMAGE_TAG"              = trim(":", local.parsed.pseudo_tag)
     }
   }
 }

--- a/images/cassandra-medusa/tests/main.tf
+++ b/images/cassandra-medusa/tests/main.tf
@@ -34,7 +34,7 @@ resource "imagetest_harness_k3s" "this" {
       "IMAGE_REPOSITORY"       = split("/", local.parsed.repo)[0]
       "NAME"                   = split("/", local.parsed.repo)[1]
       "K8SSANDRA_CLUSTER_NAME" = "foo-${random_id.suffix.hex}"
-      "IMAGE_TAG"              = trim(":", local.parsed.pseudo_tag)
+      "IMAGE_TAG"              = local.parsed.pseudo_tag
     }
   }
 }

--- a/images/cassandra-medusa/tests/main.tf
+++ b/images/cassandra-medusa/tests/main.tf
@@ -9,7 +9,9 @@ variable "digest" {
   description = "The image digest to run tests over."
 }
 
-resource "random_pet" "suffix" {}
+resource "random_id" "suffix" {
+  byte_length = 4
+}
 
 locals { parsed = provider::oci::parse(var.digest) }
 
@@ -27,12 +29,12 @@ resource "imagetest_harness_k3s" "this" {
       }
     ]
     envs = {
-      "NAMESPACE"              = "k8s-medusa-${random_pet.suffix.id}"
+      "NAMESPACE"              = "k8s-medusa-${random_id.suffix.hex}"
       "IMAGE_REGISTRY"         = local.parsed.registry
       "IMAGE_REPOSITORY"       = split("/", local.parsed.repo)[0]
       "NAME"                   = split("/", local.parsed.repo)[1]
-      "K8SSANDRA_CLUSTER_NAME" = "foo-${random_pet.suffix.id}"
-      "IMAGE_TAG"              = local.parsed.pseudo_tag
+      "K8SSANDRA_CLUSTER_NAME" = "foo-${random_id.suffix.hex}"
+      "IMAGE_TAG"              = "latest"
     }
   }
 }
@@ -51,5 +53,9 @@ resource "imagetest_feature" "basic" {
 
   labels = {
     type = "k8s"
+  }
+
+  timeouts = {
+    create = "15m"
   }
 }

--- a/images/cassandra-medusa/tests/medusa-install.sh
+++ b/images/cassandra-medusa/tests/medusa-install.sh
@@ -32,6 +32,7 @@ retry_command() {
 
     # In the event we fail, print out the status of resources in the cluster.
     kubectl get all --all-namespaces
+    kubectl events --all-namespaces
 
     echo "Error: Failed after $max_attempts attempts for: $description"
     return 1

--- a/images/cassandra-medusa/tests/medusa-install.sh
+++ b/images/cassandra-medusa/tests/medusa-install.sh
@@ -139,10 +139,10 @@ spec:
 EOF
 
 # Check readiness of the Cassandra Medusa pod
-retry_command 30 30 "Cassandra Medusa pod readiness" "kubectl wait --for=condition=Ready pod -l app=${K8SSANDRA_CLUSTER_NAME}-k3d-medusa-standalone -n ${NAMESPACE} --timeout=2m"
+retry_command 5 15 "Cassandra Medusa pod readiness" "kubectl wait --for=condition=Ready pod -l app=${K8SSANDRA_CLUSTER_NAME}-k3d-medusa-standalone -n ${NAMESPACE} --timeout=2m"
 
 # Check readiness of the Cassandra stateful set
-retry_command 30 30 "Cassandra stateful set readiness" "kubectl get statefulset ${K8SSANDRA_CLUSTER_NAME}-k3d-default-sts -n ${NAMESPACE} --no-headers -o custom-columns=READY:.status.readyReplicas | grep -q '1'"
+retry_command 5 15 "Cassandra stateful set readiness" "kubectl get statefulset ${K8SSANDRA_CLUSTER_NAME}-k3d-default-sts -n ${NAMESPACE} --no-headers -o custom-columns=READY:.status.readyReplicas | grep -q '1'"
 
 # Check Medusa gRPC server startup
 kubectl logs -l app=${K8SSANDRA_CLUSTER_NAME}-k3d-medusa-standalone --tail -1 -n ${NAMESPACE} | grep "Starting server. Listening on port 50051"

--- a/images/cassandra-medusa/tests/medusa-install.sh
+++ b/images/cassandra-medusa/tests/medusa-install.sh
@@ -143,7 +143,7 @@ EOF
 retry_command 5 15 "Cassandra Medusa pod readiness" "kubectl wait --for=condition=Ready pod -l app=${K8SSANDRA_CLUSTER_NAME}-k3d-medusa-standalone -n ${NAMESPACE} --timeout=2m"
 
 # Check readiness of the Cassandra stateful set
-retry_command 5 15 "Cassandra stateful set readiness" "kubectl get statefulset ${K8SSANDRA_CLUSTER_NAME}-k3d-default-sts -n ${NAMESPACE} --no-headers -o custom-columns=READY:.status.readyReplicas | grep -q '1'"
+retry_command 5 15 "Cassandra stateful set readiness" "kubectl wait --for=condition=Ready pod -l statefulset.kubenernetes.io/pod-name=${K8SSANDRA_CLUSTER_NAME}-k3d-default-sts-0 --timeout=2m"
 
 # Check Medusa gRPC server startup
 kubectl logs -l app=${K8SSANDRA_CLUSTER_NAME}-k3d-medusa-standalone --tail -1 -n ${NAMESPACE} | grep "Starting server. Listening on port 50051"

--- a/images/cassandra-medusa/tests/medusa-install.sh
+++ b/images/cassandra-medusa/tests/medusa-install.sh
@@ -95,7 +95,7 @@ spec:
     serverVersion: "4.0.1"
     datacenters:
       - metadata:
-          name: ${K8SSANDRA_CLUSTER_NAME}
+          name: k3d
         size: 1
         storageConfig:
           cassandraDataVolumeClaimSpec:
@@ -139,13 +139,13 @@ spec:
 EOF
 
 # Check readiness of the Cassandra Medusa pod
-retry_command 30 30 "Cassandra Medusa pod readiness" "kubectl wait --for=condition=Ready pod -l app=${K8SSANDRA_CLUSTER_NAME}-${K8SSANDRA_CLUSTER_NAME}-medusa-standalone -n ${NAMESPACE} --timeout=2m"
+retry_command 30 30 "Cassandra Medusa pod readiness" "kubectl wait --for=condition=Ready pod -l app=${K8SSANDRA_CLUSTER_NAME}-k3d-medusa-standalone -n ${NAMESPACE} --timeout=2m"
 
 # Check readiness of the Cassandra stateful set
-retry_command 30 30 "Cassandra stateful set readiness" "kubectl get statefulset ${K8SSANDRA_CLUSTER_NAME}-${K8SSANDRA_CLUSTER_NAME}-default-sts -n ${NAMESPACE} --no-headers -o custom-columns=READY:.status.readyReplicas | grep -q '1'"
+retry_command 30 30 "Cassandra stateful set readiness" "kubectl get statefulset ${K8SSANDRA_CLUSTER_NAME}-k3d-default-sts -n ${NAMESPACE} --no-headers -o custom-columns=READY:.status.readyReplicas | grep -q '1'"
 
 # Check Medusa gRPC server startup
-kubectl logs -l app=${K8SSANDRA_CLUSTER_NAME}-${K8SSANDRA_CLUSTER_NAME}-medusa-standalone --tail -1 -n ${NAMESPACE} | grep "Starting server. Listening on port 50051"
+kubectl logs -l app=${K8SSANDRA_CLUSTER_NAME}-k3d-medusa-standalone --tail -1 -n ${NAMESPACE} | grep "Starting server. Listening on port 50051"
 
 # Create Medusa Backup
 kubectl apply -n ${NAMESPACE} -f - <<EOF


### PR DESCRIPTION
Use shortnames in imagetest (using random_id not random_pet) to prevent names longer the k8s limits

The cassandra operator expects medusa  images to consist of registry, repository, image, tag 

Update test pod/statefulset wait/timeouts due to upstream removal of standalone pod