### PR TITLE
docs(images): updating documentation files

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -1,248 +1,158 @@
 # Image Guidelines and Best Practices
 
-This document describes the standards expected for Chainguard images in order to provide users with
-a consistent and smooth experience. New images must meet these standards or document why they deviate.
-
-Many of these guidelines are marked as requirements in the new image PR checklist, and may be enforced by tests that block merging a PR.
-Code reviewers should also check for this behavior.
-
-## Sending a Pull Request
-
-We have a number of automated checks that must pass before a pull request is merged.
-
-Commits must be signed with either [Gitsign](https://github.com/sigstore/gitsign) or with regular [gpg signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). For new images, you'll also need to run the included `monopod` tool to "fix" the image README file. This will lint the file and add a default header with relevant links.
-
-To install monopod:
-
-```
-go install ./monopod
-```
-
-- Running monopod for README checks - this must be executed from the root of the project:
-
-```
-monopod readme
-```
+This document describes the design standards every Chainguard Image follows so that users get a consistent and smooth experience across the catalog. When you inspect an image's `locked_config.json` or its published behaviour, these are the conventions it has been built to.
 
 ## Version Availability
 
-Our policy is to provide the latest available version of the software, tagged `:latest`, usually with a developer variant tagged `:latest-dev`.
+The catalog provides the latest available version of the software, tagged `:latest`, usually with a developer variant tagged `:latest-dev`.
 
-Developer variants include `busybox` and `apk-tools` to allow users to install other packages at runtime. This is useful for debugging and development, but should not be used in production.
+Developer variants include `busybox` and `apk-tools` so that additional packages can be installed at runtime. They are useful for debugging and development and are not intended for production.
 
-Older versions and other variants are available through the [commercial suite of Chainguard Images](https://www.chainguard.dev/chainguard-images).
-
-In some cases, older images may use the `tflib/tagger` module to provide version-tagged images. These are for legacy purposes only and should not be used for new images.
+Older versions and additional variants are available through the [commercial suite of Chainguard Images](https://www.chainguard.dev/chainguard-images).
 
 ### Architectures
 
-Images are built for `aarch64` and `x86_64` by default.
+Images are built for `aarch64` and `x86_64` by default. You can see the concrete architectures baked into any image by inspecting the `archs` field inside `locked_config.json`.
 
 ## Users
 
-The user account a Chainguard Image runs as is configured in the `apko.yaml` file, or in the equivalent HCL file in `config/main.tf`.
+The user account a Chainguard Image runs as is defined in the `accounts` block of its apko configuration (visible inside `locked_config.json`).
 
-Where there is an existing standard `username` for an image used by other distributions, favor using this. Having consistency with this `username` will reduce friction when adopting Chainguard Images.
+Where there is an existing standard `username` used by other distributions for the same software, we favor that name. Consistency reduces friction when adopting Chainguard Images as a drop-in replacement.
 
-If no existing standard `username` exists consider using “`nonroot`”. Set the GID and UID to 65532 unless another UID is required for compatibility with tooling.
+If there is no existing standard `username`, we use `nonroot`. GID and UID are set to `65532` unless another UID is required for compatibility with upstream tooling.
 
-The default user account to run as is set in the `run-as` field of the `apko.yaml` file. This is the UID of the user account to run as. If the `run-as` field is not set, the default is `0` (root). Prefer to specify the UID instead of the username.
+The default user to run as is set in the `run-as` field. When `run-as` is not set, the container runs as `0` (root). We prefer specifying the UID rather than the username.
 
-This standard configuration is also available in HCL in the `tflib/accts` module.
-
-**Example 1**: (matching upstream user name)
+**Example 1** — matching an upstream user name:
 
 ```yaml
 accounts:
- groups:
-   - groupname: maven
-     gid: 65532
- users:
-   - username: maven
-     uid: 65532
+  groups:
+    - groupname: maven
+      gid: 65532
+  users:
+    - username: maven
+      uid: 65532
   run-as: 65532
 ```
 
-or
-
-```hcl
-module "accts" {
-  source = "../../../tflib/accts"
-  name = "maven"
-}
-
-output "config" {
-  value = jsonencode({
-    ...
-    accounts = module.accts.block
-    ...
-  })
-}
-```
-
-**Example 2**: (using Chainguard default user name)
+**Example 2** — using the Chainguard default user name:
 
 ```yaml
 accounts:
- groups:
-   - groupname: nonroot
-     gid: 65532
- users:
-   - username: nonroot
-     uid: 65532
- run-as: 65532
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+  run-as: 65532
 ```
 
-or
-
-```hcl
-module "accts" { source = "../../../tflib/accts" }
-
-output "config" {
-  value = jsonencode({
-    ...
-    accounts = module.accts.block
-    ...
-  })
-}
-```
-
-See [./TERRAFORM.md] for more information about Terraform-driven build configuration.
-
-In some cases it may be more user friendly to run as root. In these cases, make sure there is still a `nonroot` user in the image so it can be easily changed and add docs on how to do so (e.g. ``docker run –user nonroot …``).
+In some cases it is more user-friendly for an image to run as root. When that is the case we still ship a `nonroot` user in the image so it can easily be switched to (e.g. `docker run --user nonroot ...`), and we document how to do so.
 
 ### Switching User
 
-Another common requirement is to start a container as root and switch to a less privileged user after performing an operation requiring elevated privileges. We see this in the PostgreSQL image, which runs an entrypoint script as root on startup to create a database if it doesn’t exist. After creating the DB (which requires elevated privileges),  the script uses the `suexec` utility to switch to the `postgres` user when starting the main DB process.
+Another common pattern is to start a container as root and switch to a less-privileged user after an operation that requires elevated privileges. The PostgreSQL image does this: the entrypoint script runs as root on startup to create a database if it doesn't exist, then uses `suexec` to drop to the `postgres` user before starting the main DB process.
 
 ## CMD and ENTRYPOINT
 
-This can get confusing. Basically, in _Docker terminology_, the [CMD](https://docs.docker.com/engine/reference/builder/#cmd) is passed as an argument to [ENTRYPOINT](https://docs.docker.com/engine/reference/builder/#entrypoint) as the command to run in the container when it starts. If the ENTRYPOINT isn’t set, commands will still get interpreted with `/bin/sh -c`. For this reason, base images like alpine, debian and wolfi-base don’t set an entrypoint but commands like `docker run cgr.dev/chainguard/wolfi-base ls` still work as expected.
+In Docker terminology, [CMD](https://docs.docker.com/engine/reference/builder/#cmd) is passed as an argument to [ENTRYPOINT](https://docs.docker.com/engine/reference/builder/#entrypoint) when the container starts. If ENTRYPOINT isn't set, the CMD is interpreted with `/bin/sh -c`. That is why base images like `alpine`, `debian`, and `wolfi-base` don't set an entrypoint but `docker run cgr.dev/chainguard/wolfi-base ls` still works as expected.
 
-In the Docker Official images, all images except base images (Alpine, Debian etc) use an entrypoint script. Sometimes these do special processing such as setting up permissions on volumes, but often they are just used to interpret arguments and pass either to the image command or the system (so `–version` and `ls` both work as expected. See for example the [Node entrypoint.sh](https://github.com/nodejs/docker-node/blob/e75fa5270326ffaff8fee03153f3bf16860084d4/19/buster/docker-entrypoint.sh). For our distroless images there is an extra cost to using an entrypoint script as it requires a shell to be installed. For that reason, entrypoint scripts are normally only provided in `dev` image variants.
-
-In apko YAML, setting ENTRYPOINT and CMD looks a little different. Here's an example from the [Node image](https://github.com/chainguard-images/images/blob/main/images/node/configs/latest.apko.yaml):
+In apko, ENTRYPOINT and CMD are set like this (from the Node image):
 
 ```yaml
 entrypoint:
- command: /usr/bin/node
+  command: /usr/bin/node
 cmd: --help
 ```
 
-or
+This sets ENTRYPOINT to `/usr/bin/node` and CMD to `--help`.
 
-```hcl
-variable "config" {
-  value = jsonencode({
-    ...
-    entrypoint = {
-      command = "/usr/bin/node"
-    }
-    cmd = "--help"
-    ...
-  })
-}
-```
+For apko-built images that need an entrypoint *script*, the script must be provided by a melange package. See the [Postgres entrypoint](https://github.com/wolfi-dev/os/blob/main/postgresql/postgresql-entrypoint.sh) for an example.
 
-This sets ENTRYPOINT to `/usr/bin/node` and CMD to `–help`.
+The conventions we apply:
 
-For apko-built images that need an entrypoint script, it has to be provided in a melange package. See the [Postgres package](https://github.com/wolfi-dev/os/blob/main/postgresql/postgresql-entrypoint.sh) for an example.
-
-Set the ENTRYPOINT and CMD as follows:
-
-* ENTRYPOINT:
-    * Applications, servers and tooling should call the main application without arguments e.g. `redis-server`. As there is no shell you may need to use the full path.
-    * Base images (static, wolfi-base etc) leave empty.
-    * Dev variants should use an entrypoint script to make the image behave as described above.
-* CMD should be set appropriately for the type of image:
-    * Long running server software like DBs or load balancers should start the main process as normal (may be empty if ENTRYPOINT is enough)
-    * Utilities and tools like grep or curl should show the standard help message (or version information if not available) e.g.` –help` or `–version`.
-    * Base images can start a shell if there is one `[/bin/sh]`
-* Try to have a close experience to any popular equivalent images
+* ENTRYPOINT
+  * Applications, servers, and tooling call the main binary without arguments (e.g. `redis-server`). Because there is no shell you may need to use the full path.
+  * Base images (`static`, `wolfi-base`, etc.) leave ENTRYPOINT empty.
+  * Dev variants use an entrypoint script so the image behaves as described above.
+* CMD
+  * Long-running servers (databases, load balancers) start the main process as normal — may be empty if ENTRYPOINT is enough.
+  * Utilities and tools (`grep`, `curl`) show a help or version message, e.g. `--help` or `--version`.
+  * Base images can start a shell if there is one (`[/bin/sh]`).
+* Aim for a close experience to any popular equivalent image.
 
 ## Process Managers / Supervisors / Init System
 
-In most cases this shouldn’t be necessary, but occasionally you may find an image needs to use a process manager or init system, perhaps for handling multiple processes, logging or signals. Docker bundles [tini ](https://github.com/krallin/tini)for this reason, and we bundle [s6](https://skarnet.org/software/s6/s6-supervise.html). See the [apko docs](https://github.com/chainguard-dev/apko/blob/main/docs/apko_file.md#entrypoint-top-level-element) for usage.
+Most images shouldn't need one, but occasionally an image needs a process manager or init system — for handling multiple processes, logging, or signals. Docker bundles [tini](https://github.com/krallin/tini) for this reason; our images bundle [s6](https://skarnet.org/software/s6/s6-supervise.html). See the [apko docs](https://github.com/chainguard-dev/apko/blob/main/docs/apko_file.md#entrypoint-top-level-element) for usage.
 
 ## Environment Variables
 
-Consider adding environment variables to expose configuration options. In cloud native environments it is typically much easier to set an environment variable (and have it vary per container) than it is to mount a configuration file or even pass arguments to an executable.
+Environment variables are a good way to expose configuration. In cloud-native environments it is typically much easier to set an environment variable (and vary it per container) than to mount a configuration file or pass arguments.
 
-This should be extended to include setting passwords, at least where the use of the password is enforced. Whilst having a password exposed in an environment variable may have security implications, it is common and a supported pattern in Kubernetes (it's worth linking to the [docs on k8s secrets](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/) in user documentation).
+This extends to passwords, at least where the use of the password is enforced. Having a password in an environment variable has security implications, but it is a common and supported pattern in Kubernetes (it is worth linking users to the [Kubernetes Secrets documentation](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/)).
 
-The [postgres image documentation](https://github.com/chainguard-images/images/tree/main/images/postgres) provides an example of how to do this:
+The [postgres image documentation](https://github.com/chainguard-images/images/tree/main/images/postgres) provides an example:
 
-    The only mandatory environment variable needed by the PostgreSQL image is POSTGRES_PASSWORD
-    To test and not persist PostgreSQL data run...
+> The only mandatory environment variable needed by the PostgreSQL image is `POSTGRES_PASSWORD`. To test and not persist PostgreSQL data run…
 
 ```sh
 docker run --rm -e POSTGRES_PASSWORD=password -ti --name postgres-test cgr.dev/chainguard/postgres:latest
 ```
 
-The postgres image also sets the PGDATA environment variable to the default location of the postgres database, which looks like this in the [apko YAML](https://github.com/chainguard-images/images/blob/main/images/postgres/configs/latest.apko.yaml):
-
+The postgres image also sets `PGDATA` to the default location of the postgres database:
 
 ```yaml
 environment:
- PGDATA: /var/lib/postgresql/data
-```
-
-or
-
-```hcl
-environment = {
-  "PGDATA" = "/var/lib/postgresql/data"
-}
+  PGDATA: /var/lib/postgresql/data
 ```
 
 > **Note**
-> If a config has no environment variables set, `apko` sets defaults for `PATH` and `SSL_CERT_FILE`.
+> If an apko config has no environment variables set, `apko` sets defaults for `PATH` and `SSL_CERT_FILE`.
 
 ## Signals
 
-Please test that the image handles signals properly. In particular check that SIGTERM is handled and the container quits immediately (if it’s not handled Docker will wait 10s before reaping). You can test this as follows:
+Images must handle signals properly. In particular, SIGTERM must be handled so that the container exits immediately (if it isn't handled, Docker waits 10s before reaping). You can verify this:
 
 ```
 ❯ docker run -d --name test cgr.dev/chainguard/nginx
-```
-
-
-```
 9987b2f37044b72460956f1821bbba0499e0e724d2987f870099976601cf701b
 ❯ docker kill test
 test
 ```
 
-The kill command should return immediately (not in 10s).
+The `kill` command should return immediately, not after 10 seconds.
 
 ## Documentation
 
-Follow the example of other images such as [static](https://github.com/chainguard-images/images/tree/main/images/static#usage). Try to keep a new user in mind - what do they need to know? What questions are they likely to have?
+Every image has its own README under `images/<name>/README.md`. Good examples follow the style of the [static image](https://github.com/chainguard-images/images/tree/main/images/static#usage): keep a new user in mind, state what they need to know, anticipate the questions they'll have.
 
-Remember users will likely have used other popular images. If our image works noticeably differently, document the differences.
+Users are likely to have used other popular images for the same software. If our image works noticeably differently, document the differences.
 
 ### Usage Example
 
-Add examples of using the image. Ideally there should be links to code examples. Check the [static image as good example](https://github.com/chainguard-images/images/tree/main/images/static#usage) for a base image. And note the [code examples also available](https://github.com/chainguard-images/images/tree/main/images/static/examples).
+Add usage examples. Ideally there are links to code examples as well. See the [static image](https://github.com/chainguard-images/images/tree/main/images/static#usage) for a good base-image example, together with the [code examples](https://github.com/chainguard-images/images/tree/main/images/static/examples) it ships.
 
 ## Logs
 
-Error logs should be streamed to `stderr`. Normal logging should be streamed to `stdout`. DO NOT write logs to file as they will eat up disk over time; better to stream and let the user store or ignore it.
+Error logs stream to `stderr`. Normal logging streams to `stdout`. Do not write logs to a file inside the image — they will eat disk over time; stream them and let the user store or discard them.
 
 ## Tests
 
-Each image should have end-to-end tests verifying the basic functionality is working. Tests are configured by a `tests` module which can invoke an `oci_exec_test` or `helm_release` to install a Helm chart.
+Each image has end-to-end tests verifying the basic functionality works. Tests live under `images/<name>/tests/`.
 
-Base images should be tested by running something on top of them. The [static image tests](https://github.com/chainguard-images/images/tree/main/images/static/tests) includes the following:
+Base images are tested by running something on top of them. The [static image tests](https://github.com/chainguard-images/images/tree/main/images/static/tests) include:
 
 ```
 for lang in c golang rust; do
- docker build --build-arg BASE=${IMAGE_NAME} --tag smoke-test-${lang} --file examples/Dockerfile.${lang} examples
- docker run smoke-test-${lang}
+  docker build --build-arg BASE=${IMAGE_NAME} --tag smoke-test-${lang} --file examples/Dockerfile.${lang} examples
+  docker run smoke-test-${lang}
 done
 ```
 
-Which calls out to Dockerfiles such as [this one for Go](https://github.com/chainguard-images/images/blob/main/images/static/examples/Dockerfile.golang):
+Which calls out to Dockerfiles like [this one for Go](https://github.com/chainguard-images/images/blob/main/images/static/examples/Dockerfile.golang):
 
 ```
 ARG BASE=cgr.dev/chainguard/static
@@ -257,15 +167,15 @@ COPY --from=build /hello /hello
 CMD ["/hello"]
 ```
 
-Other tests that should be considered:
+Additional tests worth considering:
 
-* Tests for any configuration options provided e.g. setting a password
-* Mounting data or configuration e.g. running nginx with a HTML directory
-* Connecting via another container
+* Any configuration options the image exposes (e.g. setting a password).
+* Mounting data or configuration (e.g. running nginx against an HTML directory).
+* Connecting from another container.
 
 ## Vulnerability scanning
 
-Use Grype to find vulnerabilities in Chainguard images. Note that we rely on a tweaked configuration when monitoring vulnerabilities. Add the following content to the file `~/.grype.yaml` to capture more accurate findings:
+Use [Grype](https://github.com/anchore/grype) to find vulnerabilities in Chainguard Images. We rely on a tweaked configuration when monitoring vulnerabilities — add this to `~/.grype.yaml` for more accurate findings:
 
 ```
 external-sources:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,106 @@
+# Building Chainguard Images locally
+
+Every image in this repository ships a `locked_config.json` — a lock file that contains the fully resolved, pinned build inputs for each supported architecture. It embeds per-architecture [`apko`](https://github.com/chainguard-dev/apko) configurations (packages at exact versions, accounts, entrypoint, annotations, and so on) that our release pipeline feeds directly to the `apko` Terraform provider to produce the images at `cgr.dev/chainguard`.
+
+To build locally with the `apko` CLI, you first need to use `jq` to extract the raw apko config from the lock file — the CLI doesn't consume `locked_config.json` directly. The steps below walk through that.
+
+> `apko` and Chainguard's public package repository (`apk.cgr.dev/chainguard`) are enough to build any image in this repo — no Chainguard account or internal tooling required.
+
+## Prerequisites
+
+- [`apko`](https://github.com/chainguard-dev/apko?tab=readme-ov-file#installation)
+- [`jq`](https://jqlang.org/)
+- Docker (or any tool that can load an OCI tarball) — optional, only needed to run the image afterwards
+
+## What's inside `locked_config.json`
+
+The top-level shape is:
+
+```json
+{
+  "imageLocks": {
+    "<variant-name>": {
+      "configs": {
+        "amd64":  "{\"config\": { ...apko config for amd64... }}",
+        "arm64":  "{\"config\": { ...apko config for arm64... }}",
+        "index":  "{\"config\": { ...merged config for the index... }}"
+      },
+      "devConfigs": { ... },
+      "repo":  "public/<name>",
+      "tags":  ["latest", ...]
+    }
+  }
+}
+```
+
+Each entry under `imageLocks` is one publishable variant. The `configs` map holds a stringified JSON apko configuration per architecture — package list at pinned versions, accounts, entrypoint, annotations, paths, and so on. The release pipeline passes these directly to the `apko` Terraform provider; to use them with the `apko` CLI you extract the inner `.config` object with `jq` (see below).
+
+## Build an image in three commands
+
+The example below builds the `static` image. Swap `static` for any directory name under [`images/`](./images) to build a different image.
+
+```sh
+# 1. Extract the apko config for the desired variant.
+jq -r '.imageLocks["static-public"].configs.index | fromjson | .config' \
+  images/static/locked_config.json > static.apko.json
+
+# 2. Build with apko. --arch host limits to your current architecture;
+#    drop it to build the full multi-arch index.
+apko build static.apko.json cgr.dev/chainguard/static:local static.tar --arch host
+
+# 3. (Optional) Load into Docker and run.
+docker load < static.tar
+docker run --rm cgr.dev/chainguard/static:local
+```
+
+The variant key (`static-public` above) matches the key inside `imageLocks`. Most images have a single variant; a few publish multiple (for example a base and a `-dev` counterpart). To list the variants available for an image:
+
+```sh
+jq -r '.imageLocks | keys[]' images/<name>/locked_config.json
+```
+
+## Building for a specific architecture
+
+`configs` exposes per-architecture entries (`amd64`, `arm64`) and a combined `index`. Pick whichever matches what you want to produce:
+
+```sh
+# Single arch, matching your machine.
+jq -r '.imageLocks["static-public"].configs.amd64 | fromjson | .config' \
+  images/static/locked_config.json > static.amd64.apko.json
+apko build static.amd64.apko.json cgr.dev/chainguard/static:local static.tar
+
+# Multi-arch index.
+jq -r '.imageLocks["static-public"].configs.index | fromjson | .config' \
+  images/static/locked_config.json > static.apko.json
+apko build static.apko.json cgr.dev/chainguard/static:local static.tar
+```
+
+## Publishing to your own registry
+
+`apko publish` pushes directly to a registry instead of writing a tarball:
+
+```sh
+apko publish static.apko.json ghcr.io/<you>/static:local
+```
+
+You'll need to be authenticated to the destination registry (`docker login`, `gh auth`, etc.).
+
+### A note on digests
+
+A locally built image will not produce the same digest as the corresponding `cgr.dev/chainguard` image, even from the same `locked_config.json`. `apko` stamps the current timestamp into the image config at build time, which changes the image digest. The package layers (filesystem contents) will be identical; only the config blob — and therefore the overall manifest digest — will differ.
+
+You can use [`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to compare the layer digests between a locally published image and the one in the registry:
+
+```sh
+diff \
+  <(crane manifest cgr.dev/chainguard/static:latest | jq -r '[.layers[].digest] | sort[]') \
+  <(crane manifest ghcr.io/<you>/static:local       | jq -r '[.layers[].digest] | sort[]')
+```
+
+An empty diff means the filesystem layers are identical. The SBOM and cosign attestations attached by our release pipeline are not reproduced by a local build.
+
+## Further reading
+
+- [`apko` documentation](https://github.com/chainguard-dev/apko/tree/main/docs) — full reference for the configuration format.
+- [`apko` file format](https://github.com/chainguard-dev/apko/blob/main/docs/apko_file.md) — description of every field you'll see in `locked_config.json`.
+- [Chainguard public APK repository](https://apk.cgr.dev/chainguard) — where the pinned packages come from.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,56 @@
 # Chainguard Images
 
-### Learn more about Chainguard Images
+This repository holds the public build configuration for available [Chainguard Images](https://images.chainguard.dev) — minimal, hardened OCI images published to `cgr.dev/chainguard/<image>`.
 
-https://edu.chainguard.dev/chainguard/chainguard-images/
+## Using an image
 
-### See available images
+Images are published at `cgr.dev/chainguard/<name>`. For example:
 
-https://images.chainguard.dev
+```sh
+docker pull cgr.dev/chainguard/static:latest
+docker pull cgr.dev/chainguard/nginx:latest
+```
 
-### Log in to view the full catalog
+Browse the full catalog at [images.chainguard.dev](https://images.chainguard.dev). Each image's usage notes live in its own README under [`images/<name>/README.md`](./images).
 
-https://console.chainguard.dev
+## How images are built
+
+Every image is produced with [`apko`](https://github.com/chainguard-dev/apko) from a pinned, reproducible configuration stored alongside the image:
+
+```
+images/<name>/
+├── locked_config.json   # Pinned apko config per architecture (+ tags, repo)
+├── README.md            # User-facing documentation for the image
+├── tests/               # End-to-end tests
+└── metadata.yaml        # Image metadata
+```
+
+`locked_config.json` is the source of truth for what goes into the published image. It contains a fully resolved apko configuration — exact package versions, accounts, entrypoint, environment, and annotations — for each supported architecture. Because the package versions are pinned, builds are reproducible: the same `locked_config.json` produces the same image content.
+
+Publication is driven by the [`release.yaml`](./.github/workflows/release.yaml) workflow. When a `locked_config.json` changes on `main` (or on the daily schedule), the workflow shards the affected images and invokes the Terraform module at [`main.tf`](./main.tf), which:
+
+1. Reads `images/<name>/locked_config.json`.
+2. Builds each variant with the `apko` Terraform provider.
+3. Publishes the resulting OCI images to `cgr.dev/chainguard/<name>` along with SBOMs and [cosign](https://github.com/sigstore/cosign) attestations.
+4. Applies the `tags` declared in the lock file.
+
+## Building an image locally
+
+You can reproduce a build on your own machine using `apko` and the `locked_config.json` checked into this repo. See [`BUILDING.md`](./BUILDING.md) for a step-by-step example.
+
+## Repository layout
+
+| Path | Purpose |
+| --- | --- |
+| `images/<name>/` | Per-image build config, tests, and README |
+| `policies/` | Policy definitions applied to published images |
+| `tflib/` | Shared Terraform modules used by the release driver |
+| `.github/workflows/release.yaml` | Workflow that runs the release |
+
+## More
+
+- [Image guidelines](./BEST_PRACTICES.md) — the design standards every image follows.
+- [Withdrawing images](./WITHDRAWING_IMAGES.md) — how tags and repos are retired.
+- [Security policy](./SECURITY.md) — reporting vulnerabilities.
+- [Chainguard Images docs](https://edu.chainguard.dev/chainguard/chainguard-images/) — background and concepts.
+- [Chainguard Console](https://console.chainguard.dev) — log in to view the full commercial catalog.

--- a/WITHDRAWING_IMAGES.md
+++ b/WITHDRAWING_IMAGES.md
@@ -5,7 +5,7 @@ Sometimes an image needs to be removed from the repository because it was errone
 To do so:
 
 - Add the full image refs that need to be removed to `withdrawn-images.txt`
-- Run the ["Withdraw Images"](https://github.com/chainguard-images/images/os/blob/main/.github/workflows/withdraw-images.yaml) workflow on GitHub.
+- Run the ["Withdraw Images"](https://github.com/chainguard-images/images/blob/main/.github/workflows/withdraw-images.yaml) workflow on GitHub.
 
 This ensures that these operations are only done using the Chainguard identity with permission, and not by any human user directly. This also provides an audit trail of such operations.
 
@@ -23,6 +23,6 @@ Sometimes an image repo needs to be removed entirely because it was erroneously 
 To do so:
 
 - Add the repo basename that need to be removed to `withdrawn-repos.txt`
-- Run the ["Withdraw Repos"](https://github.com/chainguard-images/images/os/blob/main/.github/workflows/withdraw-repos.yaml) workflow on GitHub.
+- Run the ["Withdraw Repos"](https://github.com/chainguard-images/images/blob/main/.github/workflows/withdraw-repos.yaml) workflow on GitHub.
 
 This ensures that these operations are only done using the Chainguard identity with permission, and not by any human user directly. This also provides an audit trail of such operations.


### PR DESCRIPTION
Refs: CON-1357

Updated documentation to the following (based on latest images changes):

1. README.md: Proper landing page. Explains what the repo is, describes the current build flow (locked_config.json → release.yaml → lmain.tf), adds a directory layout table, pull quickstart, and links to all supporting docs.
2. BUILDING.md (new): Customer-facing guide for reproducing a build locally using only public tooling (apko + jq). Covers the locked_config.json structure, a 3-command recipe to extract the config and build with apko, single-arch vs. multi-arch builds, and publishing to a personal registry.
3. BEST_PRACTICES.md: Removed stale references to the legacy build flow (HCL tflib/accts alternate examples throughout, the tflib/tagger legacy note, and the broken ./TERRAFORM.md link). All YAML/HCL dual-examples collapsed to YAML only (the format used in locked_config.json.)
4. WITHDRAWING_IMAGES.md: Fixed two broken workflow URLs that had a stray /os/ path segment.