### PR TITLE
release: bump shards to 60 so each module lives alone

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ on:
 concurrency: release
 
 env:
-  TOTAL_SHARDS: 40
+  TOTAL_SHARDS: 60
   TF_VAR_target_repository: cgr.dev/chainguard
 
 permissions:


### PR DESCRIPTION
Previously, on X-Men:
https://github.com/chainguard-images/images/pull/2938
https://github.com/chainguard-images/images/pull/2940