### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
     groups:
       actions:
         update-types:

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -23,6 +23,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
       id: octo-sts

--- a/.github/workflows/presubmit-readme.yaml
+++ b/.github/workflows/presubmit-readme.yaml
@@ -16,6 +16,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - id: changed
         uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,8 @@ jobs:
       - id: shard
         name: Shard
         shell: bash
+        env:
+          INPUTS_ONLY: ${{ inputs.only }}
         run: |
           mapfile -t images < <(find ./images -maxdepth 2 -name "locked_config.json" | awk -F'/' '{print $3}' | sort -u | shuf)
 
@@ -56,13 +58,15 @@ jobs:
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
           # Overwrite the output above if workflow_dispatch'd with `only`
-          if [ -n "${{ inputs.only }}" ]; then
-            shard='[{"index": 0, "image": "${{ inputs.only }}"}]'
+          if [ -n "${INPUTS_ONLY}" ]; then
+            shard="[{\"index\": 0, \"image\": \"${INPUTS_ONLY}\"}]"
             echo "matrix=${shard}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Shard Results
-        run: echo '${{ steps.shard.outputs.matrix }}'
+        env:
+          MATRIX: ${{ steps.shard.outputs.matrix }}
+        run: echo "$MATRIX"
 
     outputs:
       matrix: "${{steps.shard.outputs.matrix}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - id: shard
         name: Shard

--- a/.github/workflows/withdraw-images.yaml
+++ b/.github/workflows/withdraw-images.yaml
@@ -27,9 +27,11 @@ jobs:
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
       - uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0 # v0.6
-      - run: |
+      - env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
           while IFS= read -r img; do
-            if [[ "${{ github.event.inputs.dry_run }}" == "false" ]]; then
+            if [[ "$DRY_RUN" == "false" ]]; then
               crane delete "$img" || true
               crane delete "$img-dev" || true
             else

--- a/.github/workflows/withdraw-repos.yaml
+++ b/.github/workflows/withdraw-repos.yaml
@@ -28,9 +28,11 @@ jobs:
       - uses: chainguard-dev/setup-chainctl@2cddd35a2f120d9973e58094dc6878c93cf58c28 # v0.5.1
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
-      - run: |
+      - env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
           while IFS= read -r repo; do
-            if [[ "${{ github.event.inputs.dry_run }}" == "false" ]]; then
+            if [[ "$DRY_RUN" == "false" ]]; then
               chainctl image repo rm "$repo" || true
             else
               echo "DRY RUN: chainctl image repo rm $repo || true"

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,3 +7,10 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
This PR applies GitHub Actions hardening fixes across the workflows in
`.github/workflows/`, surfaced by static analysis (zizmor).

## What this changes

- **`persist-credentials: false` on checkout steps.** The affected jobs don't
  push back to the repo, so the auto-persisted `GITHUB_TOKEN` in `.git/config`
  is unnecessary — dropping it narrows the blast radius of later steps.
- **Template-injection fix.** `workflow_dispatch` input expressions that were
  interpolated directly into `run:` blocks are moved into `env:` and referenced
  as quoted shell variables, so the shell — not the workflow templater — handles
  them.
- **Repo-level zizmor config.** Disables cosmetic pedantic-only rules and sets a
  dependabot cooldown threshold, so future scans stay focused on substantive
  findings.

## Test plan

- `zizmor .github/` — clean after these changes.
- `actionlint` — workflows still parse with no errors.

Refs: PSEC-923