### PR TITLE
Harden Withdraw Repos workflow: safety check, push trigger, no swallowed failures (CON-2596)

### DIFF
--- a/.github/workflows/withdraw-repos.yaml
+++ b/.github/workflows/withdraw-repos.yaml
@@ -1,15 +1,27 @@
+name: Withdraw Repos
+
 on:
   workflow_dispatch:
     inputs:
       dry_run:
         type: boolean
         default: true
-        description: If true, just log
+        description: Execute as dry run, only log details
+      skip_safety_check:
+        type: boolean
+        default: false
+        description: Bypass the customer-repo source count safety check
+  push:
+    branches: [main]
+    paths:
+      - "withdrawn-repos.txt"
 
 permissions: {}
 
 jobs:
   withdraw:
+    if: github.repository == 'chainguard-images/images'
+
     runs-on: ubuntu-latest
 
     permissions:
@@ -28,11 +40,28 @@ jobs:
       - uses: chainguard-dev/setup-chainctl@2cddd35a2f120d9973e58094dc6878c93cf58c28 # v0.5.1
         with:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/b6461e99e132298f
-      - run: |
-          while IFS= read -r repo; do
-            if [[ "${{ github.event.inputs.dry_run }}" == "false" ]]; then
-              chainctl image repo rm "$repo" || true
-            else
-              echo "DRY RUN: chainctl image repo rm $repo || true"
-            fi
-          done < <(grep -v '\#' withdrawn-repos.txt)
+
+      - name: Withdraw repos
+        env:
+          # A push to main (the mirror sync of withdrawn-repos.txt from
+          # chainguard-dev/stereo containers/public/) runs live; manual
+          # dispatch defaults to a dry run.
+          DRY_RUN: ${{ github.event.inputs.dry_run == 'true' }}
+          SKIP_SAFETY_CHECK: ${{ github.event.inputs.skip_safety_check == 'true' }}
+        run: |
+          set -eu -o pipefail
+          ./hack/withdraw-repos.sh
+
+      - uses: step-security/action-slack-notify@e4cdee14a905d9da46ba47ad9309704407d8cd79 # v2.4.0
+        if: failure()
+        env:
+          SLACK_ICON: http://github.com/chainguard-dev.png?size=48
+          SLACK_USERNAME: guardian
+          SLACK_WEBHOOK: ${{ secrets.DISTROLESS_SLACK_WEBHOOK }}
+          SLACK_MSG_AUTHOR: chainguardian
+          SLACK_CHANNEL: chainguard-images-alerts
+          SLACK_COLOR: "#8E1600"
+          MSG_MINIMAL: "true"
+          SLACK_TITLE: "[withdraw-repos] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_MESSAGE: |
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/WITHDRAWING_IMAGES.md
+++ b/WITHDRAWING_IMAGES.md
@@ -22,7 +22,17 @@ Sometimes an image repo needs to be removed entirely because it was erroneously 
 
 To do so:
 
-- Add the repo basename that need to be removed to `withdrawn-repos.txt`
-- Run the ["Withdraw Repos"](https://github.com/chainguard-images/images/blob/main/.github/workflows/withdraw-repos.yaml) workflow on GitHub.
+- Add the repo basename to `containers/public/withdrawn-repos.txt` in
+  [chainguard-dev/stereo](https://github.com/chainguard-dev/stereo). The repo-root
+  `withdrawn-repos.txt` in this repo is a mirror of that file — do not edit it here,
+  the mirror sync will overwrite it.
+- When the mirrored change lands on `main`, the
+  ["Withdraw Repos"](https://github.com/chainguard-images/images/blob/main/.github/workflows/withdraw-repos.yaml)
+  workflow runs automatically. You can also dispatch it manually; manual dispatch
+  defaults to a dry run.
+
+Before deleting, the workflow verifies via the registry API that no customer repos
+are sourced from the repo being withdrawn. Failed deletions fail the run and alert
+`#chainguard-images-alerts`.
 
 This ensures that these operations are only done using the Chainguard identity with permission, and not by any human user directly. This also provides an audit trail of such operations.

--- a/hack/withdraw-repos.sh
+++ b/hack/withdraw-repos.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Withdraw (delete) repos under the public "chainguard" org.
+#
+# Reads the repo-root withdrawn-repos.txt, which is mirrored from
+# chainguard-dev/stereo containers/public/withdrawn-repos.txt.
+# Each non-comment, non-empty line is either:
+#   - a bare repo name, resolved as a direct child of the public org, or
+#   - a full repo UIDP (for nested repos that cannot be addressed by name).
+#
+# Ported from chainguard-dev/stereo containers/hack/withdraw-repos.sh
+# (CON-1963), adapted for the public org. Failures are accumulated and
+# the script exits non-zero at the end, so one bad repo does not abort
+# the rest but the run still goes red (CON-2596).
+
+# cgr.dev/chainguard (the public org).
+parent_id="720909c9f5279097d847ad02a2f24ba8f59de36a"
+
+API_BASE="${API_BASE:-https://console-api.enforce.dev}"
+
+withdrawn_file="$(realpath "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../withdrawn-repos.txt")"
+
+unsafe=0
+failed=0
+for entry in $(grep -v '\#' "$withdrawn_file"); do
+    if [[ "$entry" =~ ^[0-9a-f]{40}(/[0-9a-f]{16})+$ ]]; then
+        # Full repo UIDP: it must live under the public org.
+        if [[ "$entry" != "$parent_id"/* ]]; then
+            echo "ERROR: $entry: repo UIDP is not under the public org $parent_id"
+            failed=1
+            continue
+        fi
+        repo_id="$entry"
+    else
+        repo_json=$(chainctl images repos list --parent "$parent_id" --repo "$entry" -o json) \
+            || { echo "ERROR: $entry: failed to look up repo"; exit 1; }
+        repo_id=$(echo "$repo_json" | jq -r '.items[0].id // empty')
+        if [[ -z "$repo_id" ]]; then echo "WARNING: skipping $entry (repo not found)"; continue; fi
+    fi
+
+    # Safety check: ensure no customer repos are sourced from this repo.
+    if [[ "${SKIP_SAFETY_CHECK:-false}" != "true" ]]; then
+        response=$(curl -sSf -H "Authorization: Bearer $(chainctl auth token)" "${API_BASE}/registry/v1/repocountbysource/${repo_id}") \
+            || { echo "ERROR: $entry: failed to query repo count by source"; exit 1; }
+        count=$(echo "$response" | jq -re '.count') \
+            || { echo "WARNING: $entry: could not determine customer repo count, skipping"; continue; }
+        if [[ "$count" != "0" ]]; then
+            echo "UNSAFE: $entry: $count customer repos are sourced from it"
+            unsafe=1
+            continue
+        fi
+        echo "SAFE: $entry: 0 customer repos sourced from it"
+    fi
+
+    # CI sets DRY_RUN=false on live runs; anything else is a dry run.
+    if [[ "${DRY_RUN:-true}" == "false" ]]; then
+        if (set -x; chainctl image repo rm "$repo_id"); then
+            echo "WITHDRAWN: $entry"
+        else
+            echo "ERROR: $entry: failed to withdraw"
+            failed=1
+        fi
+    else
+        echo "DRY RUN: chainctl image repo rm $repo_id  # $entry"
+    fi
+done
+
+if [[ "$unsafe" -ne 0 ]]; then
+    echo "One or more repos are unsafe to withdraw. Set SKIP_SAFETY_CHECK=true to bypass."
+    exit 1
+fi
+if [[ "$failed" -ne 0 ]]; then
+    echo "One or more repo withdrawals failed."
+    exit 1
+fi

--- a/hack/withdraw-repos.sh
+++ b/hack/withdraw-repos.sh
@@ -5,9 +5,9 @@ set -eu -o pipefail
 #
 # Reads the repo-root withdrawn-repos.txt, which is mirrored from
 # chainguard-dev/stereo containers/public/withdrawn-repos.txt.
-# Each non-comment, non-empty line is either:
-#   - a bare repo name, resolved as a direct child of the public org, or
-#   - a full repo UIDP (for nested repos that cannot be addressed by name).
+# Each non-comment, non-empty line is a bare repo name, resolved as a
+# direct child of the public org. Nested repos are an invalid state
+# (DeleteRepo does not cascade) and must be cleaned up manually by UIDP.
 #
 # Ported from chainguard-dev/stereo containers/hack/withdraw-repos.sh
 # (CON-1963), adapted for the public org. Failures are accumulated and
@@ -23,21 +23,16 @@ withdrawn_file="$(realpath "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/..
 
 unsafe=0
 failed=0
-for entry in $(grep -v '\#' "$withdrawn_file"); do
-    if [[ "$entry" =~ ^[0-9a-f]{40}(/[0-9a-f]{16})+$ ]]; then
-        # Full repo UIDP: it must live under the public org.
-        if [[ "$entry" != "$parent_id"/* ]]; then
-            echo "ERROR: $entry: repo UIDP is not under the public org $parent_id"
-            failed=1
-            continue
-        fi
-        repo_id="$entry"
-    else
-        repo_json=$(chainctl images repos list --parent "$parent_id" --repo "$entry" -o json) \
-            || { echo "ERROR: $entry: failed to look up repo"; exit 1; }
-        repo_id=$(echo "$repo_json" | jq -r '.items[0].id // empty')
-        if [[ -z "$repo_id" ]]; then echo "WARNING: skipping $entry (repo not found)"; continue; fi
+for entry in $(grep -v '#' "$withdrawn_file"); do
+    if [[ "$entry" == */* ]]; then
+        echo "ERROR: $entry: not a bare repo name; nested repos are an invalid state, remove them manually by UIDP"
+        failed=1
+        continue
     fi
+    repo_json=$(chainctl images repos list --parent "$parent_id" --repo "$entry" -o json) \
+        || { echo "ERROR: $entry: failed to look up repo"; exit 1; }
+    repo_id=$(echo "$repo_json" | jq -r '.items[0].id // empty')
+    if [[ -z "$repo_id" ]]; then echo "WARNING: skipping $entry (repo not found)"; continue; fi
 
     # Safety check: ensure no customer repos are sourced from this repo.
     if [[ "${SKIP_SAFETY_CHECK:-false}" != "true" ]]; then


### PR DESCRIPTION
Hardens the dispatch-only **Withdraw Repos** workflow (zero runs since 2023) to the standard of stereo's live private-catalog port. Fix item 5 of [CON-2596](https://linear.app/chainguard/issue/CON-2596) / [internal-dev#26825](https://github.com/chainguard-dev/internal-dev/issues/26825).

## Changes

- Deletion loop moved to `hack/withdraw-repos.sh`, ported from stereo's `containers/hack/withdraw-repos.sh`. Each entry resolves to a repo UIDP under the public `chainguard` org before deletion: bare names match direct children exactly (no interactive-selector hang in CI), missing repos skip with a warning, and slashed entries (nested repos) error and fail the run — nested repos are an invalid state, cleaned up manually by UIDP.
- `|| true` removed. Failures accumulate and the script exits non-zero — one bad repo no longer aborts the rest, and a red run now means something.
- `repocountbysource` safety check: refuses to withdraw a repo that customer repos sync from. `skip_safety_check` dispatch input bypasses it (same knob as stereo).
- Push trigger on `withdrawn-repos.txt` (`main` only): the mirror sync from stereo runs the withdrawal live. Manual dispatch still defaults to `dry_run: true`.
- Slack alert on failure via the existing `DISTROLESS_SLACK_WEBHOOK`.
- `if: github.repository == 'chainguard-images/images'` fork guard; `WITHDRAWING_IMAGES.md` now says to edit the file in stereo, not here.

Kept `egress-policy: audit` (repo convention); tightening egress on a never-exercised workflow belongs in its own PR.

Validated: `bash -n`; workflow YAML parsed; script smoke-tested with stubbed `chainctl`/`curl` — dry-run default, failure accumulation + exit 1, not-found skip, safety gate blocks and fails, bypass works, slashed entry rejected with non-zero exit.

## Deferred

The end state is one owner: extend the `stereo-withdraw-containers` identity to the public org and retire this legacy pair. Tracked in [CON-2865](https://linear.app/chainguard/issue/CON-2865). The operator runbook for the CON-2596 cleanup lives on chainguard-dev/stereo#322388.
