### PR TITLE
Fixing PHP images with missing configuration

### DIFF
--- a/images/php/fpm.tf
+++ b/images/php/fpm.tf
@@ -1,35 +1,57 @@
-module "fpm-config" { source = "./config/fpm" }
+module "fpm-config" {
+  for_each = toset(local.versions)
+  source   = "./config/fpm"
 
-module "fpm" {
-  source = "../../tflib/publisher"
+  extra_packages = [
+    "php-${each.key}-curl",
+    "php-${each.key}-openssl",
+    "php-${each.key}-iconv",
+    "php-${each.key}-mbstring",
+    "php-${each.key}-mysqlnd",
+    "php-${each.key}-pdo",
+    "php-${each.key}-pdo_sqlite",
+    "php-${each.key}-pdo_mysql",
+    "php-${each.key}-sodium",
+    "php-${each.key}-phar",
+    "php-${each.key}",
+    "php-${each.key}-fpm",
+  ]
+}
 
+module "versioned-fpm" {
+  for_each           = toset(local.versions)
+  source             = "../../tflib/publisher"
   name               = basename(path.module)
   target_repository  = var.target_repository
-  config             = module.fpm-config.config
+  config             = module.fpm-config[each.key].config
   extra_dev_packages = ["composer"]
+  main_package       = "php-${each.key}"
 }
 
 module "test-fpm" {
+  for_each  = toset(local.versions)
   source    = "./tests"
-  digest    = module.fpm.image_ref
+  digest    = module.versioned-fpm[each.key].image_ref
   check-fpm = true
 }
 
 module "test-fpm-dev" {
+  for_each  = toset(local.versions)
   source    = "./tests"
+  digest    = module.versioned-fpm[each.key].dev_ref
+  check-dev = true
   check-fpm = true
-  check-dev = true # Check for PIP in dev variants.
-  digest    = module.fpm.dev_ref
 }
 
-resource "oci_tag" "latest-fpm" {
-  depends_on = [module.test-fpm]
-  digest_ref = module.fpm.image_ref
-  tag        = "latest-fpm"
-}
-
-resource "oci_tag" "latest-fpm-dev" {
-  depends_on = [module.test-fpm-dev]
-  digest_ref = module.fpm.dev_ref
-  tag        = "latest-fpm-dev"
+module "fpm-tagger" {
+  source     = "../../tflib/tagger"
+  depends_on = [module.test-fpm, module.test-fpm-dev]
+  tags = merge(concat([
+    for v in local.versions : [
+      { for t in module.versioned-fpm[v].tag_list : "${t}-fpm" => module.versioned-fpm[v].image_ref },
+      { for t in module.versioned-fpm[v].tag_list : "${t}-fpm-dev" => module.versioned-fpm[v].dev_ref },
+      { latest-fpm = module.versioned-fpm[v].image_ref },
+      { latest-fpm-dev = module.versioned-fpm[v].dev_ref },
+    ]
+  ]...)...)
 }

--- a/images/php/generated.tf
+++ b/images/php/generated.tf
@@ -3,18 +3,18 @@
 output "summary" {
   value = merge(
     {
-      basename(path.module) = {
-        "ref"    = module.fpm.image_ref
-        "config" = module.fpm.config
-        "tags"   = ["latest-fpm"]
-      }
+      for k, v in module.versioned : k => {
+      "ref"    = v.image_ref
+      "config" = v.config
+      "tags"   = v.tag_list
+    }
     },
     {
-      basename(path.module) = {
-        "ref"    = module.latest.image_ref
-        "config" = module.latest.config
-        "tags"   = ["latest"]
-      }
-  })
+      for k, v in module.versioned-fpm : k => {
+      "ref"    = v.image_ref
+      "config" = v.config
+      "tags"   = v.tag_list
+    }
+    })
 }
 


### PR DESCRIPTION
PHP images are currently broken due to an [autocommit](https://github.com/chainguard-images/images/commit/98390556a62d667fccf30b3d3b1b9dae02a75a9c) syncing configs from private, where the `main.tf` was not updated accordingly which resulted in images without required packages.

This PR mirrors what is set up in images-private.

Slack thread: https://chainguard-dev.slack.com/archives/C0627BW5GLF/p1718902653639689