### PR TITLE
Defines id and run-as variables for postgres-image

### DIFF
--- a/images/postgres/main.tf
+++ b/images/postgres/main.tf
@@ -20,6 +20,9 @@ module "latest-config" {
     "libpq",
     "pgaudit",
   ]
+  run-as = 0
+  id     = 70
+
 }
 
 module "latest" {
@@ -28,6 +31,7 @@ module "latest" {
   target_repository = var.target_repository
   config            = module.latest-config.config
   build-dev         = true
+  main_package      = "postgresql"
 }
 
 module "test-latest" {


### PR DESCRIPTION
Defines variables id and run-as used in `config/main.tf` and builds default postgres image with the latest tag.
