### PR TITLE
vault,consul: provide BUSL-licensed version as latest

### DIFF
--- a/images/consul/config/main.tf
+++ b/images/consul/config/main.tf
@@ -9,9 +9,33 @@ variable "extra_packages" {
   default     = []
 }
 
+variable "extra_repositories" {
+  description = "The additional repositories to install from."
+  type        = list(string)
+  default     = []
+}
+
+variable "extra_keyring" {
+  description = "The additional keys to use."
+  type        = list(string)
+  default     = []
+}
+
+locals { base_config = yamldecode(file("${path.module}/template.apko.yaml")) }
+
 data "apko_config" "this" {
-  config_contents = file("${path.module}/template.apko.yaml")
-  extra_packages  = var.extra_packages
+  config_contents = yamlencode(merge(
+    local.base_config,
+    {
+      // Allow injecting extra repositories and keyrings.
+      contents = {
+        repositories = var.extra_repositories
+        keyring      = var.extra_keyring
+        packages     = local.base_config.contents.packages
+      }
+    },
+  ))
+  extra_packages = var.extra_packages
 }
 
 output "config" {

--- a/images/consul/main.tf
+++ b/images/consul/main.tf
@@ -11,10 +11,12 @@ variable "target_repository" {
 module "latest-config" {
   source = "./config"
   extra_packages = [
-    "consul<1.17",
-    "consul-oci-entrypoint<1.17",
-    "consul-oci-entrypoint-compat<1.17",
+    "consul",
+    "consul-oci-entrypoint",
+    "consul-oci-entrypoint-compat",
   ]
+  extra_repositories = ["https://packages.cgr.dev/extras"]
+  extra_keyring      = ["https://packages.cgr.dev/extras/chainguard-extras.rsa.pub"]
 }
 
 module "latest" {

--- a/images/vault/vault.tf
+++ b/images/vault/vault.tf
@@ -1,6 +1,8 @@
 module "vault-config" {
-  source         = "./configs/vault"
-  extra_packages = ["vault<1.15", "vault-entrypoint"]
+  source             = "./configs/vault"
+  extra_packages     = ["vault", "vault-entrypoint"]
+  extra_repositories = ["https://packages.cgr.dev/extras"]
+  extra_keyring      = ["https://packages.cgr.dev/extras/chainguard-extras.rsa.pub"]
 }
 
 module "vault" {


### PR DESCRIPTION
This updates `vault:latest` and `consul:latest` to be the actual latest versions from the extras repo, which are BUSL licensed.

This partially matches what we do for `terraform:latest`, which is its actual latest BUSL-licensed version. For Terraform we also provide `terraform:mpl` which is the last non-BUSL-licensed version. I won't do that for vault and consul until someone tells me I should.