### PR TITLE
DNM (until 2024-08-12): LTS Turn Down

### DIFF
--- a/withdrawn-repos.txt
+++ b/withdrawn-repos.txt
@@ -25,3 +25,8 @@ jitsucom-bulker-syncctl
 
 # removed in https://github.com/chainguard-images/images/pull/2597
 harbor-db
+
+# LTS Turn Down - August 12, 2024
+jdk-lts
+jre-lts
+node-lts


### PR DESCRIPTION
See https://www.chainguard.dev/unchained/updates-to-lts-images-in-chainguard-images-developer-tier