### PR TITLE
Add wget to kubeflow-pipelines visualization server

### DIFF
--- a/images/kubeflow-pipelines-visualization-server/config/main.tf
+++ b/images/kubeflow-pipelines-visualization-server/config/main.tf
@@ -9,7 +9,10 @@ terraform {
 }
 
 variable "extra_packages" {
-  default     = ["kubeflow-pipelines-visualization-server"]
+  default     = [
+    "kubeflow-pipelines-visualization-server",
+    "wget",
+  ]
   description = "The additional packages to install"
 }
 


### PR DESCRIPTION
Add wget to kubeflow-pipelines visualization server

- wget is needed for liveness and readiness probes.

Closes #2920

