### PR TITLE
withdraw pytorch-cuda12

### DIFF
--- a/withdrawn-repos.txt
+++ b/withdrawn-repos.txt
@@ -27,3 +27,6 @@ harbor-db
 jdk-lts
 jre-lts
 node-lts
+
+# pytorch-cuda12 removal - superseded by pytorch
+pytorch-cuda12


### PR DESCRIPTION
withdraw `pytorch-cuda12` image, as it is superseded by `pytorch`