### PR TITLE
feat(lock-release): add pusher identity to lock release workflow

### DIFF
--- a/.github/workflows/lock-release.yaml
+++ b/.github/workflows/lock-release.yaml
@@ -98,6 +98,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: chainguard-dev/setup-chainctl@2cddd35a2f120d9973e58094dc6878c93cf58c28 # v0.5.1
+        with:
+          identity: 4fdb48f3679017671e7c99ca09b1dd98b43758c9/c2f17bf4facc9994
+
       - name: Disk cleanup
         if: ${{ contains(matrix.shard.image, 'pytorch') }}
         run: |


### PR DESCRIPTION
Add new pusher identity to push to `cgr.dev/scratch-images/`