### PR TITLE
Ignore tj-actions/changed-files updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "tj-actions/changed-files"
     open-pull-requests-limit: 10
     groups:
       actions:


### PR DESCRIPTION
This Action has been compromised and we should avoid any updates.