### PR TITLE
use more shards

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ on:
 concurrency: release
 
 env:
-  TOTAL_SHARDS: 2
+  TOTAL_SHARDS: 256
   TF_VAR_target_repository: cgr.dev/chainguard
 
 permissions:


### PR DESCRIPTION
https://github.com/chainguard-images/images/pull/2937 dropped us to 2 shards, but that means when one of them fails to plan (like one does now) it takes down ~half of our images.

Instead, let's just give each image its own shard.