### PR TITLE
ci: apply shellcheck fixes to workflows

### DIFF
--- a/.github/workflows/reinstate-images.yaml
+++ b/.github/workflows/reinstate-images.yaml
@@ -36,14 +36,14 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           set -x
-          for img in $(grep -v '\#' reinstated-images.txt); do
-            tag_ref="$(echo $img | cut -d@ -f1)"
-            tag="$(echo $tag_ref | cut -d: -f2)"
-            digest_ref="$(echo $img | sed 's/:[^@]*@/@/')"
+          while IFS= read -r img; do
+            tag_ref="${img%@*}"                    # e.g. cgr.dev/chainguard/foo:latest
+            tag="${tag_ref##*:}"                   # e.g. latest
+            digest_ref="${tag_ref%:*}@${img#*@}"   # e.g. cgr.dev/chainguard/foo@sha256:...
             # Note: if "crane digest" passes, do not attempt to retag it
             if [[ "$DRY_RUN" == "false" ]]; then
               crane digest "$tag_ref" || crane tag "$digest_ref" "$tag" || true
             else
-              echo "DRY RUN: crane digest "$tag_ref" || crane tag "$digest_ref" "$tag" || true"
+              echo "DRY RUN: crane digest \"$tag_ref\" || crane tag \"$digest_ref\" \"$tag\" || true"
             fi
-          done
+          done < <(grep -v '\#' reinstated-images.txt)

--- a/.github/workflows/withdraw-images.yaml
+++ b/.github/workflows/withdraw-images.yaml
@@ -28,7 +28,7 @@ jobs:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
       - uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
       - run: |
-          for img in $(grep -v '\#' withdrawn-images.txt); do
+          while IFS= read -r img; do
             if [[ "${{ github.event.inputs.dry_run }}" == "false" ]]; then
               crane delete "$img" || true
               crane delete "$img-dev" || true
@@ -36,4 +36,4 @@ jobs:
               echo "DRY RUN: crane delete $img || true"
               echo "DRY RUN: crane delete $img-dev || true"
             fi
-          done
+          done < <(grep -v '\#' withdrawn-images.txt)

--- a/.github/workflows/withdraw-repos.yaml
+++ b/.github/workflows/withdraw-repos.yaml
@@ -29,10 +29,10 @@ jobs:
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
       - run: |
-          for repo in $(grep -v '\#' withdrawn-repos.txt); do
+          while IFS= read -r repo; do
             if [[ "${{ github.event.inputs.dry_run }}" == "false" ]]; then
-              chainctl image repo rm $repo || true
+              chainctl image repo rm "$repo" || true
             else
               echo "DRY RUN: chainctl image repo rm $repo || true"
             fi
-          done
+          done < <(grep -v '\#' withdrawn-repos.txt)


### PR DESCRIPTION
### Notes for reviewer

Our Action Lint workflow has been repeatedly failing on a number of warnings for these workflows. The following changes look to amend those warnings.