### PR TITLE
Fix up presubmit-readme.yaml

### DIFF
--- a/.github/workflows/presubmit-readme.yaml
+++ b/.github/workflows/presubmit-readme.yaml
@@ -16,7 +16,6 @@ jobs:
           files_yaml: |
             automated:
               - ./images/**
-              - ./monopod/**
               - ./tflib/**
               - ./.terraform.lock.hcl
               - ./Makefile
@@ -25,7 +24,7 @@ jobs:
               - ./go.mod
               - ./go.sum
 
-      - if: steps.changed.outputs.automated_any_changed == 'true'
+      - if: steps.changed.outputs.automated_any_modified == 'true'
         run: |
           echo "You have made changes to files that are managed by automation."
           exit 1


### PR DESCRIPTION
According to https://github.com/tj-actions/changed-files?tab=readme-ov-file#outputs-

any_modified	string	Returns true when any of
the filenames provided using the
files* or files_ignore* inputs have been modified. This defaults to true when
no patterns are specified. i.e.
includes a combination of all added, copied, modified, renamed, and deleted files (ACMRD).

The check should have failed in #2818 but it didnt, that is bad