### PR TITLE
ci(images): add parallel pipeline for image migration

### DIFF
--- a/.github/workflows/lock-release.yaml
+++ b/.github/workflows/lock-release.yaml
@@ -1,0 +1,236 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'images/**/locked_config.json'
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Specific image name to build"
+        type: string
+        required: false
+        default: ""
+
+concurrency:
+  group: ${{ inputs.only || 'lock-release' }}
+  cancel-in-progress: false
+
+env:
+  TF_VAR_target_repository: chainreg.biz/chainguard-cue-public
+
+permissions: {}
+
+jobs:
+  shard:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: shard
+        name: Shard
+        shell: bash
+        run: |
+          images=($(find ./images -maxdepth 2 -name "locked_config.json" | awk -F'/' '{print $3}' | sort -u | shuf))
+
+          total=${#images[@]}
+
+          declare -a bins
+          for ((i = 0; i < total; i++)); do
+            bins[$i]="${images[$i]}"
+          done
+
+          matrix=$(printf "%s\n" "${bins[@]}" | jq -cRnjr '[inputs] | [ range(0; length) as $i | { "index": $i | tostring, "image": .[$i] } ]')
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+
+          # Overwrite the output above if workflow_dispatch'd with `only`
+          if [ -n "${{ inputs.only }}" ]; then
+            shard='[{"index": 0, "image": "${{ inputs.only }}"}]'
+            echo "matrix=${shard}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Shard Results
+        run: echo '${{ steps.shard.outputs.matrix }}'
+
+    outputs:
+      matrix: "${{steps.shard.outputs.matrix}}"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: shard
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(needs.shard.outputs.matrix) }}
+
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: "1.8.*"
+          terraform_wrapper: false
+
+      - uses: chainguard-dev/setup-chainctl@2cddd35a2f120d9973e58094dc6878c93cf58c28 # v0.5.1
+        with:
+          identity: e4670617ad8ebe9b7268c32598f96921a57d19ee/dfda71087f27ea61
+
+      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Disk cleanup
+        if: ${{ contains(matrix.shard.image, 'pytorch') }}
+        run: |
+          ## All disk reclaim actions look sus and are not actively
+          ## maintained, doing it by hand as per https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg#6-how-to-automate-cleanup-in-your-ci
+
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL and other toolcaches
+          sudo rm -rf /opt/hostedtoolcache
+
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
+      - name: Terraform apply
+        timeout-minutes: 60
+        env:
+          TF_VAR_image_name: ${{ matrix.shard.image }}
+        run: |
+          set -exo pipefail
+          env | grep '^TF_VAR_'
+
+          # TODO(uhryniuk): Enable after locked image validation is complete.
+          # make enable-active-tag-update
+
+          cd lock-release
+          terraform init -upgrade
+          terraform plan -out lock-release.tfplan
+          terraform apply -auto-approve --parallelism=$(nproc) -json lock-release.tfplan | tee /tmp/mega-module.tf.json | jq -r '.["@message"]'
+
+      - name: Collect TF diagnostics
+        if: ${{ always() }}
+        id: tf-diag
+        uses: chainguard-dev/actions/terraform-diag@f45211d3e8f9d2676c6b8cdd6a765435e06c819d # v1.6.13
+        with:
+          json-file: /tmp/mega-module.tf.json
+
+      - name: Upload terraform logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: "mega-module-${{ matrix.shard.index }}.tf.json"
+          path: /tmp/mega-module.tf.json
+
+      - uses: step-security/action-slack-notify@e04c77a65bae8b6c0373478a1cb8fd7e012637e6 # v2.3.5
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        env:
+          SLACK_ICON: http://github.com/chainguard-dev.png?size=48
+          SLACK_USERNAME: guardian
+          SLACK_WEBHOOK: ${{ secrets.DISTROLESS_SLACK_WEBHOOK }}
+          SLACK_MSG_AUTHOR: chainguardian
+          SLACK_CHANNEL: chainguard-images-alerts
+          SLACK_COLOR: "#8E1600"
+          MSG_MINIMAL: "true"
+          SLACK_TITLE: "[images] lock-release failed (shard ${{ matrix.shard.index }})"
+          SLACK_MESSAGE: |
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ${{ steps.tf-diag.outputs.errors }}
+
+  summary:
+    name: "Lock Release Summary"
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: build
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: "Download shard logs"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/shard-logs
+          pattern: mega-module-*
+
+      - run: |
+          find '/tmp/shard-logs' -name 'mega-module.tf.json' | while read file; do
+            shard_index=$(echo "$file" | sed -E 's/.*mega-module-([0-9]+)\.tf\.json.*/\1/')
+            echo $shard_index
+            jq -cr --arg shard_index "$shard_index" '. + {"shard_index":$shard_index}' $file >> logs.tf.json
+          done
+
+      - run: |
+          jq -r 'select(.["@level"]=="error")' logs.tf.json > errors.tf.json
+
+      - run: |
+          echo "| Status | Shard | Image | Summary | Address |" >> $GITHUB_STEP_SUMMARY
+          echo "| :-:    | ----- | ----- | ------- | ------- |" >> $GITHUB_STEP_SUMMARY
+
+          export rows="$(jq -r '"| ❌ | " + .shard_index + " | " + (.diagnostic.address | split(".")[1]) + " | ```" + .diagnostic.summary + "``` | ```" + .diagnostic.address + "``` |"' errors.tf.json)"
+          echo "${rows}"
+
+          cat >> $GITHUB_STEP_SUMMARY <<EOR
+          ${rows}
+          EOR
+
+      - name: Error Details
+        run: |
+          jq -r '"::group:: shard: " + .shard_index + " | " + (.diagnostic.address | split(".")[1]) + "\nresource: " + .diagnostic.address + "\n\nsummary: " + .diagnostic.summary + "\n\ndetails:\n\n" + .diagnostic.detail + "\n::endgroup::"' errors.tf.json || true


### PR DESCRIPTION
### Notes for reviewer

We're moving towards using locked image configs to have reproducible builds for our public images.

Considering this, we are setting up a second release workflow which will build and publish the locked configs to a temporary register. Once the quality has been assured to the newly locked images, we will cutover the workflow and continue publishing to our public repository (`cgr.dev/chainguard`).

To be clear, we will have 2 parallel build pipelines for a temporary time until we can assert image quality and parity to the legacy TF-based counterparts.