### PR TITLE
use smaller runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       matrix: "${{steps.shard.outputs.matrix}}"
 
   build:
-    runs-on: ubuntu-latest-32-cores
+    runs-on: ubuntu-latest
     needs: shard
     strategy:
       fail-fast: false


### PR DESCRIPTION
#2938 except without 32c runners per.

this should put us at 4c per shard: https://github.com/joshrwolf/images/pull/new/smaller-runners