### PR TITLE
Adding workdir to apko image

### DIFF
--- a/images/apko/config/main.tf
+++ b/images/apko/config/main.tf
@@ -21,7 +21,7 @@ output "config" {
     entrypoint = {
       command = "/usr/bin/apko"
     }
-    cmd = "--help"
+    cmd = "--help",
     "work-dir": "/work"
  })
 }

--- a/images/apko/config/main.tf
+++ b/images/apko/config/main.tf
@@ -22,5 +22,6 @@ output "config" {
       command = "/usr/bin/apko"
     }
     cmd = "--help"
-  })
+    "work-dir": "/work"
+ })
 }


### PR DESCRIPTION
### Image Size
unchanged.


The work directory is missing from the image.

Documentation currently states:

```
docker run -v "$PWD":/work cgr.dev/chainguard/apko build examples/alpine-base.yaml apko-alpine:edge apko-alpine.tar
```

In order for this to successfully produce a tar to your local system you have to modify the line to:

```
docker run -v "$PWD":/work cgr.dev/chainguard/apko build /work/examples/alpine-base.yaml apko-alpine:edge /work/apko-alpine.tar
```

This then successfully builds, it looks like when this image was in chainguard-dev/images it declared a work-dir:

```
paths:
  - path: /work
    type: directory
    permissions: 0o777

work-dir: /work

entrypoint:
  command: /usr/bin/apko
cmd: --help
```

https://github.com/chainguard-dev/images/blob/main/images/apko/configs/latest.apko.yaml

This appears to have been lost during a transition or something.