### PR TITLE
fix(dex): ensure gomplate is included even when extra_packages is specified

### DIFF
--- a/images/dex/config/main.tf
+++ b/images/dex/config/main.tf
@@ -10,14 +10,16 @@ variable "extra_packages" {
   // or update this default to [] if this isn't a version stream image.
   default = [
     "dex",
-    // Other packages your image needs
-    "gomplate",
   ]
+}
+
+locals {
+  required_packages = ["gomplate"] // gomplate is required by dex
 }
 
 data "apko_config" "this" {
   config_contents = file("${path.module}/template.apko.yaml")
-  extra_packages  = var.extra_packages
+  extra_packages  = concat(var.extra_packages, local.required_packages)
 }
 
 output "config" {


### PR DESCRIPTION
Ensure that the `gomplate` package is always included in the image even when a value is specified for the `extra_packages` variable.