### PR TITLE
Tested locally produces image with work-dir as /work

### DIFF
--- a/images/apko/config/main.tf
+++ b/images/apko/config/main.tf
@@ -22,5 +22,6 @@ output "config" {
       command = "/usr/bin/apko"
     }
     cmd = "--help"
+    work-dir = "/work"
   })
 }


### PR DESCRIPTION
There is currently no WorkingDir on public image. This causes issues with running APKO to create images without providing full paths.

```docker pull cgr.dev/chainguard/apko```


```docker inspect cgr.dev/chainguard/apko ```

```
            "Image": "",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": [
                "/usr/bin/apko"
            ],
```



