### PR TITLE
reduce shards to 50

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ on:
 concurrency: release
 
 env:
-  TOTAL_SHARDS: 60
+  TOTAL_SHARDS: 50
   TF_VAR_target_repository: cgr.dev/chainguard
 
 permissions:


### PR DESCRIPTION
test a theory in the shard "logic" causing everything to go into 1 shard.

I think n_shards needs to be n_imagemodules otherwise everything is packed into 1 shard