### PR TITLE
Update Metadata for Image Registry AI Category

### DIFF
--- a/images/gpu-feature-discovery/metadata.yaml
+++ b/images/gpu-feature-discovery/metadata.yaml
@@ -10,3 +10,4 @@ upstream_url: https://github.com/NVIDIA/gpu-feature-discovery
 keywords: 
   - application
   - tools
+  - ai

--- a/images/influxdb/metadata.yaml
+++ b/images/influxdb/metadata.yaml
@@ -10,3 +10,4 @@ upstream_url: https://github.com/influxdata/influxdb
 keywords:
   - application
   - databases
+  - ai

--- a/images/kibana/metadata.yaml
+++ b/images/kibana/metadata.yaml
@@ -11,3 +11,4 @@ keywords:
   - application
   - observability
   - metrics
+  - ai

--- a/images/meilisearch/metadata.yaml
+++ b/images/meilisearch/metadata.yaml
@@ -10,3 +10,4 @@ upstream_url: https://www.meilisearch.com/
 keywords:
   - analytics
   - application
+  - ai

--- a/images/mongodb/metadata.yaml
+++ b/images/mongodb/metadata.yaml
@@ -10,3 +10,4 @@ upstream_url: https://github.com/mongodb/mongo
 keywords:
   - application
   - database
+  - ai

--- a/images/opensearch/metadata.yaml
+++ b/images/opensearch/metadata.yaml
@@ -10,3 +10,4 @@ upstream_url: https://opensearch.org/
 keywords:
   - analytics
   - application
+  - ai

--- a/images/postgres/metadata.yaml
+++ b/images/postgres/metadata.yaml
@@ -10,3 +10,4 @@ upstream_url: https://www.postgresql.org/
 keywords:
   - application
   - databases
+  - ai

--- a/images/rstudio/metadata.yaml
+++ b/images/rstudio/metadata.yaml
@@ -10,3 +10,4 @@ upstream_url: https://github.com/rstudio/rstudio
 keywords:
   - application
   - ide
+  - ai

--- a/images/solr/metadata.yaml
+++ b/images/solr/metadata.yaml
@@ -9,3 +9,4 @@ readme_file: README.md
 upstream_url: https://github.com/apache/solr
 keywords:
   - application
+  - ai


### PR DESCRIPTION
These changes update the keywords in the metadata files for some images so they show up in the right category at images.chainguard.dev. 